### PR TITLE
Override xml2js dependency to fix vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26388,9 +26388,9 @@
 			}
 		},
 		"node_modules/xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
 			"dependencies": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"
@@ -45978,8 +45978,9 @@
 			"dev": true
 		},
 		"xml2js": {
-			"version": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
 			"requires": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -43160,7 +43160,7 @@
 				"got": "^11.8.0",
 				"is-gzip": "2.0.0",
 				"p-limit": "^3.1.0",
-				"xml2js": "^0.4.23"
+				"xml2js": "^0.5.0"
 			},
 			"dependencies": {
 				"is-gzip": {
@@ -45978,8 +45978,7 @@
 			"dev": true
 		},
 		"xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+			"version": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
 			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
 			"requires": {
 				"sax": ">=0.6.0",

--- a/package.json
+++ b/package.json
@@ -111,5 +111,8 @@
 	},
 	"workspaces": [
 		"packages/*"
-	]
+	],
+	"overrides": {
+		"xml2js": "^0.5.0"
+	}
 }


### PR DESCRIPTION
## Description

[Previous PR](https://github.com/GoogleChromeLabs/ps-analysis-tool/pull/144) couldn't fix the vulnerabilities (ran `npm audit fix`) issue, therefore we override the xml2js version.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
