### PR TITLE
Fix: Misattribution of affected cookies

### DIFF
--- a/packages/cli/src/procedures/analyzeTechnologiesUrlsInBatches.ts
+++ b/packages/cli/src/procedures/analyzeTechnologiesUrlsInBatches.ts
@@ -61,7 +61,5 @@ export const analyzeTechnologiesUrlsInBatches = async (
     });
   }
 
-  console.log(report);
-
   return report;
 };


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR fixes a bug found while smoke testing. Due to a missing filtration step in "responseReceivedExtraInfo" blocked cookies where counted as accepted cookies which misattributed some 3p cookies to be marked as not affected when they are.
The missing filtration step is added in this PR.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
