### PR TITLE
Grey out empty frame URLs

### DIFF
--- a/packages/design-system/src/components/accordion/accordionChildren.tsx
+++ b/packages/design-system/src/components/accordion/accordionChildren.tsx
@@ -32,6 +32,7 @@ interface AccordionChildrenProps {
   currentIndex: number;
   defaultIcon: React.FC<React.SVGProps<SVGSVGElement>>;
   hasChildren?: boolean;
+  greyOutEmptyFrameURL: Record<string, boolean>;
   index?: number;
   isTabFocused: boolean;
   isAccordionChildSelected: boolean;
@@ -60,6 +61,7 @@ const AccordionChildren: React.FC<AccordionChildrenProps> = ({
   currentIndex = 1000,
   defaultIcon,
   hasChildren = false,
+  greyOutEmptyFrameURL,
   index,
   isTabFocused,
   isAccordionChildSelected,
@@ -111,9 +113,11 @@ const AccordionChildren: React.FC<AccordionChildrenProps> = ({
                     tabs={tabs}
                     currentIndex={currentIndex}
                     key={key}
+                    tabId={tabId}
                     accordionMenuItemName={key}
                     defaultIcon={tabs[currentIndex].icons.default}
                     isTabFocused={isTabFocused}
+                    greyOutEmptyFrameURL={greyOutEmptyFrameURL}
                     isAccordionChildSelected={selectedFrame === key}
                     selectedIcon={tabs[currentIndex].icons.selected}
                     onAccordionChildClick={onAccordionChildClick}
@@ -140,6 +144,7 @@ const AccordionChildren: React.FC<AccordionChildrenProps> = ({
                         selectedIndex === currentIndex && !selectedFrame
                       }
                       hasChildren={Boolean(tab?.hasChildren)}
+                      greyOutEmptyFrameURL={greyOutEmptyFrameURL}
                       accordionMenuItemName={tab.display_name}
                       selectedFrame={selectedFrame}
                       defaultIcon={tab.icons.default}
@@ -173,10 +178,13 @@ const AccordionChildren: React.FC<AccordionChildrenProps> = ({
       }
       role="treeitem"
       className={classNames(
-        'pl-12 py-0.5 h-5 flex items-center cursor-default outline-0 dark:text-bright-gray',
+        'pl-12 py-0.5 h-5 flex items-center cursor-default outline-0 dark:text-bright-gray' +
+          (tabId === 'cookies' && greyOutEmptyFrameURL[accordionMenuItemName]
+            ? ' text-slate-400 dark:text-slate-500'
+            : ''),
         isAccordionChildSelected &&
           (isTabFocused
-            ? 'bg-royal-blue text-white dark:bg-medium-persian-blue dark:text-chinese-silver'
+            ? 'bg-royal-blue text-slate-50 dark:bg-medium-persian-blue dark:text-slate-300'
             : 'bg-gainsboro dark:bg-outer-space')
       )}
     >


### PR DESCRIPTION
## Description

Since not all frames have available cookie data, it becomes redundant to click on every URL. It would be helpful to grey out iframe URLs that lack this data.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<img width="1439" alt="image" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/6297436/39c6b2da-1e85-49d5-9544-3a90b4646c44">

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
