### PR TITLE
Fix: Trim out whitespace from the cookie key.

### DIFF
--- a/packages/extension/src/localStore/cookieStore.ts
+++ b/packages/extension/src/localStore/cookieStore.ts
@@ -43,7 +43,8 @@ const CookieStore = {
           continue;
         }
 
-        const cookieKey = getCookieKey(cookie.parsedCookie);
+        let cookieKey = getCookieKey(cookie.parsedCookie);
+        cookieKey = cookieKey?.trim();
 
         if (_updatedCookies?.[cookieKey]) {
           _updatedCookies[cookieKey] = {

--- a/packages/extension/src/serviceWorker/createCookieObject.ts
+++ b/packages/extension/src/serviceWorker/createCookieObject.ts
@@ -94,9 +94,9 @@ export async function createCookieObject(
   );
 
   return {
-    name,
+    name: (name as string)?.trim(),
     value,
-    domain,
+    domain: (domain as string)?.trim(),
     path: (path as string)?.trim(),
     secure,
     httponly,

--- a/packages/extension/src/serviceWorker/createCookieObject.ts
+++ b/packages/extension/src/serviceWorker/createCookieObject.ts
@@ -97,7 +97,7 @@ export async function createCookieObject(
     name,
     value,
     domain,
-    path,
+    path: (path as string)?.trim(),
     secure,
     httponly,
     samesite,


### PR DESCRIPTION
## Description
This PR aims to remove duplicate cookies from the cookie table which were induced because of whitespace in parsed cookies.

## Relevant Technical Choices
- Add `.trim` function after getting cookie key.
- As a fallback trim whitespace from name, domain and path while parsing cookie key in request and response.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---