### PR TITLE
Fix: Update checkbox dimensions and resizer visiblity

### DIFF
--- a/packages/extension/src/view/devtools/components/cookies/cookieFilter/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieFilter/index.tsx
@@ -37,18 +37,20 @@ const FiltersList = () => {
   }
 
   return (
-    <ul>
-      {filters
-        .filter((filter) => Boolean(filter.filters?.size))
-        .map((filter, index) => (
-          <ListItem
-            key={index}
-            filter={filter}
-            selectedFilters={selectedFilters}
-            setSelectedFilters={setSelectedFilters}
-          />
-        ))}
-    </ul>
+    <div className="h-full overflow-auto p-3">
+      <ul>
+        {filters
+          .filter((filter) => Boolean(filter.filters?.size))
+          .map((filter, index) => (
+            <ListItem
+              key={index}
+              filter={filter}
+              selectedFilters={selectedFilters}
+              setSelectedFilters={setSelectedFilters}
+            />
+          ))}
+      </ul>
+    </div>
   );
 };
 

--- a/packages/extension/src/view/devtools/components/cookies/cookieFilter/subList.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieFilter/subList.tsx
@@ -57,7 +57,7 @@ const SubList: React.FC<SubListProps> = ({
               type="checkbox"
               name={filter.keys}
               className={classNames(
-                'accent-royal-blue dark:accent-orange-400 w-3 h-3 dark:bg-outer-space dark:min-h-0 dark:min-w-0 dark:h-[13px] dark:w-[13px]',
+                'accent-royal-blue dark:accent-orange-400 w-3 h-3 dark:bg-outer-space dark:min-h-[12px] dark:min-w-[12px]',
                 {
                   'dark:appearance-none dark:text-manatee dark:border dark:rounded-[3px]':
                     !(

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/index.tsx
@@ -77,19 +77,15 @@ const CookiesListing = () => {
             bottom: true,
             left: false,
           }}
-          className="h-full flex"
+          className="flex"
         >
           {cookiesAvailable && isFilterMenuOpen && (
             <Resizable
               minWidth="10%"
               maxWidth="50%"
               enable={{
-                top: false,
                 right: true,
-                bottom: false,
-                left: false,
               }}
-              className="overflow-y-scroll overflow-x-hidden p-3"
             >
               <FiltersList />
             </Resizable>

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/index.tsx
@@ -81,7 +81,7 @@ const CookiesListing = () => {
         >
           {cookiesAvailable && isFilterMenuOpen && (
             <Resizable
-              minWidth="10%"
+              minWidth="100px"
               maxWidth="50%"
               enable={{
                 right: true,


### PR DESCRIPTION
## Description
This PR fixes the squeezing of the checkbox in the dark theme when the parent component is resized alongside the unavailability of a resizer when filters overflow the container.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
