### PR TITLE
Fix: infinite render on some websites.

### DIFF
--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -156,57 +156,15 @@ export const Provider = ({ children }: PropsWithChildren) => {
     [tabId]
   );
 
-  const cookieChangeListener = useCallback(
-    async (changeInfo: chrome.cookies.CookieChangeInfo) => {
-      if (
-        tabCookies &&
-        Object.keys(tabCookies).includes(changeInfo.cookie.name)
-      ) {
-        const isIbcCompliant = await checkIbcCompliance(
-          changeInfo.cookie.sameSite,
-          changeInfo.cookie.secure,
-          changeInfo.cookie.name,
-          tabCookies[changeInfo.cookie.name].url
-        );
-
-        const isCookieSet = Boolean(
-          await chrome.cookies.get({
-            name: changeInfo.cookie.name,
-            url: tabCookies[changeInfo.cookie.name].url,
-          })
-        );
-
-        const newCookieData = {
-          ...tabCookies[changeInfo.cookie.name],
-          isIbcCompliant,
-          isCookieSet,
-        };
-
-        setTabCookies({
-          ...tabCookies,
-          [changeInfo.cookie.name]: newCookieData,
-        });
-      }
-    },
-    [tabCookies]
-  );
-
   useEffect(() => {
     intitialSync();
     chrome.storage.local.onChanged.addListener(storeChangeListener);
     chrome.tabs.onUpdated.addListener(tabUpdateListener);
-    chrome.cookies.onChanged.addListener(cookieChangeListener);
     return () => {
       chrome.storage.local.onChanged.removeListener(storeChangeListener);
       chrome.tabs.onUpdated.removeListener(tabUpdateListener);
-      chrome.cookies.onChanged.removeListener(cookieChangeListener);
     };
-  }, [
-    cookieChangeListener,
-    intitialSync,
-    storeChangeListener,
-    tabUpdateListener,
-  ]);
+  }, [intitialSync, storeChangeListener, tabUpdateListener]);
 
   return (
     <Context.Provider value={{ state: { tabCookies, tabUrl }, actions: {} }}>

--- a/packages/extension/src/worker/service-worker.ts
+++ b/packages/extension/src/worker/service-worker.ts
@@ -167,15 +167,3 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
 chrome.runtime.onInstalled.addListener(async () => {
   await chrome.storage.local.clear();
 });
-
-/**
- * Listen to changes in cookie store and sync extension local store
- * when any cookies are delted ( through application tab in devtools )
- */
-chrome.cookies.onChanged.addListener(
-  async (changeInfo: chrome.cookies.CookieChangeInfo) => {
-    if (changeInfo.cause === 'explicit' && changeInfo.removed) {
-      await CookieStore.deleteCookie(changeInfo.cookie.name);
-    }
-  }
-);


### PR DESCRIPTION
## Description

Changes in cookie store caused by some websites cause overload on stateProvider in devtools. This PR removes the listener for the same from service worker and stateProvider in devtools.

<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
