### PR TITLE
Fix: Responsive table on changing dock size.

### DIFF
--- a/packages/design-system/src/components/table/useColumnResizing/index.tsx
+++ b/packages/design-system/src/components/table/useColumnResizing/index.tsx
@@ -40,7 +40,7 @@ const useColumnResizing = (
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [columns, setColumns] = useState<TableColumn[]>([]);
 
-  useEffect(() => {
+  const setColumnsCallback = useCallback(() => {
     if (options) {
       const tableWidth =
         tableContainerRef.current?.getBoundingClientRect().width || 0;
@@ -62,11 +62,7 @@ const useColumnResizing = (
       }
 
       setColumns(newColumns);
-    }
-  }, [options, tableColumns]);
-
-  useEffect(() => {
-    if (!options) {
+    } else {
       const tableWidth =
         tableContainerRef.current?.getBoundingClientRect().width || 0;
       const newColumns = tableColumns.map((column) => ({
@@ -77,6 +73,14 @@ const useColumnResizing = (
       setColumns(newColumns);
     }
   }, [options, tableColumns]);
+
+  useEffect(() => {
+    setColumnsCallback();
+    window.addEventListener('resize', setColumnsCallback);
+    return () => {
+      window.removeEventListener('resize', setColumnsCallback);
+    };
+  }, [setColumnsCallback]);
 
   const onMouseDown = useCallback(
     (

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/cookieTable/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/cookieTable/index.tsx
@@ -17,7 +17,7 @@
 /**
  * External dependencies.
  */
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 import type {
   CookieTableData,
   SortingState,
@@ -73,7 +73,7 @@ const CookieTable = ({ cookies, selectedFrame }: CookieTableProps) => {
       selectedColumns: state?.selectedColumns as Record<string, boolean>,
     }));
 
-  const [, setForcedUpdate] = useState(false);
+  const [, forceUpdate] = useReducer((x) => x + 1, 0);
 
   const tableColumns = useMemo<TableColumn[]>(
     () => [
@@ -206,9 +206,9 @@ const CookieTable = ({ cookies, selectedFrame }: CookieTableProps) => {
   });
 
   useEffect(() => {
-    window.addEventListener('resize', () => setForcedUpdate(true));
+    window.addEventListener('resize', () => forceUpdate());
     return () => {
-      window.removeEventListener('resize', () => setForcedUpdate(true));
+      window.removeEventListener('resize', () => forceUpdate());
     };
   }, []);
 

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/cookieTable/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/cookieTable/index.tsx
@@ -17,7 +17,7 @@
 /**
  * External dependencies.
  */
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type {
   CookieTableData,
   SortingState,
@@ -72,6 +72,9 @@ const CookieTable = ({ cookies, selectedFrame }: CookieTableProps) => {
       columnSizing: state?.columnSizing as Record<string, number>,
       selectedColumns: state?.selectedColumns as Record<string, boolean>,
     }));
+
+  const [, setForcedUpdate] = useState(false);
+
   const tableColumns = useMemo<TableColumn[]>(
     () => [
       {
@@ -201,6 +204,13 @@ const CookieTable = ({ cookies, selectedFrame }: CookieTableProps) => {
           : undefined,
     },
   });
+
+  useEffect(() => {
+    window.addEventListener('resize', () => setForcedUpdate(true));
+    return () => {
+      window.removeEventListener('resize', () => setForcedUpdate(true));
+    };
+  }, []);
 
   return (
     <div className="flex-1 w-full h-full text-outer-space-crayola border-x border-american-silver dark:border-quartz">


### PR DESCRIPTION
## Description
This PR aims to fix the issue of the table not taking up the whole space when the DecTools dock type is changed.

## Relevant Technical Choices

- Table is forced rerendered once the dock type is changed.

## Testing Instructions


## Additional Information:

## Screenshot/Screencast

https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/59614577/8a3ca298-b493-4782-8a36-9e4be9f52492



