### PR TITLE
Fix: SameSite showing undefined in chips

### DIFF
--- a/packages/extension/src/view/devtools/stateProviders/filterManagementStore/constants.ts
+++ b/packages/extension/src/view/devtools/stateProviders/filterManagementStore/constants.ts
@@ -95,18 +95,15 @@ export const CUSTOM_FILTER_MAPPING = {
 };
 
 export const MAPPING_KEYS_TO_NAME = {
-  // eslint-disable-next-line prettier/prettier
-  'samesite': 'SameSite',
+  samesite: 'SameSite',
   'analytics.category': 'Category',
   'parsedCookie.domain': 'Domain',
   'parsedCookie.httponly': 'HttpOnly',
   'parsedCookie.secure': 'Secure',
   'parsedCookie.path': 'Path',
   'analytics.platform': 'Platform',
-  // eslint-disable-next-line prettier/prettier
-  'isCookieSet': 'Cookie Accepted',
-  // eslint-disable-next-line prettier/prettier
-  'headerType': 'Set Via',
-  // eslint-disable-next-line prettier/prettier
-  'retentionPeriod': 'Retention Period',
+  isCookieSet: 'Cookie Accepted',
+  headerType: 'Set Via',
+  retentionPeriod: 'Retention Period',
+  isFirstParty: 'Scope',
 };


### PR DESCRIPTION
## Description
This PR aims to introduce a hotfix for the bug where `SameSite` filter showed undefined in filter chips in `cookieTopBar`.

## Relevant Technical Choices
- Add `sameSite` constant to `MAPPING_KEYS_TO_NAME`.

## Testing Instructions
- Open this branch in a terminal.
- Run `npm start`.
- Open `aljazeera.com` in Chrome. Open DevTools and go to `PrivacySandbox` Tab in DevTools.
- Click on the arrow which is on the left `Cookies` header.
- Go to any frame and select filter you should see the filters in a new way `FilterName: selectedFilterValue`

## Additional Information:


## Screenshot/Screencast

---