### PR TITLE
Updating CLI default and help message

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,12 +53,12 @@ program
   .option('-c, --csv-path <value>', 'Path to a CSV file with a set of URLs.')
   .option(
     '-p, --sitemap-path <value>',
-    'Path to a sitmap saved in the file system'
+    'Path to a sitemap saved in the file system'
   )
-  .option('-ul, --url-limit <value>', 'No of Urls to analyze')
+  .option('-ul, --url-limit <value>', 'No of URLs to analyze')
   .option(
     '-nh, --no-headless ',
-    'Flag for running puppeteer in non headless mode'
+    'Flag for running puppeteer in non-headless mode'
   )
   .option(
     '-np, --no-prompts',

--- a/packages/cli/src/utils/validateArgs.ts
+++ b/packages/cli/src/utils/validateArgs.ts
@@ -48,11 +48,11 @@ const validateArgs = async (
 
   if (numArgs !== 1) {
     console.log(
-      `Please provide one and only one of the following 
-        a) URL of a site (-u or --url) 
+      `Please provide one and only one of the following
+        a) URL of a site (-u or --url)
         b) URL of a sitemap (-s or --sitemap-url)
         c) Path to a CSV file (-c or --csv-path)
-        d) Path to a XML file (-p or --sitemap-path)`
+        d) Path to an XML file (-p or --sitemap-path)`
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Description

There are a few typos on the Default and Help message from the CLI. This pull request is related to issue #450

## Testing Instructions

- run the CLI without any option ´npm run cli´
- run the help command from CLI ´npm run cli -- --help´

---

## Checklist

<!-- Check these after PR creation -->

- [ ] I have thoroughly tested this code to the best of my abilities.
- [ ] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
