### PR TITLE
Adding plural string for "Frame details" sections

### DIFF
--- a/packages/design-system/src/utils/prepareFrameStatsComponent.ts
+++ b/packages/design-system/src/utils/prepareFrameStatsComponent.ts
@@ -77,7 +77,10 @@ export default function prepareFrameStatsComponent(
   return {
     dataMapping: [
       {
-        title: 'Frame details',
+        title:
+          Object.keys(tabFrames || {}).length > 1
+            ? 'Frames details'
+            : 'Frame details',
         count: Object.keys(tabFrames || {}).length,
         data: [
           {

--- a/packages/design-system/src/utils/prepareFrameStatsComponent.ts
+++ b/packages/design-system/src/utils/prepareFrameStatsComponent.ts
@@ -77,10 +77,7 @@ export default function prepareFrameStatsComponent(
   return {
     dataMapping: [
       {
-        title:
-          Object.keys(tabFrames || {}).length > 1
-            ? 'Frames details'
-            : 'Frame details',
+        title: Object.keys(tabFrames || {}).length > 1 ? 'Frames' : 'Frame',
         count: Object.keys(tabFrames || {}).length,
         data: [
           {


### PR DESCRIPTION
## Description

On the Cookies landing page in the Frame details section, the count for frames doesn't have a plural version for the frames counting.  This pull request includes a plural version for counting frames when the amount is greater than one. 

## Relevant Technical Choices

This pull request adds a conditional to `prepareFrameStatsComponent` to display the plural string "Frames".

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Screenshot/Screencast

**before:**
![Screenshot from 2024-01-02 22-09-52](https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/330792/aa9ce366-b370-4a46-8a0f-678eaa419e56)

**after:**
![Screenshot 2024-01-03 at 09 45 21](https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/330792/a043d20c-496a-4c58-8750-55704a044e8c)



---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
