### PR TITLE
Fixing hover input state in dark mode

### DIFF
--- a/packages/design-system/src/components/searchInput/index.tsx
+++ b/packages/design-system/src/components/searchInput/index.tsx
@@ -64,7 +64,7 @@ const SearchInput = ({ value, onChange, clearInput }: SearchInputProps) => {
       className={`w-3/5 cursor-text bg-white dark:bg-charleston-green text-raisin-black dark:text-bright-gray border rounded flex justify-between items-center gap-1 mx-[3px] my-px px-[3px] pt-0.5 pb-px box-content text-xs ${
         isFocused
           ? 'border-sapphire dark:border-baby-blue-eyes'
-          : 'border-chinese-silver dark:border-davys-grey hover:bg-lotion'
+          : 'border-chinese-silver dark:border-davys-grey hover:bg-lotion dark:hover:bg-outer-space '
       }`}
     >
       <input


### PR DESCRIPTION
## Description

This pull request adds the hover state for the search field in the cookies panel. The hover state works fine in light mode but was missing in dark mode.

## Relevant Technical Choices

Included the hover selector for dark mode

## Testing Instructions
1. Set your environment in Dark mode
2. Open Chrome DevTools
3. Go to the Cookies' table panel
4. Pass the mouse over the search input field.
5. The input should change the color


## Additional Information:

-

## Screenshot/Screencast

before:
https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/330792/7a0fb38c-04de-4618-b29e-895a8b87ba98

after:
https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/330792/1c8e8e0f-2c5b-4b6b-b428-4ec099723e67



---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #294 
