### PR TITLE
Fix: Add unknown frames in extension.

### DIFF
--- a/packages/common/src/utils/filterCookiesByFrame.ts
+++ b/packages/common/src/utils/filterCookiesByFrame.ts
@@ -32,16 +32,38 @@ const filterCookiesByFrame = (
   frameUrl: string | null
 ) => {
   const frameFilteredCookies: { [key: string]: CookieTableData } = {};
+  if (!cookies || !frameUrl || !tabFrames || !tabFrames[frameUrl]) {
+    return Object.values(frameFilteredCookies);
+  }
+  let tabFramesIDMap: number[] = [];
 
-  if (cookies && frameUrl && tabFrames && tabFrames[frameUrl]) {
+  Object.keys(tabFrames).forEach((url) => {
+    tabFramesIDMap = [
+      ...new Set<number>([...tabFrames[url].frameIds, ...tabFramesIDMap]),
+    ];
+  });
+
+  if (tabFrames[frameUrl].frameIds?.length === 0) {
     Object.entries(cookies).forEach(([key, cookie]) => {
-      tabFrames[frameUrl].frameIds?.forEach((frameId) => {
-        if (cookie.frameIdList?.includes(frameId)) {
-          frameFilteredCookies[key] = cookie;
+      let hasFrame = false;
+      cookie.frameIdList?.forEach((frameId) => {
+        if (tabFramesIDMap.includes(frameId as number)) {
+          hasFrame = true;
         }
       });
+      if (!hasFrame && cookie.frameIdList?.length > 0) {
+        frameFilteredCookies[key] = cookie;
+      }
     });
   }
+
+  Object.entries(cookies).forEach(([key, cookie]) => {
+    tabFrames[frameUrl].frameIds?.forEach((frameId) => {
+      if (cookie.frameIdList?.includes(frameId)) {
+        frameFilteredCookies[key] = cookie;
+      }
+    });
+  });
 
   return Object.values(frameFilteredCookies);
 };

--- a/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
+++ b/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
@@ -265,7 +265,12 @@ const useFrameOverlay = (
             ? filteredCookies.filter((cookie) => cookie.isFirstParty)
             : [];
           const blockedCookies = filteredCookies
-            ? filteredCookies.filter((cookie) => cookie.isBlocked)
+            ? filteredCookies.filter(
+                (cookie) =>
+                  cookie.isBlocked ||
+                  (cookie.blockedReasons?.length !== undefined &&
+                    cookie.blockedReasons?.length > 0)
+              )
             : [];
           const blockedReasons = filteredCookies
             ? filteredCookies

--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -155,6 +155,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
           return tabFrame;
         })
       );
+      modifiedTabFrames['Unknown Frame(s)'] = { frameIds: [] };
       setTabFrames(modifiedTabFrames);
     },
     []


### PR DESCRIPTION
## Description
Sometimes frames could be added and removed resulting in the cookies set by those frames to disappear from the application tab and show up in the network tab along with the PSAT tab. To fix this we have added an `Unknown frame(s)` which will show the collection of all such cookies present in the extension.



Partially addresses #339 
