### PR TITLE
Feature: On Mouse leaving the frame remove tooltip and keep overlay

### DIFF
--- a/packages/extension/src/contentScript/index.ts
+++ b/packages/extension/src/contentScript/index.ts
@@ -24,6 +24,7 @@ import {
   setOverlayPosition,
   addTooltip,
   setTooltipPosition,
+  removeAllTooltips,
 } from './popovers';
 import type { ResponseType } from './types';
 import { CookieStore } from '../localStore';
@@ -375,7 +376,7 @@ class WebpageContentScript {
     const frameToScrollTo = frameElements[0];
     const visibleIFrameCount = frameCount['numberOfVisibleFrames'];
     const hiddenIFrameCount = frameCount['numberOfHiddenFrames'];
-
+    removeAllPopovers();
     const popoverElement = this.insertPopoversConditionHandler(
       frameElements,
       visibleIFrameCount,
@@ -430,15 +431,7 @@ class WebpageContentScript {
       isNonIframeElement &&
       this.port
     ) {
-      removeAllPopovers();
-
-      if (chrome.runtime?.id) {
-        this.port.postMessage({
-          attributes: {
-            iframeOrigin: '',
-          },
-        });
-      }
+      removeAllTooltips();
 
       this.bodyHoverStateSent = true;
     }
@@ -503,6 +496,7 @@ class WebpageContentScript {
   handleMouseMove(event: Event) {
     if (event?.type === 'mouseenter') {
       this.isHoveringOverPage = true;
+      removeAllPopovers();
     } else if (event?.type === 'mouseleave') {
       this.isHoveringOverPage = false;
     }

--- a/packages/extension/src/contentScript/popovers/index.ts
+++ b/packages/extension/src/contentScript/popovers/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 export { default as findSelectedFrameElements } from './findSelectedFrameElements';
-export { default as removeAllPopovers } from './removeAllPopovers';
+export * from './removeAllPopovers';
 export { default as toggleFrameHighlighting } from './toggleFrameHighlighting';
 export * from './overlay';
 export * from './tooltip';

--- a/packages/extension/src/contentScript/popovers/removeAllPopovers.ts
+++ b/packages/extension/src/contentScript/popovers/removeAllPopovers.ts
@@ -22,6 +22,15 @@ import { OVERLAY_CLASS, TOOLTIP_CLASS } from '../constants';
  * Removes all tooltips and overlays from the current document.
  * @returns {void}
  */
+const removeAllTooltips = (): void => {
+  const selectors = `.${TOOLTIP_CLASS}`;
+  const existingPopovers = document.querySelectorAll(selectors);
+
+  existingPopovers.forEach((element) => {
+    element.parentNode?.removeChild(element);
+  });
+};
+
 const removeAllPopovers = (): void => {
   const selectors = `.${OVERLAY_CLASS}, .${TOOLTIP_CLASS}`;
   const existingPopovers = document.querySelectorAll(selectors);
@@ -31,4 +40,4 @@ const removeAllPopovers = (): void => {
   });
 };
 
-export default removeAllPopovers;
+export { removeAllPopovers, removeAllTooltips };


### PR DESCRIPTION
## Description
This PR aims to remove the tooltip once the mouse exits `iframe` element it will remove the tooltip but will remove the overlay.

## Relevant Technical Choices
- Add a function which removes the tooltip on the page.

## Testing Instructions

- Switch to this branch and in the terminal run `npm start`.
- Go to `psanalysis.rt.gw`. Open DevTools and switch to the PrivacySandbox tab.
- Go to the cookies header and select the `inspection` icon.
- Hover over the iframe and once you leave the iframe you should see a blue overlay over the screen but no tooltip.

## Additional Information:


## Screenshot/Screencast

https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/59614577/a9d0c34b-2186-43cc-a15e-26d904b04404



---