### PR TITLE
Handle opaque origin error when using `document.browsingTopics`

### DIFF
--- a/packages/extension/src/contentScript/index.ts
+++ b/packages/extension/src/contentScript/index.ts
@@ -516,20 +516,23 @@ class WebpageContentScript {
    * Set topics to be used in the Topics landing page.
    */
   async setTopics() {
-    if (
-      !document.prerendering &&
-      'browsingTopics' in document &&
-      document.featurePolicy &&
-      document.featurePolicy.allowsFeature('browsing-topics')
-    ) {
-      const activeTabUrl = window.location.origin;
-      const topicsObjArr = await document.browsingTopics();
-      const topicsIdArr = topicsObjArr.map(
-        (topic: { [key: string]: string | number }) => topic.topic
-      );
+    try {
+      if (
+        !document.prerendering &&
+        'browsingTopics' in document &&
+        document.featurePolicy &&
+        document.featurePolicy.allowsFeature('browsing-topics')
+      ) {
+        const activeTabUrl = window.location.origin;
+        const topicsObjArr = await document.browsingTopics();
+        const topicsIdArr = topicsObjArr.map(
+          (topic: { [key: string]: string | number }) => topic.topic
+        );
 
-      CookieStore.setTopics(activeTabUrl, topicsIdArr);
-    }
+        CookieStore.setTopics(activeTabUrl, topicsIdArr);
+      }
+      // eslint-disable-next-line no-empty
+    } catch (error) {}
   }
 }
 


### PR DESCRIPTION
## Description

Fix the following opaque origin error when using `document.browsingTopics`

> Uncaught (in promise) InvalidAccessError: document.browsingTopics() is not allowed in an opaque origin context.
>

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
