### PR TITLE
Fix: Frame overlay issues of scrolling into view

### DIFF
--- a/packages/extension/src/contentScript/index.ts
+++ b/packages/extension/src/contentScript/index.ts
@@ -61,6 +61,11 @@ class WebpageContentScript {
 
     this.listenToConnection();
     this.setTopics();
+    if (chrome.runtime?.id) {
+      chrome.runtime.sendMessage({
+        setInPage: true,
+      });
+    }
   }
 
   /**

--- a/packages/extension/src/utils/test-data/globalChrome.ts
+++ b/packages/extension/src/utils/test-data/globalChrome.ts
@@ -48,5 +48,9 @@ export default {
     onConnect: {
       addListener: () => '',
     },
+    onMessage: {
+      addListener: () => '',
+      removeListener: () => '',
+    },
   },
 } as unknown as typeof chrome;

--- a/packages/extension/src/view/devtools/components/sidebar/index.tsx
+++ b/packages/extension/src/view/devtools/components/sidebar/index.tsx
@@ -46,6 +46,7 @@ const Sidebar: React.FC<SidebarProps> = ({ selectedIndex, setIndex }) => {
     isCurrentTabBeingListenedTo,
     isInspecting,
     setIsInspecting,
+    canStartInspecting,
   } = useCookieStore(({ state, actions }) => ({
     setSelectedFrame: actions.setSelectedFrame,
     tabFrames: state.tabFrames,
@@ -53,6 +54,7 @@ const Sidebar: React.FC<SidebarProps> = ({ selectedIndex, setIndex }) => {
     isCurrentTabBeingListenedTo: state.isCurrentTabBeingListenedTo,
     isInspecting: state.isInspecting,
     setIsInspecting: actions.setIsInspecting,
+    canStartInspecting: state.canStartInspecting,
   }));
 
   const [accordionState, setAccordionState] =
@@ -232,9 +234,10 @@ const Sidebar: React.FC<SidebarProps> = ({ selectedIndex, setIndex }) => {
     [setIndex, setSelectedFrame]
   );
 
-  const showInspectButton = tabFrames
-    ? Boolean(Object.keys(tabFrames).length)
-    : false;
+  const showInspectButton =
+    tabFrames && canStartInspecting
+      ? Boolean(Object.keys(tabFrames).length)
+      : false;
 
   return (
     <div className="overflow-auto flex h-full">

--- a/packages/extension/src/view/devtools/components/sidebar/keyboardNavigationHandlers/arrowDownHandler.ts
+++ b/packages/extension/src/view/devtools/components/sidebar/keyboardNavigationHandlers/arrowDownHandler.ts
@@ -27,7 +27,7 @@ interface ArrowUpHandlerProps {
   >;
   selectedFrame: string | null;
   setIndex: (index: number) => void;
-  setSelectedFrame: React.Dispatch<React.SetStateAction<string | null>>;
+  setSelectedFrame: (key: string | null) => void;
   selectedIndex: number;
   keys: string[];
 }

--- a/packages/extension/src/view/devtools/components/sidebar/keyboardNavigationHandlers/arrowUpHandler.ts
+++ b/packages/extension/src/view/devtools/components/sidebar/keyboardNavigationHandlers/arrowUpHandler.ts
@@ -27,7 +27,7 @@ interface ArrowUpHandlerProps {
   >;
   selectedFrame: string | null;
   setIndex: (index: number) => void;
-  setSelectedFrame: React.Dispatch<React.SetStateAction<string | null>>;
+  setSelectedFrame: (key: string | null) => void;
   selectedIndex: number;
   keys: string[];
 }

--- a/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
+++ b/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
@@ -45,6 +45,7 @@ const useFrameOverlay = () => {
     isFrameSelectedFromDevTool,
     setIsFrameSelectedFromDevTool,
     setCanStartInspecting,
+    canStartInspecting,
   } = useCookieStore(({ state, actions }) => ({
     setContextInvalidated: actions.setContextInvalidated,
     isInspecting: state.isInspecting,
@@ -57,6 +58,7 @@ const useFrameOverlay = () => {
     isFrameSelectedFromDevTool: state.isFrameSelectedFromDevTool,
     setIsFrameSelectedFromDevTool: actions.setIsFrameSelectedFromDevTool,
     setCanStartInspecting: actions.setCanStartInspecting,
+    canStartInspecting: state.canStartInspecting,
   }));
 
   const { filteredCookies } = useFilterManagementStore(({ state }) => ({
@@ -104,6 +106,12 @@ const useFrameOverlay = () => {
     },
     [setCanStartInspecting]
   );
+
+  useEffect(() => {
+    if (!canStartInspecting && isCurrentTabBeingListenedTo) {
+      setCanStartInspecting(true);
+    }
+  }, [canStartInspecting, setCanStartInspecting, isCurrentTabBeingListenedTo]);
 
   useEffect(() => {
     chrome.runtime.onMessage.addListener(listenIfContentScriptSet);
@@ -220,6 +228,7 @@ const useFrameOverlay = () => {
       }
     })();
   }, [
+    setCanStartInspecting,
     selectedFrame,
     filteredCookies,
     isInspecting,

--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -48,6 +48,7 @@ export interface CookieStoreContext {
     isInspecting: boolean;
     contextInvalidated: boolean;
     isFrameSelectedFromDevTool: boolean;
+    canStartInspecting: boolean;
   };
   actions: {
     setSelectedFrame: (key: string | null) => void;
@@ -58,6 +59,7 @@ export interface CookieStoreContext {
     setIsFrameSelectedFromDevTool: React.Dispatch<
       React.SetStateAction<boolean>
     >;
+    setCanStartInspecting: React.Dispatch<React.SetStateAction<boolean>>;
   };
 }
 
@@ -74,6 +76,7 @@ const initialState: CookieStoreContext = {
     isInspecting: false,
     contextInvalidated: false,
     isFrameSelectedFromDevTool: false,
+    canStartInspecting: false,
   },
   actions: {
     setSelectedFrame: noop,
@@ -82,6 +85,7 @@ const initialState: CookieStoreContext = {
     setIsInspecting: noop,
     getCookiesSetByJavascript: noop,
     setContextInvalidated: noop,
+    setCanStartInspecting: noop,
   },
 };
 
@@ -102,6 +106,8 @@ export const Provider = ({ children }: PropsWithChildren) => {
   const [allowedNumberOfTabs, setAllowedNumberOfTabs] = useState<string | null>(
     null
   );
+
+  const [canStartInspecting, setCanStartInspecting] = useState<boolean>(false);
 
   const [tabCookies, setTabCookies] =
     useState<CookieStoreContext['state']['tabCookies']>(null);
@@ -486,6 +492,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
           contextInvalidated,
           isInspecting,
           isFrameSelectedFromDevTool,
+          canStartInspecting,
         },
         actions: {
           setSelectedFrame,
@@ -494,6 +501,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
           setIsInspecting,
           setContextInvalidated,
           setIsFrameSelectedFromDevTool,
+          setCanStartInspecting,
         },
       }}
     >

--- a/packages/extension/src/view/devtools/tests/app.tsx
+++ b/packages/extension/src/view/devtools/tests/app.tsx
@@ -48,6 +48,7 @@ describe('App', () => {
       setSelectedFrame: noop,
       allowedNumberOfTabs: 'single',
       setIsInspecting: noop,
+      setCanStartInspecting: noop,
     });
     jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     globalThis.chrome = {

--- a/packages/extension/src/view/devtools/tests/index.tsx
+++ b/packages/extension/src/view/devtools/tests/index.tsx
@@ -103,6 +103,11 @@ describe('Index', () => {
       runtime: {
         id: 'afajkfkjabfkjas',
         getURL: () => 'data/related_website_sets.json',
+        //@ts-ignore
+        onMessage: {
+          addListener: () => '',
+          removeListener: () => '',
+        },
       },
       //@ts-ignore
       webNavigation: {


### PR DESCRIPTION
## Description
This PR aims to fix the issues of scrolling into view functionality of the frame overlay feature.

## Relevant Technical Choices
- Send a message from the content script to the extension once the content script is initialised on the webpage. Once the content-script is initialised in the webpage the inspect button will be shown.
- Modify scrollIntoView values to fix the scrolling issue of the webpage.

## Testing Instructions


## Additional Information:



## Screenshot/Screencast

