### PR TITLE
Fix: Affected cookies csv output

### DIFF
--- a/packages/cli-dashboard/src/components/utils/reportDownloader.ts
+++ b/packages/cli-dashboard/src/components/utils/reportDownloader.ts
@@ -19,6 +19,7 @@
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
 import { type Cookie as ParsedCookie } from 'simple-cookie';
+import { sanitizeCsvRecord } from '@ps-analysis-tool/common';
 
 /**
  * Internal dependencies
@@ -143,9 +144,7 @@ export const reportDownloader = (
           cookieDataToBeProcessed[frameName].frameCookies[cookie];
         const sanitizedData = {
           name: unSanitisedCookie.name,
-          value: unSanitisedCookie.value.includes(',')
-            ? `"${unSanitisedCookie.value}"`
-            : unSanitisedCookie.value,
+          value: sanitizeCsvRecord(unSanitisedCookie.value),
           domain: unSanitisedCookie.domain,
           path: unSanitisedCookie.path,
           expires: unSanitisedCookie.expires,

--- a/packages/cli-dashboard/src/components/utils/reportDownloader.ts
+++ b/packages/cli-dashboard/src/components/utils/reportDownloader.ts
@@ -139,7 +139,7 @@ export const reportDownloader = (
           sameSite: unSanitisedCookie.sameSite,
           platform: unSanitisedCookie.platform,
           category: unSanitisedCookie.category,
-          isCookieSet: !unSanitisedCookie.isBlocked,
+          isBlocked: unSanitisedCookie.isBlocked,
           gdprPortal: unSanitisedCookie?.GDPR || 'NA',
         };
 
@@ -163,7 +163,7 @@ export const reportDownloader = (
       totalCookiesCount + report.cookieData[frameName].cookiesCount;
   });
 
-  Object.keys(cookiesSet).map((cookieName: string) => {
+  Object.keys(cookiesSet).forEach((cookieName: string) => {
     const cookie = cookiesSet[cookieName];
     cookieDataValues =
       cookieDataValues + Object.values(cookie).join(',') + '\r\n';
@@ -193,7 +193,7 @@ export const reportDownloader = (
     return cookieName;
   });
 
-  Object.keys(affectedCookiesSet).map((cookieName) => {
+  Object.keys(affectedCookiesSet).forEach((cookieName) => {
     const cookie = affectedCookiesSet[cookieName];
 
     affectedCookiesCount = affectedCookiesCount + 1;
@@ -214,6 +214,7 @@ export const reportDownloader = (
       default:
         break;
     }
+
     affectedCookiesDataValues =
       affectedCookiesDataValues + Object.values(cookie).join(',') + '\r\n';
     return cookieName;

--- a/packages/cli-dashboard/src/components/utils/reportDownloader.ts
+++ b/packages/cli-dashboard/src/components/utils/reportDownloader.ts
@@ -18,32 +18,21 @@
  */
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
-import { type Cookie as ParsedCookie } from 'simple-cookie';
 import { sanitizeCsvRecord } from '@ps-analysis-tool/common';
 
 /**
  * Internal dependencies
  */
-import type { CompleteJson, CookieFrameStorageType } from '../../types';
+import type {
+  CompleteJson,
+  CookieFrameStorageType,
+  SanitisedCookieType,
+  SingleTechnology,
+} from '../../types';
 
 interface NewReport extends CompleteJson {
   affectedCookies: CookieFrameStorageType;
   cookieAnalysisSummary: Record<string, number>;
-}
-
-type SanitisedCookieType = ParsedCookie & {
-  category: string;
-  platform: string;
-  gdprPortal: string;
-  sameSite: string;
-  scope: string;
-};
-interface SingleTechnology {
-  name: string;
-  description: string;
-  confidence: number;
-  website: string;
-  categories: string;
 }
 
 export const reportDownloader = (

--- a/packages/cli-dashboard/src/components/utils/reportDownloader.ts
+++ b/packages/cli-dashboard/src/components/utils/reportDownloader.ts
@@ -32,6 +32,9 @@ interface NewReport extends CompleteJson {
 
 type SanitisedCookieType = ParsedCookie & {
   category: string;
+  platform: string;
+  gdprPortal: string;
+  sameSite: string;
   scope: string;
 };
 interface SingleTechnology {
@@ -79,6 +82,21 @@ export const reportDownloader = (
     'Platform',
     'Category',
     'Cookie Affected',
+    'GDPRPortal',
+  ];
+
+  const affectedCookieDataHeader = [
+    'Name',
+    'Value',
+    'Domain',
+    'Path',
+    'Expires',
+    'Http Only',
+    'Scope',
+    'Secure',
+    'Same Site',
+    'Platform',
+    'Category',
     'GDPRPortal',
   ];
 
@@ -215,15 +233,29 @@ export const reportDownloader = (
         break;
     }
 
-    affectedCookiesDataValues =
-      affectedCookiesDataValues + Object.values(cookie).join(',') + '\r\n';
+    const dataLine = [
+      cookie.name,
+      cookie.value,
+      cookie.domain,
+      cookie.path,
+      cookie.expires,
+      cookie.httponly,
+      cookie.scope,
+      cookie.secure,
+      cookie.sameSite,
+      cookie.platform,
+      cookie.category,
+      cookie.gdprPortal,
+    ].join(',');
+
+    affectedCookiesDataValues = affectedCookiesDataValues + dataLine + '\r\n';
     return cookieName;
   });
 
   const cookieDataCSVContent = cookieDataHeader + '\n' + cookieDataValues;
 
   const affectedCookieDataCSVContent =
-    cookieDataHeader + '\n' + affectedCookiesDataValues;
+    affectedCookieDataHeader + '\n' + affectedCookiesDataValues;
 
   technologyDataToBeProcessed.forEach((technology) => {
     const singleTechnology: SingleTechnology = {

--- a/packages/cli-dashboard/src/types.ts
+++ b/packages/cli-dashboard/src/types.ts
@@ -17,6 +17,22 @@
  * External dependencies
  */
 import type { TechnologyData } from '@ps-analysis-tool/common';
+import { type Cookie as ParsedCookie } from 'simple-cookie';
+
+export type SanitisedCookieType = ParsedCookie & {
+  category: string;
+  platform: string;
+  gdprPortal: string;
+  sameSite: string;
+  scope: string;
+};
+export interface SingleTechnology {
+  name: string;
+  description: string;
+  confidence: number;
+  website: string;
+  categories: string;
+}
 
 export type CookieJsonDataType = {
   name: string;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -20,6 +20,7 @@ export { default as filterCookiesByFrame } from './utils/filterCookiesByFrame';
 export { default as prepareCookiesCount } from './utils/prepareCookiesCount';
 export { default as prepareCookieStatsComponents } from './utils/prepareCookieStatsComponents';
 export { default as getCookieKey } from './utils/getCookieKey';
+export { default as sanitizeCsvRecord } from './utils/sanitizeCsvRecord';
 export { parseUrl } from './utils/parseUrl';
 export { default as fetchLocalData } from './utils/fetchLocalData';
 export { default as noop } from './utils/noop';

--- a/packages/common/src/utils/sanitizeCsvRecord.ts
+++ b/packages/common/src/utils/sanitizeCsvRecord.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Converts a string value to a valid CSV record.
+ * @see https://datatracker.ietf.org/doc/html/rfc4180
+ * @param {string} record - a string value that need to be converted into a CSV record.
+ * @returns {URL | null} - The parsed URL object or null if the URL is invalid.
+ */
+const sanitizeCsvRecord = (record: string): string => {
+  let recordCopy = record;
+  recordCopy = recordCopy.replaceAll('"', '""');
+  return recordCopy.includes(',') ? '"' + recordCopy + '"' : recordCopy;
+};
+
+export default sanitizeCsvRecord;

--- a/packages/common/src/utils/tests/sanitizeCsvRecords.ts
+++ b/packages/common/src/utils/tests/sanitizeCsvRecords.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies.
+ */
+import sanitizeCsvRecord from '../sanitizeCsvRecord';
+
+describe('sanitizeCsvRecord : ', () => {
+  it('should not change valid strings', () => {
+    const validString = 'already a valid value 123';
+    expect(sanitizeCsvRecord(validString)).toBe(validString);
+  });
+
+  it('should add double quotes if a , is present', () => {
+    const invalidString = 'a,value';
+    const validString = '"a,value"';
+    expect(sanitizeCsvRecord(invalidString)).toBe(validString);
+  });
+
+  it('should add double quotes before any double quotes in the string', () => {
+    const invalidString = 'a value with "quotes"';
+    const validString = 'a value with ""quotes""';
+    expect(sanitizeCsvRecord(invalidString)).toBe(validString);
+  });
+
+  it('should handle comma and quotes simultaneously', () => {
+    const invalidString = 'a value with comma , with "quotes"';
+    const validString = '"a value with comma , with ""quotes"""';
+    expect(sanitizeCsvRecord(invalidString)).toBe(validString);
+  });
+});

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "target": "es6",
+    "lib": ["es2021"],
     "module": "commonjs",
     "outDir": "dist",
     "declarationDir": "dist-types",


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
It was observed (in issue #284) that in the exported reports in the CSV files the values of the column `Cookie Affected` was flipped. This PR fixes the wrong value serialization and removes the column `Cookie Affected` from the `affected-cookies.csv` file due to it being redundant since all cookies listed in that file are affected. 

## Related technical choices
- Added a utility function in `./packages/common/src/utils/sanitizeCsvRecord.ts` for converting a string into a valid CSV record according to [RFC](https://datatracker.ietf.org/doc/html/rfc4180). 


<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #284 
