### PR TITLE
Feature: Copy paste using keyboard

### DIFF
--- a/packages/design-system/src/components/table/components/tableBody/bodyCell.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/bodyCell.tsx
@@ -89,6 +89,19 @@ const BodyCell = ({
     <div
       tabIndex={0}
       onContextMenu={handleRightClick}
+      onDoubleClick={(e) => {
+        const target = e.target as HTMLElement;
+        const range = new Range();
+        range.selectNodeContents(target);
+
+        document.getSelection()?.removeAllRanges();
+        document.getSelection()?.addRange(range);
+      }}
+      onKeyDown={(e) => {
+        if (['Meta', 'Control', 'c'].includes(e.key)) {
+          e.stopPropagation();
+        }
+      }}
       style={{ maxWidth: width }}
       className={`box-border outline-0 px-1 py-px truncate h-5 text-xs ${
         isHighlighted

--- a/packages/design-system/src/components/table/components/tableBody/index.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/index.tsx
@@ -47,9 +47,9 @@ const TableBody = ({
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>, index: number) => {
-if (!['Meta', 'Control', 'c'].includes(event.key)) {
-  event.preventDefault();
-}
+      if (!['Meta', 'Control', 'c'].includes(event.key)) {
+        event.preventDefault();
+      }
       //@ts-ignore - the `children` property will be available on the `current` property.
       const currentRow = tableBodyRef.current?.children.namedItem(index);
       let newRowId: string | undefined;

--- a/packages/design-system/src/components/table/components/tableBody/index.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/index.tsx
@@ -47,13 +47,9 @@ const TableBody = ({
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>, index: number) => {
-      if (
-        event.key !== 'Meta' &&
-        event.key !== 'Control' &&
-        event.key !== 'c'
-      ) {
-        event.preventDefault();
-      }
+if (!['Meta', 'Control', 'c'].includes(event.key)) {
+  event.preventDefault();
+}
       //@ts-ignore - the `children` property will be available on the `current` property.
       const currentRow = tableBodyRef.current?.children.namedItem(index);
       let newRowId: string | undefined;

--- a/packages/design-system/src/components/table/components/tableBody/index.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/index.tsx
@@ -47,9 +47,8 @@ const TableBody = ({
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>, index: number) => {
-      if (!['Meta', 'Control', 'c'].includes(event.key)) {
-        event.preventDefault();
-      }
+      event.preventDefault();
+
       //@ts-ignore - the `children` property will be available on the `current` property.
       const currentRow = tableBodyRef.current?.children.namedItem(index);
       let newRowId: string | undefined;

--- a/packages/design-system/src/components/table/components/tableBody/index.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/index.tsx
@@ -47,7 +47,13 @@ const TableBody = ({
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>, index: number) => {
-      event.preventDefault();
+      if (
+        event.key !== 'Meta' &&
+        event.key !== 'Control' &&
+        event.key !== 'c'
+      ) {
+        event.preventDefault();
+      }
       //@ts-ignore - the `children` property will be available on the `current` property.
       const currentRow = tableBodyRef.current?.children.namedItem(index);
       let newRowId: string | undefined;


### PR DESCRIPTION
## Description
Enable `Ctrl+C` or `Command+C(MAC)` on the cookie listing table, so the user can copy the cookie name by keyboard's shortcut only not by right-clicking and copying.

## Relevant Technical Choices
- On double-click select the entire cell content and the copy command copies the selected text.
- Stop propagation of key down event from table cell if copy commands keys are pressed.
<!-- Please describe your changes. -->

## Testing Instructions
1. Clone the `feat/copy-paste-keyboard` branch and run `npm run build` in local.
2. Refresh or reupload this extension in your Chrome as per the instructions available in the [README](https://github.com/rtCamp/cookie-analysis-tool-internal#extension-from-source).
3. Open the dev tool and check if the user can able to copy the cookie name from the cookie's table.


<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/59614577/57fc7d04-7d52-4b79-8c4b-be3a94b5caaf



---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #261 
