### PR TITLE
Fix: Report downloader duplicate cookie entries in CSV

### DIFF
--- a/packages/cli-dashboard/src/components/utils/reportDownloader.ts
+++ b/packages/cli-dashboard/src/components/utils/reportDownloader.ts
@@ -18,6 +18,7 @@
  */
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
+import { type Cookie as ParsedCookie } from 'simple-cookie';
 
 /**
  * Internal dependencies
@@ -28,6 +29,11 @@ interface NewReport extends CompleteJson {
   affectedCookies: CookieFrameStorageType;
   cookieAnalysisSummary: Record<string, number>;
 }
+
+type SanitisedCookieType = ParsedCookie & {
+  category: string;
+  scope: string;
+};
 interface SingleTechnology {
   name: string;
   description: string;
@@ -109,6 +115,8 @@ export const reportDownloader = (
 
   newReport.affectedCookies = {};
 
+  const cookiesSet: { [key: string]: SanitisedCookieType } = {};
+  const affectedCookiesSet: { [key: string]: SanitisedCookieType } = {};
   Object.keys(cookieDataToBeProcessed).forEach((frameName) => {
     newReport.affectedCookies[frameName] = {};
     Object.keys(cookieDataToBeProcessed[frameName].frameCookies).forEach(
@@ -135,65 +143,80 @@ export const reportDownloader = (
           gdprPortal: unSanitisedCookie?.GDPR || 'NA',
         };
 
-        cookieDataValues =
-          cookieDataValues + Object.values(sanitizedData).join(',') + '\r\n';
-
-        if (unSanitisedCookie?.isFirstParty) {
-          firstPartyCookies++;
-        } else {
-          thirdPartyCookies++;
-        }
-
-        switch (unSanitisedCookie.category) {
-          case 'Marketing':
-            marketingCookies++;
-            break;
-          case 'Analytics':
-            analyticsCookies++;
-            break;
-          case 'Uncategorized':
-            uncategorisedCookies++;
-            break;
-          case 'Functional':
-            functionalCookies++;
-            break;
-          default:
-            break;
-        }
+        cookiesSet[
+          `${sanitizedData.name}:${sanitizedData.domain}:${sanitizedData.path}`
+        ] = sanitizedData;
 
         if (unSanitisedCookie.isBlocked) {
-          affectedCookiesCount = affectedCookiesCount + 1;
-
+          affectedCookiesSet[
+            `${sanitizedData.name}:${sanitizedData.domain}:${sanitizedData.path}`
+          ] = sanitizedData;
           newReport.affectedCookies[frameName] = {
             ...newReport.affectedCookies[frameName],
             [cookie]: cookieDataToBeProcessed[frameName].frameCookies[cookie],
           };
-          switch (unSanitisedCookie.category) {
-            case 'Marketing':
-              affectedMarketingCookies++;
-              break;
-            case 'Analytics':
-              affectedAnalyticsCookies++;
-              break;
-            case 'Uncategorized':
-              affectedUncategorisedCookies++;
-              break;
-            case 'Functional':
-              affectedFunctionalCookies++;
-              break;
-            default:
-              break;
-          }
-          affectedCookiesDataValues =
-            affectedCookiesDataValues +
-            Object.values(sanitizedData).join(',') +
-            '\r\n';
         }
       }
     );
 
     totalCookiesCount =
       totalCookiesCount + report.cookieData[frameName].cookiesCount;
+  });
+
+  Object.keys(cookiesSet).map((cookieName: string) => {
+    const cookie = cookiesSet[cookieName];
+    cookieDataValues =
+      cookieDataValues + Object.values(cookie).join(',') + '\r\n';
+
+    if (cookie?.scope === 'First Party') {
+      firstPartyCookies++;
+    } else {
+      thirdPartyCookies++;
+    }
+
+    switch (cookie.category) {
+      case 'Marketing':
+        marketingCookies++;
+        break;
+      case 'Analytics':
+        analyticsCookies++;
+        break;
+      case 'Uncategorized':
+        uncategorisedCookies++;
+        break;
+      case 'Functional':
+        functionalCookies++;
+        break;
+      default:
+        break;
+    }
+    return cookieName;
+  });
+
+  Object.keys(affectedCookiesSet).map((cookieName) => {
+    const cookie = affectedCookiesSet[cookieName];
+
+    affectedCookiesCount = affectedCookiesCount + 1;
+
+    switch (cookie.category) {
+      case 'Marketing':
+        affectedMarketingCookies++;
+        break;
+      case 'Analytics':
+        affectedAnalyticsCookies++;
+        break;
+      case 'Uncategorized':
+        affectedUncategorisedCookies++;
+        break;
+      case 'Functional':
+        affectedFunctionalCookies++;
+        break;
+      default:
+        break;
+    }
+    affectedCookiesDataValues =
+      affectedCookiesDataValues + Object.values(cookie).join(',') + '\r\n';
+    return cookieName;
   });
 
   const cookieDataCSVContent = cookieDataHeader + '\n' + cookieDataValues;

--- a/packages/extension/src/utils/getCurrentTabId.ts
+++ b/packages/extension/src/utils/getCurrentTabId.ts
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 export const getCurrentTab = () => {
-  return chrome.tabs.query({
-    active: true,
-    currentWindow: true,
-  });
+  try {
+    return chrome.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
+  } catch (error) {
+    //do nothing in this error
+  }
+  return Promise.resolve(undefined);
 };
 
 export const getCurrentTabId = async (tab = null) => {


### PR DESCRIPTION
## Description
This PR aims to club all the same name cookies that are in different frames before writing them to the CSV document.

## Relevant Technical Choices

## Testing Instructions

## Additional Information:


## Screenshot/Screencast


---