### PR TITLE
Change cookie Accepted column order #245

### DIFF
--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/cookieTableContainer/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/cookieTableContainer/index.tsx
@@ -81,6 +81,15 @@ const CookieTableContainer = ({
         cell: (info: InfoType) => info,
       },
       {
+        header: 'Cookie Accepted',
+        accessorKey: 'isCookieSet',
+        cell: (info: InfoType) => (
+          <p className="flex justify-center items-center">
+            <span className="font-serif">{info ? '✓' : '✗'}</span>
+          </p>
+        ),
+      },
+      {
         header: 'Expires / Max-Age',
         accessorKey: 'parsedCookie.expires',
         cell: (info: InfoType) => (info ? info : 'Session'),
@@ -124,19 +133,6 @@ const CookieTableContainer = ({
         cell: (info: InfoType) => (
           <p className="truncate w-full">
             {!info ? 'Third Party' : 'First Party'}
-          </p>
-        ),
-      },
-      {
-        header: 'Cookie Accepted',
-        accessorKey: 'isCookieSet',
-        cell: (info: InfoType) => (
-          <p className="flex justify-center items-center">
-            {info ? (
-              <span className="font-serif">✓</span>
-            ) : (
-              <span className="font-serif">✗</span>
-            )}
           </p>
         ),
       },


### PR DESCRIPTION
## Description

This pull request moves the "Cookie Accepted" column earlier on the cookie data analysis table and removes a duplication of the tag span.

## Relevant Technical Choices

This change was suggested by issue #245, the column "Cookie Accepted" is important information for the 3PCD debugging process.

## Testing Instructions

1. Open the Chrome DevTools
2. Select the Privacy Sandbox tab
3. On the sidebar go to the Cookie Data Analysis Panel
4. Check the position for the "Cookie Accepted" Column.

## Screenshot/Screencast

before:
![Screenshot 2023-11-15 at 08 45 18](https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/330792/ae803623-66b5-4e2f-aec6-2609b16e60ec)

after:
![Screenshot 2023-11-15 at 11 39 52](https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/330792/fa222f05-4fe8-4db3-bdaa-5ffcbf6d6828)


---


Fixes #245
