### PR TITLE
Fix: CLI dashboard not showing data

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -85,7 +85,10 @@ const initialize = async () => {
   }
 };
 
-const saveResults = async (outDir: string, result: CompleteJson[]) => {
+const saveResults = async (
+  outDir: string,
+  result: CompleteJson | CompleteJson[]
+) => {
   await ensureFile(outDir + '/out.json');
   await writeFile(outDir + '/out.json', JSON.stringify(result, null, 4));
 };
@@ -217,10 +220,13 @@ const startDashboardServer = async (dir: string) => {
     } as CompleteJson;
   });
 
-  await saveResults(path.join(outputDir, prefix), result);
+  await saveResults(
+    path.resolve(outputDir),
+    result.length === 1 ? result[0] : result
+  );
 
   if (outDir) {
-    await saveCSVReports(path.join(outputDir, prefix), result);
+    await saveCSVReports(path.resolve(outputDir), result);
     return;
   }
 


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

Fix for CLI dashboard not visualizing data. In the CLI routine, there was a minor bug that caused the `out.json` to be in the wrong directory.

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
