### PR TITLE
Create third-party-cookie-breakage-report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/third-party-cookie-breakage-report.md
+++ b/.github/ISSUE_TEMPLATE/third-party-cookie-breakage-report.md
@@ -1,0 +1,39 @@
+---
+name: Third Party Cookie Breakage Report
+about: Inform us about a breakage you have encountered while testing
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Important Note** -
+Please ensure that this submission is for one specific issue. If you have multiple breakage issues to report, please file them separately to allow for ease of triage by our team.
+
+----
+
+### Copy and paste the URL of the broken site.
+Enter the URL where you encountered the issue
+
+
+### Describe in detail the problem you experienced
+Include instructions for our team to reproduce the issue step by step.
+
+
+### Screenshots
+If applicable, add screenshots to help explain the breakage better.
+
+
+### Google Chrome Version
+Share the current chrome version on your system, here's a [how-to] (https://support.google.com/chrome/answer/95414?co=GENIE.Platform%3DDesktop&hl=en#zippy=%2Ccheck-for-an-update-the-current-browser-version:~:text=Other%20info%20about%20updating%20Chrome)
+
+
+### List of extensions loaded
+Share the list of active extensions in your browser to help us best replicate the issue
+
+
+### (Optional) Is the affected site used mostly in a managed enterprise setup (i.e. on corporate devices)?
+
+
+### (Optional) Any other pertinent info that may be required. 
+If you are aware of the underlying technical issues, please share as much as you can here.


### PR DESCRIPTION

## Description

Adding a new issue template so that it can be mentioned in the `Quick Links` sections of our landing pages and make it easier for the user to report a breakage for us to review while they test their site using our tool.


