### PR TITLE
Frame Overlay: Display only privacy sandbox-related allowed features

### DIFF
--- a/packages/extension/src/contentScript/constants.ts
+++ b/packages/extension/src/contentScript/constants.ts
@@ -19,3 +19,16 @@ export const TOOLTIP_CLASS = 'ps-tooltip';
 // @todo Remove hard coded string and use add "more" link/button instead.
 export const ALL_ALLOWED_FEATURES =
   'accelerometer, attribution-reporting, autoplay, bluetooth, browsing-topics, camera, ch-device-memory, ch-downlink, ch-dpr, ch-ect, ch-prefers-color-scheme, ch-prefers-reduced-motion, ch-rtt, ch-save-data, ch-ua, ch-ua-arch, ch-ua-bitness, ch-ua-form-factor, ch-ua-full-version, ch-ua-full-version-list, ch-ua-mobile, ch-ua-model, ch-ua-platform, ch-ua-platform-version, ch-ua-wow64, ch-viewport-height, ch-viewport-width, ch-width, clipboard-read, clipboard-write, cross-origin-isolated, display-capture, encrypted-media, fullscreen, gamepad, geolocation, gyroscope, hid, identity-credentials-get, idle-detection, interest-cohort, join-ad-interest-group, keyboard-map, local-fonts, magnetometer, microphone, midi, otp-credentials, payment, picture-in-picture, private-aggregation, private-state-token-issuance, private-state-token-redemption, publickey-credentials-get, run-ad-auction, screen-wake-lock, serial, shared-storage, shared-storage-select-url, storage-access, sync-xhr, unload, usb, window-placement, xr-spatial-tracking';
+
+export const PS_RELATED_ALLOWED_FEATURES = [
+  'attribution-reporting', // For ad click attribution.
+  'browsing-topics', // Relates to topic-based browsing.
+  'interest-cohort', // For cohort-based advertising.
+  'join-ad-interest-group', // Part of the FLEDGE API for interest-based advertising.
+  'private-aggregation', // For aggregating data privately.
+  'private-state-token-issuance', // For issuing and redeeming privacy-preserving tokens.
+  'private-state-token-redemption', // For issuing and redeeming privacy-preserving tokens.
+  'run-ad-auction', // Part of the FLEDGE API for conducting ad auctions.
+  'shared-storage', // For privacy-preserving shared storage.
+  'shared-storage-select-url', // For privacy-preserving shared storage.
+];

--- a/packages/extension/src/contentScript/popovers/tooltip/createTooltip.ts
+++ b/packages/extension/src/contentScript/popovers/tooltip/createTooltip.ts
@@ -125,7 +125,7 @@ const createTooltip = (
   const allowedFeaturedValue = displayShowMoreButton
     ? allowedFeaturesInCompactView
     : allowedFeatureInExpandedView;
-  info['Allowed features'] =
+  info['Allowed features (PS related)'] =
     allowedFeaturedValue === ALL_ALLOWED_FEATURES
       ? 'all'
       : allowedFeaturedValue;

--- a/packages/extension/src/contentScript/utils/getAllowedFeatures.ts
+++ b/packages/extension/src/contentScript/utils/getAllowedFeatures.ts
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Internal dependencies.
+ */
+import { PS_RELATED_ALLOWED_FEATURES } from '../constants';
+
 const getAllowedFeatures = (iframe: HTMLElement) => {
   if (!iframe || !iframe?.featurePolicy) {
     return 'Unknown';
@@ -21,7 +26,11 @@ const getAllowedFeatures = (iframe: HTMLElement) => {
   const featurePolicy = iframe?.featurePolicy;
 
   // Then query feature for specific
-  const allowed = featurePolicy.allowedFeatures();
+  const allAllowedFeatures = featurePolicy.allowedFeatures() || [];
+
+  const allowed = allAllowedFeatures.filter((feature: string) => {
+    return PS_RELATED_ALLOWED_FEATURES.includes(feature);
+  });
 
   return allowed && allowed.length ? allowed.sort() : 'N/A';
 };


### PR DESCRIPTION
## Description

Display only privacy sandbox-related allowed features in the tooltip.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<img width="543" alt="image" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/6297436/fd697b98-3120-4ce2-8805-0c7a31e90a7f">

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
