### PR TITLE
Implement the tldts package for identifying first and third-party domains.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13558,6 +13558,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/tldts": {
+			"version": "6.0.8",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.0.8.tgz",
+			"integrity": "sha512-gc0SFsuvk5IfBMTfDDy7MnH5Ut138HkavoiSiOTbyaPMCFU5eN95Rl9YrovVCkD0eOrwEhxXYbxe2bcKRcc7ag==",
+			"dependencies": {
+				"tldts-core": "^6.0.8"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "6.0.8",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.0.8.tgz",
+			"integrity": "sha512-9DoeDV0eqDmXKkg43LGxLdJZstcdNfdhAElerrChj78Y3fYcidTKtVSLjXC0w6naMWYejPvJtTpnRPWHJJD4yw=="
+		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
 			"dev": true,
@@ -14724,6 +14740,7 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"simple-cookie": "^1.0.15",
+				"tldts": "^6.0.8",
 				"use-context-selector": "^1.4.1"
 			}
 		}
@@ -15786,6 +15803,7 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"simple-cookie": "^1.0.15",
+				"tldts": "*",
 				"use-context-selector": "^1.4.1"
 			}
 		},
@@ -23209,6 +23227,19 @@
 		"thunky": {
 			"version": "1.1.0",
 			"dev": true
+		},
+		"tldts": {
+			"version": "6.0.8",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.0.8.tgz",
+			"integrity": "sha512-gc0SFsuvk5IfBMTfDDy7MnH5Ut138HkavoiSiOTbyaPMCFU5eN95Rl9YrovVCkD0eOrwEhxXYbxe2bcKRcc7ag==",
+			"requires": {
+				"tldts-core": "^6.0.8"
+			}
+		},
+		"tldts-core": {
+			"version": "6.0.8",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.0.8.tgz",
+			"integrity": "sha512-9DoeDV0eqDmXKkg43LGxLdJZstcdNfdhAElerrChj78Y3fYcidTKtVSLjXC0w6naMWYejPvJtTpnRPWHJJD4yw=="
 		},
 		"tmpl": {
 			"version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15803,7 +15803,7 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"simple-cookie": "^1.0.15",
-				"tldts": "*",
+				"tldts": "^6.0.8",
 				"use-context-selector": "^1.4.1"
 			}
 		},

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -15,6 +15,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "simple-cookie": "^1.0.15",
+    "tldts": "^6.0.8",
     "use-context-selector": "^1.4.1"
   }
 }

--- a/packages/extension/src/utils/isFirstParty.ts
+++ b/packages/extension/src/utils/isFirstParty.ts
@@ -16,19 +16,28 @@
 /**
  * External dependencies.
  */
-import { parse } from 'tldts';
+import { getDomain } from 'tldts';
+
+/**
+ * Internal dependencies.
+ */
+import { parseUrl } from './parseUrl';
 
 /**
  * Identifies if cookie's domain is first party by comparing domain of the given url.
  * @param {string} cookieDomain Cookie URL (URL of the server which is setting/updating cookies).
- * @param {string} tabURL Top level url ( URL in tab's address bar )
- * @returns {boolean | null} true for 1p; false for 3p; null for if no cookie domain was passed.
+ * @param {string} tabUrl Top level url ( URL in tab's address bar )
+ * @returns {boolean | null} true for 1p; false for 3p; null if bad tab URL was passed.
  */
 const isFirstParty = (
   cookieDomain: string | undefined,
-  tabURL: string
-): boolean => {
-  return !cookieDomain || parse(tabURL)?.domain === parse(cookieDomain)?.domain;
+  tabUrl: string
+): boolean | null => {
+  if (!parseUrl(tabUrl)) {
+    return null;
+  }
+
+  return !cookieDomain || getDomain(tabUrl) === getDomain(cookieDomain);
 };
 
 export default isFirstParty;

--- a/packages/extension/src/utils/isFirstParty.ts
+++ b/packages/extension/src/utils/isFirstParty.ts
@@ -13,28 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * External dependencies.
+ */
+import { parse } from 'tldts';
 
 /**
- * Identifies if a cookie is first party by comparing top and cookie URL.
- * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
+ * Identifies if a cookie is first party by comparing domain.
  * @param {string} tabURL Cookie URL (URL of the server which is setting/updating cookies).
  * @param {string} cookieDomain Top level url ( URL in tab's address bar ).
- * @returns {boolean | null} true for 1p; false for 3p; null for if bad URLs are passed.
+ * @returns {boolean | null} true for 1p; false for 3p; null for if no cookie domain was passed.
  */
 const isFirstParty = (
   tabURL: string,
   cookieDomain: string | undefined
 ): boolean | null => {
-  if (!cookieDomain) {
-    return true;
-  }
-  try {
-    const tabOrigin = new URL(tabURL).origin;
-
-    return tabOrigin.includes(cookieDomain);
-  } catch (error) {
-    return null;
-  }
+  return !cookieDomain || parse(tabURL)?.domain === parse(cookieDomain)?.domain;
 };
 
 export default isFirstParty;

--- a/packages/extension/src/utils/isFirstParty.ts
+++ b/packages/extension/src/utils/isFirstParty.ts
@@ -24,10 +24,10 @@ import { getDomain } from 'tldts';
 import { parseUrl } from './parseUrl';
 
 /**
- * Identifies if cookie's domain is first party by comparing domain of the given url.
- * @param {string} cookieDomain Cookie URL (URL of the server which is setting/updating cookies).
- * @param {string} tabUrl Top level url ( URL in tab's address bar )
- * @returns {boolean | null} true for 1p; false for 3p; null if bad tab URL was passed.
+ * Identifies if a cookie's domain is first party by comparing it with the domain of the given URL.
+ * @param {string | undefined} cookieDomain - The URL of the server that is setting/updating the cookie.
+ * @param {string} tabUrl - The top-level URL (URL in the tab's address bar).
+ * @returns {boolean | null} - true if the cookie is first party, false if it's third party, or null if a bad tab URL was passed.
  */
 const isFirstParty = (
   cookieDomain: string | undefined,

--- a/packages/extension/src/utils/isFirstParty.ts
+++ b/packages/extension/src/utils/isFirstParty.ts
@@ -19,15 +19,15 @@
 import { parse } from 'tldts';
 
 /**
- * Identifies if a cookie is first party by comparing domain.
- * @param {string} tabURL Cookie URL (URL of the server which is setting/updating cookies).
- * @param {string} cookieDomain Top level url ( URL in tab's address bar ).
+ * Identifies if cookie's domain is first party by comparing domain of the given url.
+ * @param {string} cookieDomain Cookie URL (URL of the server which is setting/updating cookies).
+ * @param {string} tabURL Top level url ( URL in tab's address bar )
  * @returns {boolean | null} true for 1p; false for 3p; null for if no cookie domain was passed.
  */
 const isFirstParty = (
-  tabURL: string,
-  cookieDomain: string | undefined
-): boolean | null => {
+  cookieDomain: string | undefined,
+  tabURL: string
+): boolean => {
   return !cookieDomain || parse(tabURL)?.domain === parse(cookieDomain)?.domain;
 };
 

--- a/packages/extension/src/utils/parseUrl.ts
+++ b/packages/extension/src/utils/parseUrl.ts
@@ -13,7 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const parseUrl = (url: string) => {
+/**
+ * Parses a URL string and returns a new URL object.
+ * If the URL is invalid, it returns null.
+ * @param {string} url - The URL string to parse.
+ * @returns {URL | null} - The parsed URL object or null if the URL is invalid.
+ */
+export const parseUrl = (url: string): URL | null => {
   try {
     return new URL(url);
   } catch (e) {

--- a/packages/extension/src/utils/parseUrl.ts
+++ b/packages/extension/src/utils/parseUrl.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const parseUrl = (url) => {
+export const parseUrl = (url: string) => {
   try {
     return new URL(url);
   } catch (e) {

--- a/packages/extension/src/utils/parseUrl.ts
+++ b/packages/extension/src/utils/parseUrl.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const parseUrl = (url) => {
+  try {
+    return new URL(url);
+  } catch (e) {
+    return null;
+  }
+};

--- a/packages/extension/src/utils/tests/isFirstParty.ts
+++ b/packages/extension/src/utils/tests/isFirstParty.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies.
+ */
+import isFirstParty from '../isFirstParty';
+
+describe('isFirstParty', () => {
+  it('Should return true for first party domains and subdomains', () => {
+    expect(
+      isFirstParty('https://newindianexpress.com/', 'newindianexpress.com')
+    ).toBeTruthy();
+
+    expect(
+      isFirstParty('https://indianexpress.com/', '.indianexpress.com')
+    ).toBeTruthy();
+
+    expect(
+      isFirstParty('https://indianexpress.com/', 'accounts.indianexpress.com')
+    ).toBeTruthy();
+
+    expect(
+      isFirstParty('https://indianexpress.co.in/', '.indianexpress.co.in')
+    ).toBeTruthy();
+
+    expect(
+      isFirstParty('https://indianexpress.co.in/', 'api.indianexpress.co.in')
+    ).toBeTruthy();
+
+    expect(
+      isFirstParty('https://amazonaws.com/', 'spark-public.s3.amazonaws.com')
+    ).toBeTruthy();
+  });
+
+  it('Should return false for third-party domains and subdomains', () => {
+    expect(isFirstParty('https://xyz.com/', 'xyza.com')).toBeFalsy();
+
+    expect(
+      isFirstParty('https://newindianexpress.com/', 'new.indianexpress.com')
+    ).toBeFalsy();
+
+    expect(
+      isFirstParty('https://indianexpress.com/', '.indianexpresss.com')
+    ).toBeFalsy();
+
+    expect(
+      isFirstParty('https://amazonaws.com/', 'spark-public.s3.aamazonaws.com')
+    ).toBeFalsy();
+
+    expect(isFirstParty('https://xyza.com/', 'demo.xyz.com')).toBeFalsy();
+
+    expect(isFirstParty('https://xyz.co.us/', 'demo.xyz.co.uk')).toBeFalsy();
+  });
+});

--- a/packages/extension/src/utils/tests/isFirstParty.ts
+++ b/packages/extension/src/utils/tests/isFirstParty.ts
@@ -21,27 +21,37 @@ import isFirstParty from '../isFirstParty';
 describe('isFirstParty', () => {
   it('Should return true for first party domains and subdomains', () => {
     expect(
-      isFirstParty('https://newindianexpress.com/', 'newindianexpress.com')
+      isFirstParty('https://newexample.com/', 'newexample.com')
+    ).toBeTruthy();
+
+    expect(isFirstParty('https://example.com/', '.example.com')).toBeTruthy();
+
+    expect(
+      isFirstParty('https://example.com/', 'accounts.example.com')
     ).toBeTruthy();
 
     expect(
-      isFirstParty('https://indianexpress.com/', '.indianexpress.com')
+      isFirstParty('https://example.co.in/', '.example.co.in')
     ).toBeTruthy();
 
     expect(
-      isFirstParty('https://indianexpress.com/', 'accounts.indianexpress.com')
-    ).toBeTruthy();
-
-    expect(
-      isFirstParty('https://indianexpress.co.in/', '.indianexpress.co.in')
-    ).toBeTruthy();
-
-    expect(
-      isFirstParty('https://indianexpress.co.in/', 'api.indianexpress.co.in')
+      isFirstParty('https://example.co.in/', 'api.example.co.in')
     ).toBeTruthy();
 
     expect(
       isFirstParty('https://amazonaws.com/', 'spark-public.s3.amazonaws.com')
+    ).toBeTruthy();
+
+    expect(
+      isFirstParty('https://日本.example.com', 'demo.日本.example.com')
+    ).toBeTruthy();
+
+    expect(
+      isFirstParty('https://example.com', 'https://demo.sub-domain.example.com')
+    ).toBeTruthy();
+
+    expect(
+      isFirstParty('https://example.com', 'https://sub1.sub2.example.com')
     ).toBeTruthy();
   });
 
@@ -49,12 +59,10 @@ describe('isFirstParty', () => {
     expect(isFirstParty('https://xyz.com/', 'xyza.com')).toBeFalsy();
 
     expect(
-      isFirstParty('https://newindianexpress.com/', 'new.indianexpress.com')
+      isFirstParty('https://newexample.com/', 'new.example.com')
     ).toBeFalsy();
 
-    expect(
-      isFirstParty('https://indianexpress.com/', '.indianexpresss.com')
-    ).toBeFalsy();
+    expect(isFirstParty('https://example.com/', '.examples.com')).toBeFalsy();
 
     expect(
       isFirstParty('https://amazonaws.com/', 'spark-public.s3.aamazonaws.com')

--- a/packages/extension/src/utils/tests/isFirstParty.ts
+++ b/packages/extension/src/utils/tests/isFirstParty.ts
@@ -72,4 +72,9 @@ describe('isFirstParty', () => {
 
     expect(isFirstParty('demo.xyz.co.uk', 'https://xyz.co.us/')).toBeFalsy();
   });
+
+  it('Should return null if bad url was provided', () => {
+    expect(isFirstParty('xyza.com', 'undefined')).toBeNull();
+    expect(isFirstParty('xyza.com', 'sjfcsd')).toBeNull();
+  });
 });

--- a/packages/extension/src/utils/tests/isFirstParty.ts
+++ b/packages/extension/src/utils/tests/isFirstParty.ts
@@ -53,6 +53,8 @@ describe('isFirstParty', () => {
     expect(
       isFirstParty('https://sub1.sub2.example.com', 'https://example.com')
     ).toBeTruthy();
+
+    expect(isFirstParty('', 'https://example.com')).toBeTruthy();
   });
 
   it('Should return false for third-party domains and subdomains', () => {

--- a/packages/extension/src/utils/tests/isFirstParty.ts
+++ b/packages/extension/src/utils/tests/isFirstParty.ts
@@ -21,55 +21,55 @@ import isFirstParty from '../isFirstParty';
 describe('isFirstParty', () => {
   it('Should return true for first party domains and subdomains', () => {
     expect(
-      isFirstParty('https://newexample.com/', 'newexample.com')
+      isFirstParty('newexample.com', 'https://newexample.com/')
     ).toBeTruthy();
 
-    expect(isFirstParty('https://example.com/', '.example.com')).toBeTruthy();
+    expect(isFirstParty('.example.com', 'https://example.com/')).toBeTruthy();
 
     expect(
-      isFirstParty('https://example.com/', 'accounts.example.com')
-    ).toBeTruthy();
-
-    expect(
-      isFirstParty('https://example.co.in/', '.example.co.in')
+      isFirstParty('accounts.example.com', 'https://example.com/')
     ).toBeTruthy();
 
     expect(
-      isFirstParty('https://example.co.in/', 'api.example.co.in')
+      isFirstParty('.example.co.in', 'https://example.co.in/')
     ).toBeTruthy();
 
     expect(
-      isFirstParty('https://amazonaws.com/', 'spark-public.s3.amazonaws.com')
+      isFirstParty('api.example.co.in', 'https://example.co.in/')
     ).toBeTruthy();
 
     expect(
-      isFirstParty('https://日本.example.com', 'demo.日本.example.com')
+      isFirstParty('spark-public.s3.amazonaws.com', 'https://amazonaws.com/')
     ).toBeTruthy();
 
     expect(
-      isFirstParty('https://example.com', 'https://demo.sub-domain.example.com')
+      isFirstParty('demo.日本.example.com', 'https://日本.example.com')
     ).toBeTruthy();
 
     expect(
-      isFirstParty('https://example.com', 'https://sub1.sub2.example.com')
+      isFirstParty('https://demo.sub-domain.example.com', 'https://example.com')
+    ).toBeTruthy();
+
+    expect(
+      isFirstParty('https://sub1.sub2.example.com', 'https://example.com')
     ).toBeTruthy();
   });
 
   it('Should return false for third-party domains and subdomains', () => {
-    expect(isFirstParty('https://xyz.com/', 'xyza.com')).toBeFalsy();
+    expect(isFirstParty('xyza.com', 'https://xyz.com/')).toBeFalsy();
 
     expect(
-      isFirstParty('https://newexample.com/', 'new.example.com')
+      isFirstParty('new.example.com', 'https://newexample.com/')
     ).toBeFalsy();
 
-    expect(isFirstParty('https://example.com/', '.examples.com')).toBeFalsy();
+    expect(isFirstParty('.examples.com', 'https://example.com/')).toBeFalsy();
 
     expect(
-      isFirstParty('https://amazonaws.com/', 'spark-public.s3.aamazonaws.com')
+      isFirstParty('spark-public.s3.aamazonaws.com', 'https://amazonaws.com/')
     ).toBeFalsy();
 
-    expect(isFirstParty('https://xyza.com/', 'demo.xyz.com')).toBeFalsy();
+    expect(isFirstParty('demo.xyz.com', 'https://xyza.com/')).toBeFalsy();
 
-    expect(isFirstParty('https://xyz.co.us/', 'demo.xyz.co.uk')).toBeFalsy();
+    expect(isFirstParty('demo.xyz.co.uk', 'https://xyz.co.us/')).toBeFalsy();
   });
 });

--- a/packages/extension/src/view/devtools/components/tabs/CookieTab/listItem.tsx
+++ b/packages/extension/src/view/devtools/components/tabs/CookieTab/listItem.tsx
@@ -53,12 +53,12 @@ const ListItem = ({ cookie, tabURL }: IListItem) => {
           </span>
           <span
             className={`font-bold ${
-              isFirstParty(tabURL, cookie.parsedCookie.domain)
+              isFirstParty(cookie.parsedCookie.domain, tabURL)
                 ? 'text-first-party'
                 : 'text-third-party'
             }`}
           >
-            {isFirstParty(tabURL, cookie.parsedCookie.domain)
+            {isFirstParty(cookie.parsedCookie.domain, tabURL)
               ? 'First Party'
               : 'Third Party'}
           </span>

--- a/packages/extension/src/view/devtools/components/tabs/CookieTab/listItem.tsx
+++ b/packages/extension/src/view/devtools/components/tabs/CookieTab/listItem.tsx
@@ -30,6 +30,8 @@ interface IListItem {
 }
 
 const ListItem = ({ cookie, tabURL }: IListItem) => {
+  const firstParty = isFirstParty(cookie.parsedCookie.domain, tabURL);
+
   return (
     <a href="#" className="block hover:bg-secondary">
       <div className="px-4 py-3 sm:px-6 border-b">
@@ -53,14 +55,15 @@ const ListItem = ({ cookie, tabURL }: IListItem) => {
           </span>
           <span
             className={`font-bold ${
-              isFirstParty(cookie.parsedCookie.domain, tabURL)
-                ? 'text-first-party'
-                : 'text-third-party'
+              firstParty !== null &&
+              (firstParty ? 'text-first-party' : 'text-third-party')
             }`}
           >
-            {isFirstParty(cookie.parsedCookie.domain, tabURL)
-              ? 'First Party'
-              : 'Third Party'}
+            {firstParty !== null
+              ? firstParty
+                ? 'First Party'
+                : 'Third Party'
+              : 'Unknown'}
           </span>
         </div>
       </div>

--- a/packages/extension/src/view/devtools/devtools.html
+++ b/packages/extension/src/view/devtools/devtools.html
@@ -1,8 +1,9 @@
 <!doctype html>
 <html lang="en">
 <head>
-	<title>Dev Tools</title>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PS Analysis Devtool</title>
+  <meta charset='UTF-8'>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
 <script src="devtools.js"></script>


### PR DESCRIPTION
## Description

Since we consider subdomains as first-party, it crucial to accurately determine whether a URL is a subdomain of the provided URL

Subdomains can have various formats and can be nested to multiple levels. Additionally, different domain name patterns and top-level domains (TLDs) can introduce further complexity.
While a basic regular expression pattern could capture subdomains in simple cases, it may not cover all possible scenarios. It would not account for variations such as internationalized domain names (IDNs), complex TLDs, subdomains with hyphens, or subdomains with different levels.

**Example:**

Internationalized Domain Names (IDNs):

URL: https://日本.example.com
Subdomain: 日本

Complex TLDs:

URL: https://example.co.uk
Subdomain: Empty (no subdomain)
Subdomains with Hyphens:

URL: https://demo.sub-domain.example.com
Subdomain: demo.sub-domain
Subdomains with Different Levels:

URL: https://sub1.sub2.example.com
Subdomain: sub1.sub2

Therefore it is important to use a library that can handle all of these cases.

## Relevant Technical Choices

- Use [tldts package](https://github.com/remusao/tldts#readme)
- Add unit tests.
- Add missing meta tag for devtools.html

## Testing Instructions

Go to any website (for example https://indianexpress.com/ ) and check if the first-party and third-party classification is correct.


