### PR TITLE
Enhancement: add interface use CSV file in CLI.

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,17 +18,18 @@
  */
 import { Command } from 'commander';
 import events from 'events';
-import { ensureFile, readFile, writeFile } from 'fs-extra';
+import { ensureFile, exists, readFile, writeFile } from 'fs-extra';
 // @ts-ignore Package does not support typescript.
 import Spinnies from 'spinnies';
 import { exec } from 'child_process';
+import path from 'path';
+import { parseUrl } from '@ps-analysis-tool/common';
 
 /**
  * Internal dependencies.
  */
 import Utility from './utils/utility';
 import { fetchDictionary } from './utils/fetchCookieDictionary';
-import { analyzeCookiesUrls } from './procedures/analyzeCookieUrls';
 import { analyzeCookiesUrlsInBatches } from './procedures/analyzeCookieUrlsInBatches';
 import { analyzeTechnologiesUrlsInBatches } from './procedures/analyzeTechnologiesUrlsInBatches';
 import { delay } from './utils';
@@ -53,9 +54,7 @@ program
 
 program.parse();
 
-const isHeadless = Boolean(program.opts().headless);
-
-export const initialize = async () => {
+const initialize = async () => {
   //check if devserver port in already in use
 
   const portInUse = await checkPortInUse(9000);
@@ -66,156 +65,140 @@ export const initialize = async () => {
     );
     process.exit(1);
   }
+};
 
-  const url = program.opts().url;
-  const sitemapURL = program.opts().sitemapUrl;
-  const csvPath = program.opts().csvPath;
-  const cookieDictionary = await fetchDictionary();
-  if (url) {
-    const prefix = Utility.generatePrefix(url ?? 'untitled');
-    const directory = `./out/${prefix}`;
-
-    const spinnies = new Spinnies();
-
-    spinnies.add('cookie-spinner', {
-      text: 'Analysing cookies on first page visit',
-    });
-
-    const [cookieData] = await analyzeCookiesUrls(
-      [url],
-      isHeadless,
-      DELAY_TIME,
-      cookieDictionary
-    );
-
-    spinnies.succeed('cookie-spinner', {
-      text: 'Done analyzing cookies.',
-    });
-
-    spinnies.add('technology-spinner', {
-      text: 'Analysing technologies',
-    });
-
-    const [technologyData] = await analyzeTechnologiesUrlsInBatches([url]);
-
-    spinnies.succeed('technology-spinner', {
-      text: 'Done analyzing technologies.',
-    });
-
-    const output = {
-      pageUrl: url,
-      cookieData: cookieData.cookieData,
-      technologyData,
-    };
-
-    await ensureFile(directory + '/out.json');
-    await writeFile(directory + '/out.json', JSON.stringify(output, null, 4));
-
-    exec('npm run cli-dashboard:dev');
-
-    await delay(2000);
+const validateArgs = async (
+  url: string,
+  sitemapUrl: string,
+  csvPath: string
+) => {
+  if (!url && !sitemapUrl && !csvPath) {
     console.log(
-      `Report is being served at the URL: http://localhost:9000?dir=${encodeURIComponent(
-        prefix
-      )}`
+      `Please provide one of the following 
+      a) URL of a site (-u or --url) 
+      b) URL of a sitemap (-s or --sitemap-url)
+      c) Path to a CSV file (-c or --csv-path)`
     );
-  } else if (sitemapURL) {
-    const spinnies = new Spinnies();
+    process.exit(1);
+  }
 
+  if ((url && sitemapUrl) || (sitemapUrl && csvPath) || (csvPath && url)) {
+    console.log(
+      `Please provide ONLY one of the following 
+      a) URL of a site (-u or --url) 
+      b) URL of a sitemap (-s or --sitemap-url)
+      c) Path to a CSV file (-c or --csv-path)`
+    );
+    process.exit(1);
+  }
+
+  if (csvPath) {
+    const csvFileExists = await exists(csvPath);
+    if (!csvFileExists) {
+      console.log(`No file at ${csvPath}`);
+      process.exit(1);
+    }
+  }
+
+  if (url || sitemapUrl) {
+    const _url = url || sitemapUrl;
+
+    const parsedUrl = parseUrl(_url);
+
+    if (parsedUrl === null) {
+      console.log(`Provided Url ${parsedUrl} is not valid`);
+      process.exit(1);
+    }
+  }
+};
+
+const getUrlListFromArgs = async (
+  url: string,
+  sitemapUrl: string,
+  csvPath: string,
+  // @ts-ignore Package does not support typescript.
+  spinnies
+): Promise<string[]> => {
+  let urls: string[] = [];
+
+  if (url) {
+    urls.push(url);
+  } else if (sitemapUrl) {
     spinnies.add('sitemap-spinner', {
       text: 'Parsing Sitemap',
     });
 
-    const urls: Array<string> = await Utility.getUrlsFromSitemap(sitemapURL);
+    try {
+      const _urls = await Utility.getUrlsFromSitemap(sitemapUrl);
+      urls = urls.concat(_urls);
+    } catch (error) {
+      console.log('Error parsing the sitemap file');
+      process.exit(1);
+    }
 
     spinnies.succeed('sitemap-spinner', {
       text: 'Done parsing Sitemap',
     });
-
-    const prefix = Utility.generatePrefix([...urls].shift() ?? 'untitled');
-    const directory = `./out/${prefix}`;
-    const userInput: any = await Utility.askUserInput(
-      `Provided sitemap has ${urls.length} pages. Please enter the number of pages you want to analyze (Default ${urls.length}):`,
-      { default: urls.length.toString() }
-    );
-    let numberOfUrls: number = isNaN(userInput)
-      ? urls.length
-      : parseInt(userInput);
-
-    numberOfUrls = numberOfUrls < urls.length ? numberOfUrls : urls.length;
-
-    const urlsToProcess = urls.splice(0, numberOfUrls);
-
-    const cookieAnalysisData = await analyzeCookiesUrlsInBatches(
-      urlsToProcess,
-      isHeadless,
-      DELAY_TIME,
-      cookieDictionary
-    );
-
-    spinnies.add('technology-spinner', {
-      text: 'Analysing technologies',
-    });
-
-    const technologyAnalysisData = await analyzeTechnologiesUrlsInBatches(
-      urlsToProcess,
-      3
-    );
-
-    spinnies.succeed('technology-spinner', {
-      text: 'Done analysing technologies',
-    });
-
-    const result = urlsToProcess.map((_url, ind) => {
-      return {
-        pageUrl: _url,
-        technologyData: technologyAnalysisData[ind],
-        cookieData: cookieAnalysisData[ind].cookieData,
-      };
-    });
-
-    await ensureFile(directory + '/out.json');
-    await writeFile(directory + '/out.json', JSON.stringify(result, null, 4));
-
-    exec('npm run cli-dashboard:dev');
-
-    await delay(2000);
-
-    console.log(
-      `Report is being served at the URL: http://localhost:9000?dir=${encodeURIComponent(
-        prefix
-      )}&type=sitemap`
-    );
   } else if (csvPath) {
-    const spinnies = new Spinnies();
-    spinnies.add('sitemap-spinner', {
-      text: 'Parsing Sitemap',
+    spinnies.add('csv-spinner', {
+      text: 'Parsing CSV File',
     });
 
-    let urls: string[] = [];
     try {
       const csvString = await readFile(csvPath, 'utf-8');
       const lines = csvString.split('\n');
 
-      urls = lines.reduce((acc, line) => {
+      const _urls = lines.reduce((acc, line) => {
         if (line.length === 0) {
           return acc;
         } else {
           return acc.concat(line.split(','));
         }
       }, [] as string[]);
+
+      urls = urls.concat(_urls);
     } catch (error) {
       console.log('Error reading the CSV file');
       process.exit(1);
     }
-    spinnies.succeed('sitemap-spinner', {
-      text: 'Done parsing Sitemap',
-    });
 
-    const prefix = Utility.generatePrefix([...urls].shift() ?? 'untitled');
-    const directory = `./out/${prefix}`;
-    const userInput: any = await Utility.askUserInput(
-      `Provided sitemap has ${urls.length} pages. Please enter the number of pages you want to analyze (Default ${urls.length}):`,
+    spinnies.succeed('csv-spinner', {
+      text: 'Done parsing CSV file',
+    });
+  }
+
+  return urls;
+};
+
+(async () => {
+  await initialize();
+
+  const url = program.opts().url;
+  const sitemapUrl = program.opts().sitemapUrl;
+  const csvPath = program.opts().csvPath;
+  const isHeadless = Boolean(program.opts().headless);
+
+  validateArgs(url, sitemapUrl, csvPath);
+
+  const prefix =
+    url || sitemapUrl
+      ? Utility.generatePrefix(url || sitemapUrl)
+      : path.parse(csvPath).base;
+
+  const outputDir = `./out/${prefix}`;
+  const spinnies = new Spinnies();
+
+  const urls = await getUrlListFromArgs(url, sitemapUrl, csvPath, spinnies);
+
+  let urlsToProcess: string[] = [];
+
+  if (sitemapUrl || csvPath) {
+    const userInput = await Utility.askUserInput(
+      `Provided ${sitemapUrl ? 'Sitemap' : 'CSV file'} has ${
+        urls.length
+      } pages. Please enter the number of pages you want to analyze (Default ${
+        urls.length
+      }):`,
       { default: urls.length.toString() }
     );
     let numberOfUrls: number = isNaN(userInput)
@@ -224,51 +207,64 @@ export const initialize = async () => {
 
     numberOfUrls = numberOfUrls < urls.length ? numberOfUrls : urls.length;
 
-    const urlsToProcess = urls.splice(0, numberOfUrls);
-
-    const cookieAnalysisData = await analyzeCookiesUrlsInBatches(
-      urlsToProcess,
-      isHeadless,
-      DELAY_TIME,
-      cookieDictionary
-    );
-
-    spinnies.add('technology-spinner', {
-      text: 'Analysing technologies',
-    });
-
-    const technologyAnalysisData = await analyzeTechnologiesUrlsInBatches(
-      urlsToProcess,
-      3
-    );
-
-    spinnies.succeed('technology-spinner', {
-      text: 'Done analysing technologies',
-    });
-
-    const result = urlsToProcess.map((_url, ind) => {
-      return {
-        pageUrl: _url,
-        technologyData: technologyAnalysisData[ind],
-        cookieData: cookieAnalysisData[ind].cookieData,
-      };
-    });
-
-    await ensureFile(directory + '/out.json');
-    await writeFile(directory + '/out.json', JSON.stringify(result, null, 4));
-
-    exec('npm run cli-dashboard:dev');
-
-    await delay(2000);
-
-    console.log(
-      `Report is being served at the URL: http://localhost:9000?dir=${encodeURIComponent(
-        prefix
-      )}&type=sitemap`
-    );
+    urlsToProcess = urlsToProcess.concat(urls.splice(0, numberOfUrls));
+  } else if (url) {
+    urlsToProcess.push(url);
   }
-};
 
-(async () => {
-  await initialize();
+  const cookieDictionary = await fetchDictionary();
+
+  spinnies.add('cookie-spinner', {
+    text: 'Analysing cookies on first page visit',
+  });
+
+  const cookieAnalysisData = await analyzeCookiesUrlsInBatches(
+    urlsToProcess,
+    isHeadless,
+    DELAY_TIME,
+    cookieDictionary,
+    3,
+    urlsToProcess.length !== 1 ? spinnies : undefined
+  );
+
+  spinnies.succeed('cookie-spinner', {
+    text: 'Done analyzing cookies.',
+  });
+  spinnies.add('technology-spinner', {
+    text: 'Analysing technologies',
+  });
+
+  const technologyAnalysisData = await analyzeTechnologiesUrlsInBatches(
+    urlsToProcess,
+    3,
+    urlsToProcess.length !== 1 ? spinnies : undefined
+  );
+
+  spinnies.succeed('technology-spinner', {
+    text: 'Done analyzing technologies.',
+  });
+
+  const result = urlsToProcess.map((_url, ind) => {
+    return {
+      pageUrl: _url,
+      technologyData: technologyAnalysisData[ind],
+      cookieData: cookieAnalysisData[ind].cookieData,
+    };
+  });
+
+  await ensureFile(outputDir + '/out.json');
+  await writeFile(
+    outputDir + '/out.json',
+    JSON.stringify(url ? result[0] : result, null, 4)
+  );
+
+  exec('npm run cli-dashboard:dev');
+
+  await delay(2000);
+
+  console.log(
+    `Report is being served at the URL: http://localhost:9000?dir=${encodeURIComponent(
+      prefix
+    )}${sitemapUrl || csvPath ? '&type=sitemap' : ''}`
+  );
 })();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -146,6 +146,7 @@ const getUrlListFromArgs = async (
 
     try {
       const csvString = await readFile(csvPath, 'utf-8');
+
       const lines = csvString.split('\n');
 
       const _urls = lines.reduce((acc, line) => {
@@ -155,6 +156,17 @@ const getUrlListFromArgs = async (
           return acc.concat(line.split(','));
         }
       }, [] as string[]);
+
+      if (_urls.length === 0) {
+        console.log('Provided CSV files has no urls');
+        process.exit(1);
+      }
+      _urls.forEach((_url) => {
+        if (!_url.includes('http')) {
+          console.log(`${_url} is not a valid URL`);
+          process.exit(1);
+        }
+      });
 
       urls = urls.concat(_urls);
     } catch (error) {

--- a/packages/cli/src/procedures/analyzeCookieUrlsInBatches.ts
+++ b/packages/cli/src/procedures/analyzeCookieUrlsInBatches.ts
@@ -15,12 +15,6 @@
  */
 
 /**
- * External dependencies.
- */
-// @ts-ignore Package does not support typescript.
-import Spinnies from 'spinnies';
-
-/**
  * Internal dependencies.
  */
 import { CookieDatabase } from '../types';
@@ -32,9 +26,18 @@ export const analyzeCookiesUrlsInBatches = async (
   isHeadless: boolean,
   delayTime: number,
   cookieDictionary: CookieDatabase,
-  batchSize = 3
+  batchSize = 3,
+  spinnies?: {
+    add: (
+      id: string,
+      { text, indent }: { text: string; indent: number }
+    ) => void;
+    succeed: (
+      id: string,
+      { text, indent }: { text: string; indent: number }
+    ) => void;
+  }
 ) => {
-  const spinnies = new Spinnies();
   let report: {
     pageUrl: string;
     cookieData: {
@@ -51,9 +54,11 @@ export const analyzeCookiesUrlsInBatches = async (
     const start = i;
     const end = Math.min(urls.length - 1, i + batchSize - 1);
 
-    spinnies.add(`cookies-spinner-${i}`, {
-      text: `Analysing cookies in urls ${start + 1} - ${end + 1} `,
-    });
+    spinnies &&
+      spinnies.add(`cookie-batch-spinner`, {
+        text: `Analyzing cookies in urls ${start + 1} - ${end + 1} `,
+        indent: 2,
+      });
 
     const urlsWindow = urls.slice(start, end + 1);
 
@@ -66,9 +71,11 @@ export const analyzeCookiesUrlsInBatches = async (
 
     report = [...report, ...cookieAnalysis];
 
-    spinnies.succeed(`cookies-spinner-${i}`, {
-      text: `Done analysing cookies in urls ${start + 1} - ${end + 1} `,
-    });
+    spinnies &&
+      spinnies.succeed(`cookie-batch-spinner`, {
+        text: `Done analyzing cookies in urls ${start + 1} - ${end + 1} `,
+        indent: 2,
+      });
   }
 
   return report;

--- a/packages/cli/src/procedures/analyzeTechnologiesUrlsInBatches.ts
+++ b/packages/cli/src/procedures/analyzeTechnologiesUrlsInBatches.ts
@@ -17,8 +17,7 @@
 /**
  * External dependencies.
  */
-// @ts-ignore Package does not support typescript.
-import Spinnies from 'spinnies';
+
 // @ts-ignore Package does not support typescript.
 import Wapplalyzer from 'wappalyzer';
 
@@ -29,9 +28,18 @@ import { TechnologyDetailList } from '../types';
 
 export const analyzeTechnologiesUrlsInBatches = async (
   urls: Array<string>,
-  batchSize = 3
+  batchSize = 3,
+  spinnies?: {
+    add: (
+      id: string,
+      { text, indent }: { text: string; indent: number }
+    ) => void;
+    succeed: (
+      id: string,
+      { text, indent }: { text: string; indent: number }
+    ) => void;
+  }
 ): Promise<TechnologyDetailList[]> => {
-  const spinnies = new Spinnies();
   const wappalyzer = new Wapplalyzer();
 
   let report: TechnologyDetailList[] = [];
@@ -40,9 +48,11 @@ export const analyzeTechnologiesUrlsInBatches = async (
     const start = i;
     const end = Math.min(urls.length - 1, i + batchSize - 1);
 
-    spinnies.add(`spinner-${i}`, {
-      text: `Analysing technologies in urls ${start + 1} - ${end + 1} `,
-    });
+    spinnies &&
+      spinnies.add(`tech-batch-spinner`, {
+        text: `Analyzing technologies in urls ${start + 1} - ${end + 1} `,
+        indent: 2,
+      });
 
     const urlsWindow = urls.slice(start, end + 1);
 
@@ -56,9 +66,11 @@ export const analyzeTechnologiesUrlsInBatches = async (
 
     report = [...report, ...technologyAnalysis];
 
-    spinnies.succeed(`spinner-${i}`, {
-      text: `Done technology in urls ${start + 1} - ${end + 1} `,
-    });
+    spinnies &&
+      spinnies.succeed(`tech-batch-spinner`, {
+        text: `Done analyzing technology in urls ${start + 1} - ${end + 1} `,
+        indent: 2,
+      });
   }
 
   return report;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -20,6 +20,7 @@ export { default as filterCookiesByFrame } from './utils/filterCookiesByFrame';
 export { default as prepareCookiesCount } from './utils/prepareCookiesCount';
 export { default as prepareCookieStatsComponents } from './utils/prepareCookieStatsComponents';
 export { default as getCookieKey } from './utils/getCookieKey';
+export { parseUrl } from './utils/parseUrl';
 export { default as fetchLocalData } from './utils/fetchLocalData';
 export { default as noop } from './utils/noop';
 export * from './cookies.types';


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
CLI accepts CSV file as an argument with. The list of URLs provided through the file will be then used for further analysis.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Follow instructions in the README.MD to build CLI.
- Use the new `-c` or `--csv-path` argument to pass a local csv file.
`npm run cli -- -c /path/to/urlset.csv`

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #220
