### PR TITLE
Fix: Frame overlay tooltip calculation issue

### DIFF
--- a/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
+++ b/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
@@ -186,8 +186,7 @@ const setTooltipPosition = (
     }
   }
 
-  tooltip.style.removeProperty('top');
-  tooltip.style.bottom = frameY + 'px';
+  tooltip.style.top = frameY + 'px';
 };
 
 export default setTooltipPosition;

--- a/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
+++ b/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
@@ -112,7 +112,8 @@ const setTooltipPosition = (
     } else {
       const leftOverWidth = tooltip.offsetWidth - (window.innerWidth - frameX);
 
-      tooltip.style.left = frameX + Number(window.scrollX) + 'px';
+      tooltip.style.left =
+        frameX < 0 ? '0px' : frameX + Number(window.scrollX) + 'px';
       tooltip.style.maxWidth = frameWidth - leftOverWidth + 'px';
       tooltip.style.top = `${
         frameY - tooltip.offsetHeight + Number(window.scrollY)
@@ -129,7 +130,7 @@ const setTooltipPosition = (
   }
 
   //check for space at bottom of frame
-  if (frameY + frame.offsetHeight + tooltip.offsetHeight < window.innerHeight) {
+  if (frameY + tooltip.offsetHeight < window.innerHeight) {
     /**
      * 2 conditions will be checked
      * 1) If space is available on left and space is not available on right, show on left.
@@ -168,7 +169,8 @@ const setTooltipPosition = (
       return;
     } else {
       const leftOverWidth = tooltip.offsetWidth - (window.innerWidth - frameX);
-      tooltip.style.left = frameX + Number(window.scrollX) + 'px';
+      tooltip.style.left =
+        frameX < 0 ? '0px' : frameX + Number(window.scrollX) + 'px';
       tooltip.style.maxWidth = frameWidth - leftOverWidth + 'px';
       tooltip.style.top = `${
         frameY + frame.offsetHeight + Number(window.scrollY)

--- a/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
+++ b/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
@@ -79,9 +79,7 @@ const setTooltipPosition = (
      */
     // eslint-disable-next-line prettier/prettier
     if (frameX + tooltip.offsetWidth > window.innerWidth && frameX - tooltip.offsetWidth > 0) {
-      tooltip.style.left = `${
-        frameX + tooltip.offsetWidth - window.innerWidth
-      }px`;
+      tooltip.style.left = `${frameX - tooltip.offsetWidth}px`;
       tooltip.style.top = `${
         frameY - tooltip.offsetHeight + Number(window.scrollY)
       }px`;
@@ -111,7 +109,6 @@ const setTooltipPosition = (
       return;
     } else {
       const leftOverWidth = tooltip.offsetWidth - (window.innerWidth - frameX);
-
       tooltip.style.left =
         frameX < 0 ? '0px' : frameX + Number(window.scrollX) + 'px';
       tooltip.style.maxWidth = frameWidth - leftOverWidth + 'px';
@@ -140,7 +137,7 @@ const setTooltipPosition = (
     // eslint-disable-next-line prettier/prettier
     if (frameX + frameWidth - window.innerWidth > 0 && frameX + tooltip.offsetWidth > window.innerWidth) {
       tooltip.style.left = `unset`;
-      tooltip.style.right = `${frameX + frameWidth - window.innerWidth}px`;
+      tooltip.style.right = `${frameX + frameWidth}px`;
       tooltip.style.top = `${
         frameY + frame.offsetHeight + Number(window.scrollY)
       }px`;

--- a/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
+++ b/packages/extension/src/contentScript/popovers/tooltip/setTooltipPosition.ts
@@ -71,10 +71,6 @@ const setTooltipPosition = (
 
   // If tooltop position is on top check space on top
   if (frameY > tooltip.offsetHeight && frameY - tooltip.offsetHeight >= 1) {
-    tooltip.style.top = `${
-      frameY - tooltip.offsetHeight + Number(window.scrollY)
-    }px`;
-
     /**
      * 2 conditions will be checked
      * 1) If space is available on left and space is not available on right, show on left.
@@ -82,10 +78,13 @@ const setTooltipPosition = (
      * 3) If above 2 conditions dont work show on left and reduce the width.
      */
     // eslint-disable-next-line prettier/prettier
-    if (frameX + frameWidth - window.innerWidth > 0 && frameX + tooltip.offsetWidth > window.innerWidth) {
-
-      tooltip.style.left = `unset`;
-      tooltip.style.right = `${frameX + frameWidth - window.innerWidth - 10}px`;
+    if (frameX + tooltip.offsetWidth > window.innerWidth && frameX - tooltip.offsetWidth > 0) {
+      tooltip.style.left = `${
+        frameX + tooltip.offsetWidth - window.innerWidth
+      }px`;
+      tooltip.style.top = `${
+        frameY - tooltip.offsetHeight + Number(window.scrollY)
+      }px`;
       tooltip.firstElementChild?.classList.remove(
         'ps-tooltip-top-right-notch',
         'ps-tooltip-top-left-notch',
@@ -95,10 +94,13 @@ const setTooltipPosition = (
       tooltip.firstElementChild?.classList.add('ps-tooltip-bottom-right-notch');
       return;
       // eslint-disable-next-line prettier/prettier
-    } else if (frameX + frameWidth - window.innerWidth < 0 && frameX + tooltip.offsetWidth < window.innerWidth) {
+    } else if (frameX + tooltip.offsetWidth < window.innerWidth && frameX - tooltip.offsetWidth < 0) {
 
       tooltip.style.left = frameX + Number(window.scrollX) + 'px';
       tooltip.style.right = `unset`;
+      tooltip.style.top = `${
+        frameY - tooltip.offsetHeight + Number(window.scrollY)
+      }px`;
       tooltip.firstElementChild?.classList.remove(
         'ps-tooltip-top-right-notch',
         'ps-tooltip-top-left-notch',
@@ -112,6 +114,9 @@ const setTooltipPosition = (
 
       tooltip.style.left = frameX + Number(window.scrollX) + 'px';
       tooltip.style.maxWidth = frameWidth - leftOverWidth + 'px';
+      tooltip.style.top = `${
+        frameY - tooltip.offsetHeight + Number(window.scrollY)
+      }px`;
       tooltip.firstElementChild?.classList.remove(
         'ps-tooltip-top-right-notch',
         'ps-tooltip-top-left-notch',
@@ -125,10 +130,6 @@ const setTooltipPosition = (
 
   //check for space at bottom of frame
   if (frameY + frame.offsetHeight + tooltip.offsetHeight < window.innerHeight) {
-    tooltip.style.top = `${
-      frameY + frame.offsetHeight + Number(window.scrollY)
-    }px`;
-
     /**
      * 2 conditions will be checked
      * 1) If space is available on left and space is not available on right, show on left.
@@ -138,7 +139,10 @@ const setTooltipPosition = (
     // eslint-disable-next-line prettier/prettier
     if (frameX + frameWidth - window.innerWidth > 0 && frameX + tooltip.offsetWidth > window.innerWidth) {
       tooltip.style.left = `unset`;
-      tooltip.style.right = `${frameX + frameWidth - window.innerWidth - 10}px`;
+      tooltip.style.right = `${frameX + frameWidth - window.innerWidth}px`;
+      tooltip.style.top = `${
+        frameY + frame.offsetHeight + Number(window.scrollY)
+      }px`;
       tooltip.firstElementChild?.classList.remove(
         'ps-tooltip-top-right-notch',
         'ps-tooltip-top-left-notch',
@@ -151,6 +155,9 @@ const setTooltipPosition = (
     } else if (frameX + frameWidth - window.innerWidth < 0 && frameX + tooltip.offsetWidth < window.innerWidth) {
       tooltip.style.left = frameX + Number(window.scrollX) + 'px';
       tooltip.style.right = `unset`;
+      tooltip.style.top = `${
+        frameY + frame.offsetHeight + Number(window.scrollY)
+      }px`;
       tooltip.firstElementChild?.classList.remove(
         'ps-tooltip-top-right-notch',
         'ps-tooltip-top-left-notch',
@@ -163,6 +170,9 @@ const setTooltipPosition = (
       const leftOverWidth = tooltip.offsetWidth - (window.innerWidth - frameX);
       tooltip.style.left = frameX + Number(window.scrollX) + 'px';
       tooltip.style.maxWidth = frameWidth - leftOverWidth + 'px';
+      tooltip.style.top = `${
+        frameY + frame.offsetHeight + Number(window.scrollY)
+      }px`;
       tooltip.firstElementChild?.classList.remove(
         'ps-tooltip-top-right-notch',
         'ps-tooltip-top-left-notch',


### PR DESCRIPTION
## Description
This PR aims to solve tooltip calculation problems and adds a capability to calculate the tooltip and overlay position on window resize.

## Relevant Technical Choices
- Calculate tooltip positions by checking left, right, top and bottom spacing.
- Add a callback to calculate the position on resize.
- Change parameters for scrollIntoView to have proper scrolling behaviour.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:


## Screenshot/Screencast


---