### PR TITLE
Fix: Update filtering function

### DIFF
--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/index.tsx
@@ -443,10 +443,14 @@ const CookiesListing = ({ setFilteredCookies }: CookiesListingProps) => {
           },
         },
         comparator: (value: InfoType, filterValue: string) => {
-          const val = value as string;
-          const isJS = val === 'JS';
-
-          return isJS === (filterValue === 'JS');
+          switch (filterValue) {
+            case 'JS':
+              return value === 'javascript';
+            case 'HTTP':
+              return value === 'request' || value === 'response';
+            default:
+              return true;
+          }
         },
       },
     }),


### PR DESCRIPTION
## Description

This PR updates the filter function for "set via" filtering. This solves the bug when choosing both options filters out all cookies in the list.

<!-- What do we want to achieve with this PR? -->

