### PR TITLE
Fix: Cookie data storage method

### DIFF
--- a/packages/extension/src/localStore/cookieStore.ts
+++ b/packages/extension/src/localStore/cookieStore.ts
@@ -32,13 +32,14 @@ const CookieStore = {
 
       for (const cookie of cookies) {
         const cookieName = cookie.parsedCookie.name;
-
-        if (!cookieName) {
+        const cookieDomain = cookie.parsedCookie.domain;
+        const cookiePath = cookie.parsedCookie.path;
+        if (!cookieName || !cookieDomain || !cookiePath) {
           continue;
         }
 
-        if (_updatedCookies?.[cookieName]) {
-          _updatedCookies[cookieName] = {
+        if (_updatedCookies?.[cookieName + cookieDomain + cookiePath]) {
+          _updatedCookies[cookieName + cookieDomain + cookiePath] = {
             ...cookie,
             frameIdList: Array.from(
               new Set<number>([
@@ -48,7 +49,7 @@ const CookieStore = {
             ),
           };
         } else {
-          _updatedCookies[cookieName] = cookie;
+          _updatedCookies[cookieName + cookieDomain + cookiePath] = cookie;
         }
       }
 

--- a/packages/extension/src/localStore/cookieStore.ts
+++ b/packages/extension/src/localStore/cookieStore.ts
@@ -44,7 +44,8 @@ const CookieStore = {
             frameIdList: Array.from(
               new Set<number>([
                 ...cookie.frameIdList,
-                ..._updatedCookies[cookieName].frameIdList,
+                ..._updatedCookies[cookieName + cookieDomain + cookiePath]
+                  .frameIdList,
               ])
             ),
           };

--- a/packages/extension/src/localStore/tests/cookieStore.ts
+++ b/packages/extension/src/localStore/tests/cookieStore.ts
@@ -134,16 +134,16 @@ describe('local store: CookieStore', () => {
   it('should add/update tab data', async () => {
     await CookieStore.update('123', cookieArray);
     expect(storage['123'].cookies).toStrictEqual({
-      countryCode1: cookieArray[0],
-      countryCode2: cookieArray[1],
+      'countryCode1.example1.com/': cookieArray[0],
+      'countryCode2.example2.com/': cookieArray[1],
     });
   });
 
   it('should delete cookies', async () => {
     await CookieStore.update('123', cookieArray);
-    await CookieStore.deleteCookie('countryCode1');
+    await CookieStore.deleteCookie('countryCode1.example1.com/');
     expect(storage['123'].cookies).toStrictEqual({
-      countryCode2: cookieArray[1],
+      'countryCode2.example2.com/': cookieArray[1],
     });
   });
 
@@ -154,7 +154,7 @@ describe('local store: CookieStore', () => {
       { ...cookieArray[0], frameIdList: [2] },
     ]);
     expect(storage['123'].cookies).toStrictEqual({
-      countryCode1: { ...cookieArray[0], frameIdList: [2, 1] },
+      'countryCode1.example1.com/': { ...cookieArray[0], frameIdList: [2, 1] },
     });
   });
 

--- a/packages/extension/src/view/design-system/components/table/tableBody/bodyRow.tsx
+++ b/packages/extension/src/view/design-system/components/table/tableBody/bodyRow.tsx
@@ -49,11 +49,17 @@ const BodyRow = ({
 }: BodyRowProps) => {
   const tableRowClassName = classNames(
     'outline-0',
-    row.original.parsedCookie.name !== selectedKey &&
+    row.original.parsedCookie.name +
+      row.original.parsedCookie.domain +
+      row.original.parsedCookie.path !==
+      selectedKey &&
       (index % 2
         ? 'bg-anti-flash-white dark:bg-charleston-green'
         : 'bg-white dark:bg-raisin-black'),
-    row.original.parsedCookie.name === selectedKey &&
+    row.original.parsedCookie.name +
+      row.original.parsedCookie.domain +
+      row.original.parsedCookie.path ===
+      selectedKey &&
       (isRowFocused
         ? 'bg-gainsboro dark:bg-outer-space'
         : 'bg-royal-blue text-white dark:bg-medium-persian-blue dark:text-chinese-silver')

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/cookieTable/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/cookieTable/index.tsx
@@ -216,7 +216,11 @@ const CookieTable = ({ cookies, selectedFrame }: CookieTableProps) => {
       <Table
         table={table}
         selectedKey={
-          selectedKey === null ? null : selectedKey?.parsedCookie?.name
+          selectedKey === null
+            ? null
+            : selectedKey?.parsedCookie?.name +
+              selectedKey?.parsedCookie?.domain +
+              selectedKey?.parsedCookie?.path
         }
         onRowClick={onRowClick}
         onMouseEnter={() => setIsMouseInsideHeader(true)}

--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -237,7 +237,10 @@ export const Provider = ({ children }: PropsWithChildren) => {
             }
           ).map(async ([key, value]) => {
             const isCookieSet = Boolean(
-              await chrome.cookies.get({ name: key, url: value.url })
+              await chrome.cookies.get({
+                name: value?.parsedCookie?.name,
+                url: value.url,
+              })
             );
             _cookies[key] = {
               ...value,

--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -193,7 +193,10 @@ export const Provider = ({ children }: PropsWithChildren) => {
         Object.entries(tabData.cookies as { [key: string]: CookieData }).map(
           async ([key, value]: [string, CookieData]) => {
             const isCookieSet = Boolean(
-              await chrome.cookies.get({ name: key, url: value.url })
+              await chrome.cookies.get({
+                name: value?.parsedCookie?.name,
+                url: value.url,
+              })
             );
             _cookies[key] = {
               ...value,

--- a/packages/extension/src/worker/createCookieObject.ts
+++ b/packages/extension/src/worker/createCookieObject.ts
@@ -44,7 +44,7 @@ export async function createCookieObject(
   const prevParsedCookie = (
     await findPreviousCookieDataObject(
       (await getCurrentTabId()) || '0',
-      parsedCookie.name
+      parsedCookie.name + parsedCookie.domain + parsedCookie.path
     )
   )?.parsedCookie;
 


### PR DESCRIPTION
## Description
This PR aims to remove overwriting the cookie data when we get a cookie from the same name but with a different domain or path. This problem occurred because we used to store the cookie data with the cookie name as the key and cookie data as the value. To remove this problem we modified the key from cookie name to `cookie name + cookie domain + cookie path`, using this method we are sure that we get a unique cookie key.

## Relevant Technical Choices
- Replace `[name]: value` with `[name+domain+path]:value` for cookie object.

## Testing Instructions
- In the terminal run `npm I && npm run dev`.
- Open the website farfetch.com.
- Open the DevTools and select the Privacy sandbox tab.
- In the cookie listed under the frame https://farfetch.com search for cookie `_abck` there should be 2 different cookies with the same name. These cookies should have different domains.

Fixes #138 
