### PR TITLE
Fix the method of fetching value for JS cookies.

### DIFF
--- a/packages/extension/src/utils/setDocumentCookies.ts
+++ b/packages/extension/src/utils/setDocumentCookies.ts
@@ -60,14 +60,12 @@ const processAndStoreDocumentCookies = async ({
 
       const parsedCookieData: CookieData[] = await Promise.all(
         documentCookies.map(async (singleCookie: string) => {
-          let [name] = singleCookie.split('=');
-          const [, ...rest] = singleCookie.split('=');
-          name = name.trim();
+          const [name, ...rest] = singleCookie.split('=');
           let analytics;
 
           const parsedCookie = await createCookieObject(
             {
-              name: name,
+              name: name.trim(),
               value: rest.join('='),
             },
             tabUrl,

--- a/packages/extension/src/utils/setDocumentCookies.ts
+++ b/packages/extension/src/utils/setDocumentCookies.ts
@@ -60,14 +60,15 @@ const processAndStoreDocumentCookies = async ({
 
       const parsedCookieData: CookieData[] = await Promise.all(
         documentCookies.map(async (singleCookie: string) => {
-          const cookieValue = singleCookie.split('=')[1]?.trim();
-          const cookieName = singleCookie.split('=')[0]?.trim();
+          let [name] = singleCookie.split('=');
+          const [, ...rest] = singleCookie.split('=');
+          name = name.trim();
           let analytics;
 
           const parsedCookie = await createCookieObject(
             {
-              name: cookieName,
-              value: cookieValue,
+              name: name,
+              value: rest.join('='),
             },
             tabUrl,
             cdpCookies?.cookies ?? []


### PR DESCRIPTION
## Description
The cookies which were set by javascript, when being collected did not join the `=` in the cookie value thus adding a discrepancy in the value being shown in the table.


## Screenshot/Screencast
![Screenshot 2023-12-27 at 2 16 21 PM](https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/59614577/f17c5961-7881-4801-8b72-5e7557181672)

<!-- Please provide Screenshot/Screencast, if applicable -->

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #301 
