### PR TITLE
Fix browseTopics pre-rendering error

### DIFF
--- a/packages/extension/src/contentScript/index.ts
+++ b/packages/extension/src/contentScript/index.ts
@@ -20,6 +20,7 @@ import { CookieStore } from '../localStore';
 
 (async () => {
   if (
+    !document.prerendering &&
     'browsingTopics' in document &&
     document.featurePolicy &&
     document.featurePolicy.allowsFeature('browsing-topics')


### PR DESCRIPTION
## Description

When we open devtool or resize the devtool, we often see the following error. This PR fixes that issue.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

## Screenshot/Screencast

![image](https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/6297436/123440a5-a892-493e-a098-346c3908968b)

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
