### PR TITLE
Fix: Frame overlay issues

### DIFF
--- a/packages/extension/src/contentScript/index.ts
+++ b/packages/extension/src/contentScript/index.ts
@@ -66,6 +66,11 @@ class WebpageContentScript {
   scrollEventListeners: Array<() => void> = [];
 
   /**
+   * @property {Array<() => void>} resizeEventListeners - Array of resize event listeners.
+   */
+  resizeEventListeners: Array<() => void> = [];
+
+  /**
    * @property {HTMLElement} docElement - Document element.
    */
   docElement: HTMLElement;
@@ -162,6 +167,7 @@ class WebpageContentScript {
     };
 
     this.addEventListerOnScroll(updatePosition);
+    this.addEventListenersOnResize(updatePosition);
 
     return overlay;
   }
@@ -193,6 +199,7 @@ class WebpageContentScript {
     };
 
     this.addEventListerOnScroll(updatePosition);
+    this.addEventListenersOnResize(updatePosition);
 
     return tooltip;
   }
@@ -208,6 +215,16 @@ class WebpageContentScript {
   }
 
   /**
+   * Add event listener on scroll to update overlay and tooltip positions.
+   * @param callback Callback function to update position.
+   */
+  addEventListenersOnResize(callback: () => void) {
+    this.resizeEventListeners.push(callback);
+    callback();
+    window.addEventListener('resize', callback);
+  }
+
+  /**
    * Remove all popovers.
    */
   removeAllPopovers() {
@@ -217,6 +234,14 @@ class WebpageContentScript {
       });
 
       this.scrollEventListeners = [];
+    }
+
+    if (this.resizeEventListeners.length) {
+      this.resizeEventListeners.forEach((listener) => {
+        window.removeEventListener('scroll', listener);
+      });
+
+      this.resizeEventListeners = [];
     }
 
     removeAllPopovers();

--- a/packages/extension/src/contentScript/index.ts
+++ b/packages/extension/src/contentScript/index.ts
@@ -169,7 +169,7 @@ class WebpageContentScript {
     };
 
     this.addEventListerOnScroll(updatePosition);
-    this.addEventListenersOnResize(updatePosition);
+    this.addEventListenersOnResize(() => setOverlayPosition(overlay, frame));
 
     return overlay;
   }

--- a/packages/extension/src/contentScript/index.ts
+++ b/packages/extension/src/contentScript/index.ts
@@ -250,7 +250,7 @@ class WebpageContentScript {
 
     if (this.resizeEventListeners.length) {
       this.resizeEventListeners.forEach((listener) => {
-        window.removeEventListener('scroll', listener);
+        window.removeEventListener('resize', listener);
       });
 
       this.resizeEventListeners = [];

--- a/packages/extension/src/contentScript/index.ts
+++ b/packages/extension/src/contentScript/index.ts
@@ -351,7 +351,7 @@ class WebpageContentScript {
     });
 
     frameElements.forEach((frame, index) => {
-      if (!isFrameHidden(frame)) {
+      if (!isFrameHidden(frame) && !popoverElement.frameWithTooltip) {
         popoverElement.frameWithTooltip = frame;
 
         const tooltip = this.insertTooltip(

--- a/packages/extension/src/contentScript/index.ts
+++ b/packages/extension/src/contentScript/index.ts
@@ -398,9 +398,7 @@ class WebpageContentScript {
       !isElementVisibleInViewport(frameWithTooltip, true)
     ) {
       (firstToolTip as HTMLElement).scrollIntoView({
-        behavior: 'instant',
         block: 'start',
-        inline: 'nearest',
       });
     }
   }

--- a/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
+++ b/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
@@ -75,10 +75,16 @@ const setTooltipPosition = (
       frameY - tooltip.offsetHeight + Number(window.scrollY)
     }px`;
 
-    //check for space on right
-    if (frameX + tooltip.offsetWidth > window.innerWidth) {
-      const leftOverWidth = tooltip.offsetWidth - (window.innerWidth - frameX);
-      tooltip.style.left = `${frameX - leftOverWidth - 10}px`;
+    /**
+     * 2 conditions will be checked
+     * 1) If space is available on left and space is not available on right, show on left.
+     * 2) If space is available on right and not on left, show on right.
+     * 3) If above 2 conditions dont work show on left and reduce the width.
+     */
+    // eslint-disable-next-line prettier/prettier
+    if (frameX + frameWidth - window.innerWidth > 0 && frameX + tooltip.offsetWidth > window.innerWidth) {
+      tooltip.style.left = `unset`;
+      tooltip.style.right = `${frameX + frameWidth - window.innerWidth - 10}px`;
       tooltip.firstElementChild?.classList.remove(
         'ps-tooltip-top-right-notch',
         'ps-tooltip-top-left-notch',
@@ -87,26 +93,48 @@ const setTooltipPosition = (
       );
       tooltip.firstElementChild?.classList.add('ps-tooltip-bottom-right-notch');
       return;
+      // eslint-disable-next-line prettier/prettier
+    } else if (frameX + frameWidth - window.innerWidth < 0 && frameX + tooltip.offsetWidth < window.innerWidth) {
+      tooltip.style.left = frameX + Number(window.scrollX) + 'px';
+      tooltip.style.right = `unset`;
+      tooltip.firstElementChild?.classList.remove(
+        'ps-tooltip-top-right-notch',
+        'ps-tooltip-top-left-notch',
+        'ps-tooltip-bottom-left-notch',
+        'ps-tooltip-bottom-right-notch'
+      );
+      tooltip.firstElementChild?.classList.add('ps-tooltip-bottom-left-notch');
+    } else {
+      const leftOverWidth = tooltip.offsetWidth - (window.innerWidth - frameX);
+      tooltip.style.left = frameX + Number(window.scrollX) + 'px';
+      tooltip.style.maxWidth = frameWidth - leftOverWidth + 'px';
+      tooltip.firstElementChild?.classList.remove(
+        'ps-tooltip-top-right-notch',
+        'ps-tooltip-top-left-notch',
+        'ps-tooltip-bottom-left-notch',
+        'ps-tooltip-bottom-right-notch'
+      );
+      tooltip.firstElementChild?.classList.add('ps-tooltip-bottom-left-notch');
+      return;
     }
-    tooltip.firstElementChild?.classList.remove(
-      'ps-tooltip-top-right-notch',
-      'ps-tooltip-top-left-notch',
-      'ps-tooltip-bottom-left-notch',
-      'ps-tooltip-bottom-right-notch'
-    );
-    tooltip.firstElementChild?.classList.add('ps-tooltip-bottom-left-notch');
-    return;
   }
 
   //check for space at bottom of frame
   if (frameY + frame.offsetHeight + tooltip.offsetHeight < window.innerHeight) {
-    //check for space on right
     tooltip.style.top = `${
       frameY + frame.offsetHeight + Number(window.scrollY)
     }px`;
-    if (frameX + tooltip.offsetWidth > window.innerWidth) {
-      const leftOverWidth = tooltip.offsetWidth - (window.innerWidth - frameX);
-      tooltip.style.left = `${frameX - leftOverWidth - 10}px`;
+
+    /**
+     * 2 conditions will be checked
+     * 1) If space is available on left and space is not available on right, show on left.
+     * 2) If space is available on right and not on left, show on right.
+     * 3) If above 2 conditions dont work show on left and reduce the width.
+     */
+    // eslint-disable-next-line prettier/prettier
+    if (frameX + frameWidth - window.innerWidth > 0 && frameX + tooltip.offsetWidth > window.innerWidth) {
+      tooltip.style.left = `unset`;
+      tooltip.style.right = `${frameX + frameWidth - window.innerWidth - 10}px`;
       tooltip.firstElementChild?.classList.remove(
         'ps-tooltip-top-right-notch',
         'ps-tooltip-top-left-notch',
@@ -115,16 +143,30 @@ const setTooltipPosition = (
       );
       tooltip.firstElementChild?.classList.add('ps-tooltip-top-right-notch');
       return;
+      // eslint-disable-next-line prettier/prettier
+    } else if (frameX + frameWidth - window.innerWidth < 0 && frameX + tooltip.offsetWidth < window.innerWidth) {
+      tooltip.style.left = frameX + Number(window.scrollX) + 'px';
+      tooltip.style.right = `unset`;
+      tooltip.firstElementChild?.classList.remove(
+        'ps-tooltip-top-right-notch',
+        'ps-tooltip-top-left-notch',
+        'ps-tooltip-bottom-left-notch',
+        'ps-tooltip-bottom-right-notch'
+      );
+      tooltip.firstElementChild?.classList.add('ps-tooltip-top-left-notch');
+    } else {
+      const leftOverWidth = tooltip.offsetWidth - (window.innerWidth - frameX);
+      tooltip.style.left = frameX + Number(window.scrollX) + 'px';
+      tooltip.style.maxWidth = frameWidth - leftOverWidth + 'px';
+      tooltip.firstElementChild?.classList.remove(
+        'ps-tooltip-top-right-notch',
+        'ps-tooltip-top-left-notch',
+        'ps-tooltip-bottom-left-notch',
+        'ps-tooltip-bottom-right-notch'
+      );
+      tooltip.firstElementChild?.classList.add('ps-tooltip-top-left-notch');
+      return;
     }
-    tooltip.style.left = frameX + Number(window.scrollX) + 'px';
-    tooltip.firstElementChild?.classList.remove(
-      'ps-tooltip-top-right-notch',
-      'ps-tooltip-top-left-notch',
-      'ps-tooltip-bottom-left-notch',
-      'ps-tooltip-bottom-right-notch'
-    );
-    tooltip.firstElementChild?.classList.add('ps-tooltip-top-left-notch');
-    return;
   }
 };
 

--- a/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
+++ b/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
@@ -83,6 +83,7 @@ const setTooltipPosition = (
      */
     // eslint-disable-next-line prettier/prettier
     if (frameX + frameWidth - window.innerWidth > 0 && frameX + tooltip.offsetWidth > window.innerWidth) {
+
       tooltip.style.left = `unset`;
       tooltip.style.right = `${frameX + frameWidth - window.innerWidth - 10}px`;
       tooltip.firstElementChild?.classList.remove(
@@ -95,6 +96,7 @@ const setTooltipPosition = (
       return;
       // eslint-disable-next-line prettier/prettier
     } else if (frameX + frameWidth - window.innerWidth < 0 && frameX + tooltip.offsetWidth < window.innerWidth) {
+
       tooltip.style.left = frameX + Number(window.scrollX) + 'px';
       tooltip.style.right = `unset`;
       tooltip.firstElementChild?.classList.remove(
@@ -104,8 +106,10 @@ const setTooltipPosition = (
         'ps-tooltip-bottom-right-notch'
       );
       tooltip.firstElementChild?.classList.add('ps-tooltip-bottom-left-notch');
+      return;
     } else {
       const leftOverWidth = tooltip.offsetWidth - (window.innerWidth - frameX);
+
       tooltip.style.left = frameX + Number(window.scrollX) + 'px';
       tooltip.style.maxWidth = frameWidth - leftOverWidth + 'px';
       tooltip.firstElementChild?.classList.remove(
@@ -154,6 +158,7 @@ const setTooltipPosition = (
         'ps-tooltip-bottom-right-notch'
       );
       tooltip.firstElementChild?.classList.add('ps-tooltip-top-left-notch');
+      return;
     } else {
       const leftOverWidth = tooltip.offsetWidth - (window.innerWidth - frameX);
       tooltip.style.left = frameX + Number(window.scrollX) + 'px';

--- a/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
+++ b/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
@@ -168,6 +168,9 @@ const setTooltipPosition = (
       return;
     }
   }
+
+  tooltip.style.removeProperty('top');
+  tooltip.style.bottom = frameY + 'px';
 };
 
 export default setTooltipPosition;


### PR DESCRIPTION
## Description
This PR aims to solve tooltip calculation problems and adds a capability to calculate the tooltip and overlay position on window resize.

## Relevant Technical Choices
- Calculate tooltip positions by checking left, right, top and bottom spacing.
- Add a callback to calculate the position on resize.
- Change parameters for scrollIntoView to have proper scrolling behaviour.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:


## Screenshot/Screencast


---