### PR TITLE
Fix: CLI std output changes

### DIFF
--- a/packages/cli-dashboard/src/app.tsx
+++ b/packages/cli-dashboard/src/app.tsx
@@ -47,13 +47,13 @@ const App = () => {
 
   const [type, path] = useMemo(() => {
     const urlParams = new URLSearchParams(window.location.search);
-    const folder = urlParams.get('folder');
+    const dir = urlParams.get('dir');
 
     return [
       urlParams.get('type') === 'sitemap'
         ? DisplayType.SITEMAP
         : DisplayType.SITE,
-      `/out/${folder}/out.json`,
+      `/out/${dir}/out.json`,
     ];
   }, []);
 

--- a/packages/cli-dashboard/src/app.tsx
+++ b/packages/cli-dashboard/src/app.tsx
@@ -47,12 +47,13 @@ const App = () => {
 
   const [type, path] = useMemo(() => {
     const urlParams = new URLSearchParams(window.location.search);
+    const folder = urlParams.get('folder');
 
     return [
       urlParams.get('type') === 'sitemap'
         ? DisplayType.SITEMAP
         : DisplayType.SITE,
-      urlParams.get('path')?.substring(1) || '',
+      `/out/${folder}/out.json`,
     ];
   }, []);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -113,7 +113,7 @@ export const initialize = async () => {
 
     await delay(2000);
     console.log(
-      `Report is being served at the URL: http://localhost:9000?folder=${encodeURIComponent(
+      `Report is being served at the URL: http://localhost:9000?dir=${encodeURIComponent(
         prefix
       )}`
     );

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -61,7 +61,7 @@ export const initialize = async () => {
 
   if (portInUse) {
     console.error(
-      'Error: Report server port already in use. You might be already running CLI'
+      'Error: Report server port (9000) already in use. You might be already running CLI'
     );
     process.exit(1);
   }
@@ -113,8 +113,8 @@ export const initialize = async () => {
 
     await delay(2000);
     console.log(
-      `Report is being served at the URL: http://localhost:9000?path=${encodeURIComponent(
-        directory + '/out.json'
+      `Report is being served at the URL: http://localhost:9000?folder=${encodeURIComponent(
+        prefix
       )}`
     );
   } else {
@@ -180,8 +180,8 @@ export const initialize = async () => {
     await delay(2000);
 
     console.log(
-      `Report is being served at the URL: http://localhost:9000?path=${encodeURIComponent(
-        directory + '/out.json'
+      `Report is being served at the URL: http://localhost:9000?folder=${encodeURIComponent(
+        prefix
       )}&type=sitemap`
     );
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -180,7 +180,7 @@ export const initialize = async () => {
     await delay(2000);
 
     console.log(
-      `Report is being served at the URL: http://localhost:9000?folder=${encodeURIComponent(
+      `Report is being served at the URL: http://localhost:9000?dir=${encodeURIComponent(
         prefix
       )}&type=sitemap`
     );

--- a/packages/cli/src/utils/checkPortInUse.ts
+++ b/packages/cli/src/utils/checkPortInUse.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import http from 'http';
+
+/**
+ * @param port number Port number to test
+ * @returns Promise which will resolve in a boolean value
+ */
+export function checkPortInUse(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = http
+      .createServer()
+      .listen(port, () => {
+        server.close();
+        resolve(false);
+      })
+      .on('error', () => {
+        resolve(true);
+      });
+  });
+}


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
- Error message improvements.
  - Message text updated to: Error: Report server port (9000) already in use. You might be already running CLI.
  - Process exits after throwing error.
  - Port usage is tested before starting analysis.
 
 - Out out Url changes
   - Cli and Cli dashboard are updated to use the just the folder name in the URL search params.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
