### PR TITLE
Feature: Optional tech analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ The Chrome extension provides capabilities surfaced via the extension pop-up, th
 - Run the CLI, providing a URL or a sitemap as input.
   - E.g. `npm run cli -- -s https://example.com/sitemap_index.xml`.
   - E.g. `npm run cli -- -u https://bbc.com`.
+- The dependency which analysis cookies (Wappalyzer) may require permission for using its instance chromium. Technology analysis can be skipped by using the flag `-nt` for uninteruppted analysis of the cookies.
+  - E.g. `npm run cli -- -u https://bbc.com -nt`. 
 
 
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The Chrome extension provides capabilities surfaced via the extension pop-up, th
   - E.g. `npm run cli -- -s https://example.com/sitemap_index.xml`.
   - E.g. `npm run cli -- -u https://bbc.com`.
 - The dependency which analysis cookies (Wappalyzer) may require permission for using its instance chromium. Technology analysis can be skipped by using the flag `-nt` for uninteruppted analysis of the cookies.
+  - E.g. `npm run cli -- -s https://example.com/sitemap_index.xml -nt`.
   - E.g. `npm run cli -- -u https://bbc.com -nt`. 
 
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -36,3 +36,15 @@ export interface CookieLogDetails
   sameSite: string;
   pageUrl: string;
 }
+
+export interface TechnologieDetails {
+  name: string;
+  description: string;
+  confidence: number;
+  website: string;
+  categories: { name: string }[];
+}
+
+export interface TechnologieDetailsSitemap extends TechnologieDetails {
+  frequency: number;
+}

--- a/packages/cli/src/utils/generatePrefix.ts
+++ b/packages/cli/src/utils/generatePrefix.ts
@@ -20,7 +20,8 @@
 export default function generatePrefix(url: string): string {
   const urlObject = new URL(url);
 
-  return (urlObject.hostname + urlObject.pathname)
-    .replace(/[^a-zA-Z0-9 ]/g, '-')
-    .slice(0, -1);
+  return (urlObject.hostname + urlObject.pathname).replace(
+    /[^a-zA-Z0-9 ]/g,
+    '-'
+  );
 }

--- a/packages/cli/src/utils/generateTechnology.ts
+++ b/packages/cli/src/utils/generateTechnology.ts
@@ -18,18 +18,11 @@
  */
 //@ts-ignore package does not support typescript
 import Wapplalyzer from 'wappalyzer';
+import { TechnologieDetails } from '../types';
 
 const generateTechnology = async (
   url: string
-): Promise<
-  {
-    name: string;
-    description: string;
-    confidence: number;
-    website: string;
-    categories: { name: string }[];
-  }[]
-> => {
+): Promise<TechnologieDetails[]> => {
   const wappalyzer = new Wapplalyzer();
   await wappalyzer.init();
   const site = await wappalyzer.open(url);


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
The dependency `Wappalyzer` which is used for tech stack analysis of any website asks for permission to run its unsigned copy of chromium on some systems. This PR adds a flag to skip the tech stack analysis step so that any users finding the dialog box annoying may skip the step (specially during a sitemap analysis).

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Build the cli as mentioned in the README.MD.
- Use the cli as mentioned in the README.MD but with `-nt` flag.
- E.g. `npm run cli -- -s https://example.com/sitemap_index.xml -nt`

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
