### PR TITLE
Fix: Flickering of iframe overlay on sites and some other fixes

### DIFF
--- a/packages/design-system/src/components/landingPage/index.tsx
+++ b/packages/design-system/src/components/landingPage/index.tsx
@@ -36,7 +36,7 @@ interface LandingPageProps {
 }
 
 const LandingPage = ({ title, children, isLoading }: LandingPageProps) => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
   const [news, setNews] = useState<BulletListItem[]>([]);
 
   const fetchLatestNews = async () => {

--- a/packages/extension/src/contentScript/index.ts
+++ b/packages/extension/src/contentScript/index.ts
@@ -206,11 +206,13 @@ class WebpageContentScript {
    */
   insertPopovers(response: ResponseType) {
     // If the no frame was selected in devtool.
-    if (!response.selectedFrame) {
+    if (response.removeAllFramesPopOver && !response.selectedFrame) {
       removeAllPopovers();
       return;
     }
-
+    if (!response.selectedFrame) {
+      return;
+    }
     const frameElements = findSelectedFrameElements(response.selectedFrame);
     const numberOfFrames = frameElements.length;
 
@@ -400,6 +402,7 @@ class WebpageContentScript {
         this.port.postMessage({
           attributes: {
             iframeOrigin: url ? url.origin : '',
+            isNullSetFromHover: url ? false : true,
           },
         });
       }

--- a/packages/extension/src/contentScript/index.ts
+++ b/packages/extension/src/contentScript/index.ts
@@ -43,7 +43,6 @@ class WebpageContentScript {
    */
   port: chrome.runtime.Port | null = null;
   isInspecting = false;
-  isScrolling = false;
   isHoveringOverPage = false;
   bodyHoverStateSent = false;
   scrollEventListeners: Array<() => void> = [];
@@ -114,13 +113,6 @@ class WebpageContentScript {
     } else {
       this.abortInspection();
     }
-  }
-  onScrollEnd() {
-    this.isScrolling = false;
-  }
-
-  onScrollStarted() {
-    this.isScrolling = true;
   }
 
   insertOverlay(
@@ -343,9 +335,6 @@ class WebpageContentScript {
     }
 
     this.isHoveringOverPage = true;
-    if (this.isScrolling) {
-      return;
-    }
 
     if (
       !this.bodyHoverStateSent &&

--- a/packages/extension/src/contentScript/index.ts
+++ b/packages/extension/src/contentScript/index.ts
@@ -206,7 +206,7 @@ class WebpageContentScript {
    */
   insertPopovers(response: ResponseType) {
     // If the no frame was selected in devtool.
-    if (response.removeAllFramesPopOver && !response.selectedFrame) {
+    if (response.removeAllFramePopovers && !response.selectedFrame) {
       removeAllPopovers();
       return;
     }

--- a/packages/extension/src/contentScript/types.ts
+++ b/packages/extension/src/contentScript/types.ts
@@ -19,4 +19,5 @@ export interface ResponseType {
   thirdPartyCookies?: number;
   isInspecting: boolean;
   isOnRWS?: boolean;
+  removeAllFramesPopOver?: boolean;
 }

--- a/packages/extension/src/contentScript/types.ts
+++ b/packages/extension/src/contentScript/types.ts
@@ -19,5 +19,5 @@ export interface ResponseType {
   thirdPartyCookies?: number;
   isInspecting: boolean;
   isOnRWS?: boolean;
-  removeAllFramesPopOver?: boolean;
+  removeAllFramePopovers?: boolean;
 }

--- a/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
+++ b/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
@@ -187,7 +187,7 @@ const useFrameOverlay = () => {
             : [];
           portRef.current.postMessage({
             selectedFrame,
-            removeAllFramesPopOver: isFrameSelectedFromDevTool,
+            removeAllFramePopovers: isFrameSelectedFromDevTool,
             thirdPartyCookies: thirdPartyCookies.length,
             firstPartyCookies: firstPartyCookies.length,
             isInspecting,

--- a/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
+++ b/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
@@ -16,7 +16,7 @@
 /**
  * External dependencies.
  */
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
  * Internal dependencies.
@@ -27,7 +27,7 @@ import { useFilterManagementStore } from '../stateProviders/filterManagementStor
 import { getCurrentTabId } from '../../../utils/getCurrentTabId';
 
 interface Response {
-  attributes: { iframeOrigin: React.SetStateAction<string | null> };
+  attributes: { iframeOrigin: string | null };
 }
 
 const useFrameOverlay = () => {
@@ -42,6 +42,8 @@ const useFrameOverlay = () => {
     isCurrentTabBeingListenedTo,
     allowedNumberOfTabs,
     tabFrames,
+    isFrameSelectedFromDevTool,
+    setIsFrameSelectedFromDevTool,
   } = useCookieStore(({ state, actions }) => ({
     setContextInvalidated: actions.setContextInvalidated,
     isInspecting: state.isInspecting,
@@ -51,6 +53,8 @@ const useFrameOverlay = () => {
     isCurrentTabBeingListenedTo: state.isCurrentTabBeingListenedTo,
     allowedNumberOfTabs: state.allowedNumberOfTabs,
     tabFrames: state.tabFrames,
+    isFrameSelectedFromDevTool: state.isFrameSelectedFromDevTool,
+    setIsFrameSelectedFromDevTool: actions.setIsFrameSelectedFromDevTool,
   }));
 
   const { filteredCookies } = useFilterManagementStore(({ state }) => ({
@@ -71,7 +75,8 @@ const useFrameOverlay = () => {
       name: portName,
     });
     portRef.current.onMessage.addListener((response: Response) => {
-      setSelectedFrame(response.attributes.iframeOrigin || '');
+      setSelectedFrame(response.attributes.iframeOrigin);
+      setIsFrameSelectedFromDevTool(false);
     });
 
     portRef.current.onDisconnect.addListener(() => {
@@ -83,7 +88,7 @@ const useFrameOverlay = () => {
       isInspecting: true,
     });
     setConnectedToPort(true);
-  }, [setIsInspecting, setSelectedFrame]);
+  }, [setIsFrameSelectedFromDevTool, setIsInspecting, setSelectedFrame]);
 
   const sessionStoreChangedListener = useCallback(
     async (changes: { [key: string]: chrome.storage.StorageChange }) => {
@@ -182,6 +187,7 @@ const useFrameOverlay = () => {
             : [];
           portRef.current.postMessage({
             selectedFrame,
+            removeAllFramesPopOver: isFrameSelectedFromDevTool,
             thirdPartyCookies: thirdPartyCookies.length,
             firstPartyCookies: firstPartyCookies.length,
             isInspecting,
@@ -197,6 +203,7 @@ const useFrameOverlay = () => {
     connectToPort,
     connectedToPort,
     tabFrames,
+    isFrameSelectedFromDevTool,
   ]);
 };
 

--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -47,13 +47,17 @@ export interface CookieStoreContext {
     allowedNumberOfTabs: string | null;
     isInspecting: boolean;
     contextInvalidated: boolean;
+    isFrameSelectedFromDevTool: boolean;
   };
   actions: {
-    setSelectedFrame: React.Dispatch<React.SetStateAction<string | null>>;
+    setSelectedFrame: (key: string | null) => void;
     setIsInspecting: React.Dispatch<React.SetStateAction<boolean>>;
     changeListeningToThisTab: () => void;
     getCookiesSetByJavascript: () => void;
     setContextInvalidated: React.Dispatch<React.SetStateAction<boolean>>;
+    setIsFrameSelectedFromDevTool: React.Dispatch<
+      React.SetStateAction<boolean>
+    >;
   };
 }
 
@@ -69,9 +73,11 @@ const initialState: CookieStoreContext = {
     allowedNumberOfTabs: null,
     isInspecting: false,
     contextInvalidated: false,
+    isFrameSelectedFromDevTool: false,
   },
   actions: {
     setSelectedFrame: noop,
+    setIsFrameSelectedFromDevTool: noop,
     changeListeningToThisTab: noop,
     setIsInspecting: noop,
     getCookiesSetByJavascript: noop,
@@ -103,7 +109,10 @@ export const Provider = ({ children }: PropsWithChildren) => {
   const [isInspecting, setIsInspecting] =
     useState<CookieStoreContext['state']['isInspecting']>(false);
 
-  const [selectedFrame, setSelectedFrame] =
+  const [isFrameSelectedFromDevTool, setIsFrameSelectedFromDevTool] =
+    useState<CookieStoreContext['state']['isFrameSelectedFromDevTool']>(false);
+
+  const [selectedFrame, _setSelectedFrame] =
     useState<CookieStoreContext['state']['selectedFrame']>(null);
 
   const [tabUrl, setTabUrl] =
@@ -152,6 +161,11 @@ export const Provider = ({ children }: PropsWithChildren) => {
     []
   );
 
+  const setSelectedFrame = useCallback((key: string | null) => {
+    _setSelectedFrame(key);
+    setIsFrameSelectedFromDevTool(true);
+  }, []);
+
   const intitialSync = useCallback(async () => {
     const _tabId = chrome.devtools.inspectedWindow.tabId;
 
@@ -192,7 +206,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
         ) {
           setIsCurrentTabBeingListenedTo(false);
           setLoading(false);
-          setSelectedFrame(null);
+          _setSelectedFrame(null);
           setTabFrames(null);
           return;
         } else {
@@ -300,7 +314,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
           ) {
             setIsCurrentTabBeingListenedTo(false);
             setTabFrames(null);
-            setSelectedFrame(null);
+            _setSelectedFrame(null);
             setLoading(false);
             return;
           } else {
@@ -471,6 +485,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
           allowedNumberOfTabs,
           contextInvalidated,
           isInspecting,
+          isFrameSelectedFromDevTool,
         },
         actions: {
           setSelectedFrame,
@@ -478,6 +493,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
           getCookiesSetByJavascript,
           setIsInspecting,
           setContextInvalidated,
+          setIsFrameSelectedFromDevTool,
         },
       }}
     >


### PR DESCRIPTION
## Description
It was noticed that overlay on an iframe with an empty origin would flicker. This PR aims to solve that issue.

## Relevant Technical Choices
- Add another state to detect whether the frame was selected from DevTools or from hovering of mouse while inspecting an iframe on the page.

## Testing Instructions

## Additional Information:


## Screenshot/Screencast
