### PR TITLE
Feature: Development mode

### DIFF
--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -289,7 +289,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
     }
     if (details.reason === 'update') {
       const preSetSettings = await chrome.storage.sync.get();
-      if (preSetSettings?.allowedNumberOfTabs) {
+      if (preSetSettings?.allowedNumberOfTabs && preSetSettings?.isDev) {
         return;
       }
       await chrome.storage.sync.clear();

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -252,7 +252,8 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
  */
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   await PROMISE_QUEUE.add(async () => {
-    if (changeInfo.status === 'loading' && tab.url) {
+    const syncStorage = await chrome.storage.sync.get();
+    if (changeInfo.status === 'loading' && tab.url && !syncStorage.isDev) {
       await CookieStore.removeCookieData(tabId.toString());
     }
   });

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -284,6 +284,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
       await chrome.storage.sync.clear();
       await chrome.storage.sync.set({
         allowedNumberOfTabs: 'single',
+        isDev: 'false',
       });
     }
     if (details.reason === 'update') {
@@ -294,6 +295,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
       await chrome.storage.sync.clear();
       await chrome.storage.sync.set({
         allowedNumberOfTabs: 'single',
+        isDev: 'false',
       });
     }
   });

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -253,7 +253,12 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   await PROMISE_QUEUE.add(async () => {
     const syncStorage = await chrome.storage.sync.get();
-    if (changeInfo.status === 'loading' && tab.url && !syncStorage.isDev) {
+    if (
+      changeInfo.status === 'loading' &&
+      tab.url &&
+      syncStorage.isDev === 'false' &&
+      process.env.NODE_ENV === 'production'
+    ) {
       await CookieStore.removeCookieData(tabId.toString());
     }
   });

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -40,7 +40,6 @@ const App: React.FC = () => {
       setContextInvalidated: actions.setContextInvalidated,
     })
   );
-
   const listenToMouseChange = useCallback(() => {
     if (contextInvalidatedRef.current) {
       if (!chrome.runtime?.id) {

--- a/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
+++ b/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
@@ -125,7 +125,7 @@ const useFrameOverlay = () => {
     async (changes: { [key: string]: chrome.storage.StorageChange }) => {
       try {
         const syncStorage = await chrome.storage.sync.get();
-        if (syncStorage.isDev) {
+        if (syncStorage.isDev === 'true') {
           return;
         }
         const currentTabId = await getCurrentTabId();

--- a/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
+++ b/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
@@ -125,7 +125,10 @@ const useFrameOverlay = () => {
     async (changes: { [key: string]: chrome.storage.StorageChange }) => {
       try {
         const syncStorage = await chrome.storage.sync.get();
-        if (syncStorage.isDev === 'true') {
+        if (
+          process.env.NODE_ENV === 'development' &&
+          syncStorage.isDev === 'true'
+        ) {
           return;
         }
         const currentTabId = await getCurrentTabId();

--- a/packages/extension/src/view/settings/components/tabContent/settings/index.tsx
+++ b/packages/extension/src/view/settings/components/tabContent/settings/index.tsx
@@ -29,7 +29,7 @@ const Settings: React.FC = () => {
   return (
     <div className="w-full h-full flex flex-col gap-5">
       <AllowedNumberOfTabs />
-      <IsInDevelopmentMode />
+      {process.env.NODE_ENV === 'development' && <IsInDevelopmentMode />}
     </div>
   );
 };

--- a/packages/extension/src/view/settings/components/tabContent/settings/index.tsx
+++ b/packages/extension/src/view/settings/components/tabContent/settings/index.tsx
@@ -23,11 +23,13 @@ import React from 'react';
  * Internal dependencies.
  */
 import AllowedNumberOfTabs from './allowedNumberOfTabs';
+import IsInDevelopmentMode from './isDevelopmentTab';
 
 const Settings: React.FC = () => {
   return (
     <div className="w-full h-full flex flex-col gap-5">
       <AllowedNumberOfTabs />
+      <IsInDevelopmentMode />
     </div>
   );
 };

--- a/packages/extension/src/view/settings/components/tabContent/settings/isDevelopmentTab/index.tsx
+++ b/packages/extension/src/view/settings/components/tabContent/settings/isDevelopmentTab/index.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies.
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies.
+ */
+import { useSettingsStore } from '../../../../stateProviders/syncSettingsStore';
+
+const IsInDevelopmentMode: React.FC = () => {
+  const { allowedNumberOfTabs, setSettingsInStorage } = useSettingsStore(
+    ({ state, actions }) => ({
+      allowedNumberOfTabs: state.allowedNumberOfTabs,
+      setSettingsInStorage: actions.setSettingsInStorage,
+    })
+  );
+
+  return (
+    <div className="flex flex-col gap-1">
+      <h3 className="text-sm font-medium">Is in debugging mode:</h3>
+      <div className="flex flex-row gap-1">
+        <input
+          value="true"
+          type="radio"
+          name="allowed-number-of-tabs"
+          className="text-xs"
+          onChange={(e) => setSettingsInStorage('isDev', e.target?.value)}
+          checked={allowedNumberOfTabs === 'true'}
+        />
+        On
+      </div>
+      <div className="flex flex-row gap-1">
+        <input
+          className="text-xs"
+          value="false"
+          type="radio"
+          name="allowed-number-of-tabs"
+          onChange={(e) => setSettingsInStorage('isDev', e.target?.value)}
+          checked={allowedNumberOfTabs === 'false'}
+        />
+        Off
+      </div>
+    </div>
+  );
+};
+
+export default IsInDevelopmentMode;

--- a/packages/extension/src/view/settings/components/tabContent/settings/isDevelopmentTab/index.tsx
+++ b/packages/extension/src/view/settings/components/tabContent/settings/isDevelopmentTab/index.tsx
@@ -25,9 +25,9 @@ import React from 'react';
 import { useSettingsStore } from '../../../../stateProviders/syncSettingsStore';
 
 const IsInDevelopmentMode: React.FC = () => {
-  const { allowedNumberOfTabs, setSettingsInStorage } = useSettingsStore(
+  const { isDev, setSettingsInStorage } = useSettingsStore(
     ({ state, actions }) => ({
-      allowedNumberOfTabs: state.allowedNumberOfTabs,
+      isDev: state.isDev,
       setSettingsInStorage: actions.setSettingsInStorage,
     })
   );
@@ -39,10 +39,10 @@ const IsInDevelopmentMode: React.FC = () => {
         <input
           value="true"
           type="radio"
-          name="allowed-number-of-tabs"
+          name="allow-debugging-mode"
           className="text-xs"
           onChange={(e) => setSettingsInStorage('isDev', e.target?.value)}
-          checked={allowedNumberOfTabs === 'true'}
+          checked={isDev === 'true'}
         />
         On
       </div>
@@ -51,9 +51,9 @@ const IsInDevelopmentMode: React.FC = () => {
           className="text-xs"
           value="false"
           type="radio"
-          name="allowed-number-of-tabs"
+          name="allow-debugging-mode"
           onChange={(e) => setSettingsInStorage('isDev', e.target?.value)}
-          checked={allowedNumberOfTabs === 'false'}
+          checked={isDev === 'false'}
         />
         Off
       </div>

--- a/packages/extension/src/view/settings/stateProviders/syncSettingsStore/index.tsx
+++ b/packages/extension/src/view/settings/stateProviders/syncSettingsStore/index.tsx
@@ -28,6 +28,7 @@ import { noop } from '@ps-analysis-tool/design-system';
 export interface SettingStoreContext {
   state: {
     allowedNumberOfTabs: string | null;
+    isDev: string | null;
   };
   actions: {
     setSettingsInStorage: (key: string, value: string) => void;
@@ -37,6 +38,7 @@ export interface SettingStoreContext {
 const initialState: SettingStoreContext = {
   state: {
     allowedNumberOfTabs: null,
+    isDev: null,
   },
   actions: {
     setSettingsInStorage: noop,
@@ -49,10 +51,11 @@ export const Provider = ({ children }: PropsWithChildren) => {
   const [allowedNumberOfTabs, setAllowedNumberOfTabs] = useState<string | null>(
     null
   );
+  const [isDev, setIsDev] = useState<string | null>(null);
 
   const intitialSync = useCallback(async () => {
     const currentSettings = await chrome.storage.sync.get();
-
+    setIsDev(currentSettings?.isDev);
     setAllowedNumberOfTabs(currentSettings?.allowedNumberOfTabs);
   }, []);
 
@@ -91,6 +94,12 @@ export const Provider = ({ children }: PropsWithChildren) => {
           await chrome.storage.local.clear();
         }
       }
+      if (
+        Object.keys(changes).includes('isDev') &&
+        changes['isDev']?.newValue
+      ) {
+        setIsDev(changes['isDev']?.newValue);
+      }
     },
     []
   );
@@ -109,6 +118,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
       value={{
         state: {
           allowedNumberOfTabs,
+          isDev,
         },
         actions: {
           setSettingsInStorage,


### PR DESCRIPTION
## Description
This PR aims to improve the development experience by toggling features like stopping inspection on the DevTools tab switch, removing tab data on page reload etc. This is to help in debugging the error easily.

## Relevant Technical Choices
- Add an option on the settings page to allow debugging in if `isDev` is set in the sync storage.

## Testing Instructions

- In the terminal run `npm start`.
- Go to the settings page.
- In the settings page turn on the `Is in Development mode` to `On`
- Open any site, then go to DevTools to start inspection and then switch the tab in DevTools to console or elements the frame-overlay inspection should still work.
- Repeat the same steps by stopping the development mode and then running in Production mode. In production mode switching the tab in DevTools should stop the inspection of frames.

## Additional Information:


## Screenshot/Screencast


---