### PR TITLE
Enhancement: Allow blurring the sidebar items

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -33,4 +33,4 @@ export { default as parseRequestWillBeSentExtraInfo } from './utils/parseRequest
 export { default as getDomainFromUrl } from './utils/getDomainFromUrl';
 export { default as noop } from './utils/noop';
 export * from './cookies.types';
-export const UNKNOWN_FRAME_KEY = 'Unknown frame(s)';
+export const UNKNOWN_FRAME_KEY = 'Unknown Frame(s)';

--- a/packages/design-system/src/components/sidebar/sidebarChild.tsx
+++ b/packages/design-system/src/components/sidebar/sidebarChild.tsx
@@ -96,7 +96,7 @@ const SidebarChild = ({
               ? 'bg-royal-blue text-white dark:bg-medium-persian-blue dark:text-chinese-silver'
               : 'bg-gainsboro dark:bg-outer-space'
             : 'bg-white dark:bg-raisin-black'
-        } cursor-pointer`}
+        } cursor-pointer ${sidebarItem.isBlurred ? 'opacity-50' : ''}`}
         style={{ paddingLeft: recursiveStackIndex * 16 + 12 }}
       >
         {Object.keys(sidebarItem.children)?.length !== 0 && (

--- a/packages/design-system/src/components/sidebar/useSidebar/index.tsx
+++ b/packages/design-system/src/components/sidebar/useSidebar/index.tsx
@@ -38,6 +38,7 @@ export type SidebarItemValue = {
   panel?: React.ReactNode;
   icon?: React.ReactNode;
   selectedIcon?: React.ReactNode;
+  isBlurred?: boolean;
 };
 
 export type SidebarItems = {

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -125,15 +125,20 @@ const App: React.FC = () => {
 
     const _cookiesByFrameURL = Object.values(tabCookies).reduce(
       (acc, cookie) => {
+        let hasFrame = false;
+
         cookie.frameIdList?.forEach((frameId) => {
           const url = tabFramesIdsWithURL[frameId];
 
           if (url) {
             acc[url] = true;
-          } else {
-            acc[UNKNOWN_FRAME_KEY] = true;
+            hasFrame = true;
           }
         });
+
+        if (!hasFrame && cookie.frameIdList?.length > 0) {
+          acc[UNKNOWN_FRAME_KEY] = true;
+        }
 
         return acc;
       },

--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -25,10 +25,11 @@ import React, {
   useRef,
 } from 'react';
 import { noop } from '@ps-analysis-tool/design-system';
-import type {
-  TabCookies,
-  TabFrames,
-  CookieData,
+import {
+  type TabCookies,
+  type TabFrames,
+  type CookieData,
+  UNKNOWN_FRAME_KEY,
 } from '@ps-analysis-tool/common';
 
 /**
@@ -155,7 +156,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
           return tabFrame;
         })
       );
-      modifiedTabFrames['Unknown Frame(s)'] = { frameIds: [] };
+      modifiedTabFrames[UNKNOWN_FRAME_KEY] = { frameIds: [] };
       setTabFrames(modifiedTabFrames);
     },
     []


### PR DESCRIPTION
## Description
This PR adds the capability in the sidebar to blur the sidebar item with a boolean value which can be added to the data being passed in `useSidebar` hook.
<!-- What do we want to achieve with this PR? -->


<!-- Please describe your changes. -->


<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:
- The blur effect has been added to the PSAT's sidebar when a particular frame's cookies are fetched and the table is currently empty.

<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/a0caf048-4bcf-4b6e-9bf5-33ef6917934c



<!-- Please provide Screenshot/Screencast, if applicable -->

---

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->


