### PR TITLE
Fix: MaxListenerExceedWarning when analyzing sitemap

### DIFF
--- a/packages/cli/src/procedures/analyzeTechnologiesUrlsInBatches.ts
+++ b/packages/cli/src/procedures/analyzeTechnologiesUrlsInBatches.ts
@@ -34,19 +34,18 @@ export const analyzeTechnologiesUrlsInBatches = async (
   const spinnies = new Spinnies();
 
   let report: TechnologyDetailList[] = [];
+  const wappalyzer = new Wapplalyzer();
 
   for (let i = 0; i < urls.length; i += batchSize) {
     const start = i;
     const end = Math.min(urls.length - 1, i + batchSize - 1);
+    await wappalyzer.init();
 
     spinnies.add(`spinner-${i}`, {
       text: `Analysing technologies in urls ${start + 1} - ${end + 1} `,
     });
 
     const urlsWindow = urls.slice(start, end + 1);
-    const wappalyzer = new Wapplalyzer();
-
-    await wappalyzer.init();
 
     const technologyAnalysis = await Promise.all(
       urlsWindow.map(async (url) => {
@@ -55,13 +54,12 @@ export const analyzeTechnologiesUrlsInBatches = async (
       })
     );
 
-    await wappalyzer.destroy();
-
     report = [...report, ...technologyAnalysis];
 
     spinnies.succeed(`spinner-${i}`, {
       text: `Done technology in urls ${start + 1} - ${end + 1} `,
     });
+    await wappalyzer.destroy();
   }
 
   return report;

--- a/packages/cli/src/procedures/analyzeTechnologiesUrlsInBatches.ts
+++ b/packages/cli/src/procedures/analyzeTechnologiesUrlsInBatches.ts
@@ -32,7 +32,6 @@ export const analyzeTechnologiesUrlsInBatches = async (
   batchSize = 3
 ): Promise<TechnologyDetailList[]> => {
   const spinnies = new Spinnies();
-  const wappalyzer = new Wapplalyzer();
 
   let report: TechnologyDetailList[] = [];
 
@@ -45,14 +44,18 @@ export const analyzeTechnologiesUrlsInBatches = async (
     });
 
     const urlsWindow = urls.slice(start, end + 1);
+    const wappalyzer = new Wapplalyzer();
+
+    await wappalyzer.init();
 
     const technologyAnalysis = await Promise.all(
       urlsWindow.map(async (url) => {
-        const site = await wappalyzer.open(url);
-        const results = await site.analyze();
-        return results.technologies;
+        const { technologies } = await (await wappalyzer.open(url)).analyze();
+        return technologies;
       })
     );
+
+    await wappalyzer.destroy();
 
     report = [...report, ...technologyAnalysis];
 


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

Fixes `MaxListenerExceedWarning` warning thrown when analyzing technology for sitemaps. 

`Wappalyzer` doesn't automatically cleanup after doing analysis. `destroy` function must be called before starting new batch of analysis.



Fixes #258 
