### PR TITLE
Add `description` key into `Filter` and info icon to show description

### DIFF
--- a/packages/extension/src/view/devtools/components/tabContent/cookies/cookieFilter/listItem.tsx
+++ b/packages/extension/src/view/devtools/components/tabContent/cookies/cookieFilter/listItem.tsx
@@ -21,8 +21,7 @@ import React, { useState } from 'react';
 /**
  * Internal dependencies.
  */
-// eslint-disable-next-line import/no-relative-packages
-import { ArrowDown } from '../../../../../../icons';
+import { ArrowDown, InfoIcon } from '../../../../../../icons';
 import SubList from './subList';
 import type {
   SelectedFilters,
@@ -80,16 +79,23 @@ const ListItem: React.FC<ListItemProps> = ({
 
   return (
     <li className="py-[3px]">
-      <a
-        href="#"
-        className="flex items-center text-asteriod-black dark:text-bright-gray"
-        onClick={toggleSubList}
-      >
-        <span className={showSubList ? '' : '-rotate-90'}>
-          <ArrowDown />
-        </span>
-        <p className="ml-1 leading-normal font-semi-thick">{filter.name}</p>
-      </a>
+      <div className="flex gap-2 items-center">
+        <a
+          href="#"
+          className="flex items-center text-asteriod-black dark:text-bright-gray"
+          onClick={toggleSubList}
+        >
+          <span className={showSubList ? '' : '-rotate-90'}>
+            <ArrowDown />
+          </span>
+          <p className="ml-1 leading-normal font-semi-thick">{filter.name}</p>
+        </a>
+        {filter.description && (
+          <p title={filter.description}>
+            <InfoIcon />
+          </p>
+        )}
+      </div>
       {showSubList && (
         <>
           <SubList

--- a/packages/extension/src/view/devtools/stateProviders/filterManagementStore/constants.ts
+++ b/packages/extension/src/view/devtools/stateProviders/filterManagementStore/constants.ts
@@ -61,6 +61,8 @@ export const FILTER_MAPPING = [
     keys: 'isCookieSet',
     type: 'boolean',
     order: 10,
+    description:
+      "Whether the cookie was accepted(set) in Chrome's Cookie Store",
   },
 ];
 

--- a/packages/extension/src/view/devtools/stateProviders/filterManagementStore/types.ts
+++ b/packages/extension/src/view/devtools/stateProviders/filterManagementStore/types.ts
@@ -25,4 +25,5 @@ export interface Filter {
   default?: string;
   sort?: boolean;
   order: number;
+  description?: string;
 }


### PR DESCRIPTION
## Description
This PR contains code to add an optional key `description` in `Filter` type for showing details about the filter through an info icon. Hover over the info icon shows the description for selected filter.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---
<img width="396" alt="Screenshot 2023-08-21 at 7 31 12 PM" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/f4477222-cae8-4200-b9ce-543189e5b9d9">


<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
