### PR TITLE
Relocate info icon from matrix to cookie insights on landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cookie-analysis-tool",
-	"version": "0.0.2",
+	"version": "0.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cookie-analysis-tool",
-			"version": "0.0.2",
+			"version": "0.1.0",
 			"license": "Apache-2.0",
 			"workspaces": [
 				"packages/*"
@@ -23186,7 +23186,7 @@
 		},
 		"packages/cli": {
 			"name": "@cookie-analysis-tool/cli",
-			"version": "0.0.2",
+			"version": "0.1.0",
 			"license": "Apache-2.0"
 		},
 		"packages/extension": {

--- a/packages/extension/src/view/design-system/components/circlePieChart/index.tsx
+++ b/packages/extension/src/view/design-system/components/circlePieChart/index.tsx
@@ -76,7 +76,7 @@ const CirclePieChart = ({
           <p className="text-xs text-center font-semibold leading-relaxed dark:text-bright-gray">
             {title}
           </p>
-          {title.toLocaleLowerCase() === '3rd party cookies' && (
+          {title === '3rd Party Cookies' && (
             <p
               className={infoIconClassName}
               title="An active ad-blocker or other cookie extensions may affect the results."

--- a/packages/extension/src/view/devtools/components/tabContent/cookies/cookiesLanding/cookiesMatrix/index.tsx
+++ b/packages/extension/src/view/devtools/components/tabContent/cookies/cookiesLanding/cookiesMatrix/index.tsx
@@ -32,6 +32,7 @@ import type {
   TabFrames,
   CookieStatsComponents,
 } from '../../../../../cookies.types';
+import { InfoIcon } from '../../../../../../../icons';
 
 interface CookiesMatrixProps {
   tabCookies: TabCookies | null;
@@ -112,8 +113,11 @@ const CookiesMatrix = ({
     <div className="w-full" data-testid="cookies-matrix">
       <div>
         <div className="flex gap-x-5 justify-between">
-          <h4 className="pb-3 flex-1 grow border-b border-bright-gray dark:border-quartz text-xs font-bold text-darkest-gray dark:text-bright-gray uppercase">
-            Cookies Insights
+          <h4 className="flex items-center gap-1 pb-3 flex-1 grow border-b border-bright-gray dark:border-quartz text-xs font-bold text-darkest-gray dark:text-bright-gray uppercase">
+            <span>Cookies Insights</span>
+            <span title="An active ad-blocker or other cookie extensions may affect the results.">
+              <InfoIcon />
+            </span>
           </h4>
           <h4 className="pb-3 flex-1 grow border-b border-bright-gray dark:border-quartz text-xs font-bold text-darkest-gray dark:text-bright-gray text-right">
             <button onClick={() => setIsExpanded((state) => !state)}>


### PR DESCRIPTION
## Description
This PR includes code to move info icon from matrix's `Circle` to `Cookie Matrix` in Landing page.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="901" alt="Screenshot 2023-08-23 at 10 18 24 AM" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/d41f5396-6994-404c-af12-46227de2cee2">
<img width="846" alt="Screenshot 2023-08-23 at 10 18 44 AM" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/7ac5bdb9-420f-4a72-a736-f210c7da5a4d">

<!-- Please provide Screenshot/Screencast, if applicable -->

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
