### PR TITLE
Downgrade sitemapper package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26542,7 +26542,7 @@
 				"promptly": "^3.2.0",
 				"puppeteer": "^21.0.3",
 				"simple-cookie": "^1.0.15",
-				"sitemapper": "^3.2.6",
+				"sitemapper": "^3.1.8",
 				"tldts": "^6.0.14",
 				"wappalyzer": "^6.10.66"
 			},
@@ -28285,7 +28285,7 @@
 				"promptly": "^3.2.0",
 				"puppeteer": "^21.0.3",
 				"simple-cookie": "^1.0.15",
-				"sitemapper": "^3.2.6",
+				"sitemapper": "^3.1.8",
 				"tldts": "^6.0.14",
 				"tsc-watch": "^6.0.4",
 				"typescript": "^5.0.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "promptly": "^3.2.0",
     "puppeteer": "^21.0.3",
     "simple-cookie": "^1.0.15",
-    "sitemapper": "^3.2.6",
+    "sitemapper": "^3.1.8",
     "tldts": "^6.0.14",
     "wappalyzer": "^6.10.66"
   },


### PR DESCRIPTION
## Description

As per the [dependable bot](https://github.com/GoogleChromeLabs/ps-analysis-tool/security/dependabot/8)

xml2js versions before 0.5.0 allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the __proto__ property to be edited.

## Relevant Technical Choices

Downgrade sitemapper package because the latest version depends on vulnerable versions of xml2js

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
