### PR TITLE
Fix miscellaneous allow list QA issues

### DIFF
--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -307,7 +307,6 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   PROMISE_QUEUE.clear();
   await PROMISE_QUEUE.add(async () => {
     await chrome.storage.local.clear();
-    chrome.contentSettings.cookies.clear({});
 
     if (details.reason === 'install') {
       await chrome.storage.sync.clear();

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -537,8 +537,13 @@ chrome.storage.local.onChanged.addListener(
  * Fires when the browser window is opened.
  * @see https://developer.chrome.com/docs/extensions/reference/api/windows#event-onCreated
  */
-chrome.windows.onCreated.addListener(() => {
-  chrome.contentSettings.cookies.clear({});
+chrome.windows.onCreated.addListener(async () => {
+  const totalWindows = await chrome.windows.getAll();
+
+  // We do not want to clear content settings if a user has create one more window.
+  if (totalWindows.length < 2) {
+    chrome.contentSettings.cookies.clear({});
+  }
 });
 
 chrome.storage.sync.onChanged.addListener(

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
@@ -96,7 +96,7 @@ const RowContextMenu = forwardRef<
     (async () => {
       await setParentDomain(_domain || '', setParentDomainCallback);
     })();
-  }, [_domain, setParentDomainCallback]);
+  }, [_domain, setParentDomainCallback, contextMenuOpen]);
 
   useImperativeHandle(ref, () => ({
     onRowContextMenu(e, row) {

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
@@ -215,7 +215,7 @@ const RowContextMenu = forwardRef<
                   <span id="allow-list-option">
                     {isDomainInAllowList
                       ? 'Remove Domain from Allow List'
-                      : 'Add Domain to Allow List'}
+                      : 'Allow Domain During Session'}
                   </span>
                 </button>
               )}

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
@@ -35,6 +35,7 @@ import setParentDomain from './useAllowedList/setParentDomain';
 import onAllowListClick from './useAllowedList/onAllowListClick';
 import reloadCurrentTab from '../../../../../utils/reloadCurrentTab';
 import getDotPrefixedDomain from './useAllowedList/getDotPrefixedDomain';
+import isCookieDomainInAllowList from './useAllowedList/isCookieDomainInAllowList';
 
 interface RowContextMenuProps {
   domainsInAllowList: Set<string>;
@@ -104,18 +105,10 @@ const RowContextMenu = forwardRef<
     },
   }));
 
-  const isDomainInAllowList = useMemo(() => {
-    let _isDomainInAllowList = domainsInAllowList.has(_domain);
-
-    if (!_isDomainInAllowList) {
-      _isDomainInAllowList = [...domainsInAllowList].some((storedDomain) => {
-        // For example xyz.bbc.com and .bbc.com
-        return _domain.endsWith(storedDomain) && _domain !== storedDomain;
-      });
-    }
-
-    return _isDomainInAllowList;
-  }, [_domain, domainsInAllowList]);
+  const isDomainInAllowList = isCookieDomainInAllowList(
+    _domain,
+    domainsInAllowList
+  );
 
   const handleCopy = useCallback(() => {
     try {

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
@@ -70,15 +70,14 @@ const RowContextMenu = forwardRef<
   const [parentDomain, setParentDomainCallback] = useState<string>('');
   const [selectedCookie, setSelectedCookie] = useState<CookieTableData>();
 
-  const [domain, name] = useMemo(
+  const [domain, dotPrefixedDomain, name] = useMemo(
     () => [
       selectedCookie?.parsedCookie?.domain || '',
+      getDotPrefixedDomain(selectedCookie?.parsedCookie?.domain || ''),
       selectedCookie?.parsedCookie?.name,
     ],
     [selectedCookie]
   );
-
-  const _domain = useMemo(() => getDotPrefixedDomain(domain), [domain]);
 
   const handleRightClick = useCallback(
     (e: React.MouseEvent<HTMLElement>, { originalData }: TableRow) => {
@@ -95,9 +94,9 @@ const RowContextMenu = forwardRef<
 
   useEffect(() => {
     (async () => {
-      await setParentDomain(_domain || '', setParentDomainCallback);
+      await setParentDomain(dotPrefixedDomain || '', setParentDomainCallback);
     })();
-  }, [_domain, setParentDomainCallback, contextMenuOpen]);
+  }, [dotPrefixedDomain, setParentDomainCallback, contextMenuOpen]);
 
   useImperativeHandle(ref, () => ({
     onRowContextMenu(e, row) {
@@ -106,7 +105,7 @@ const RowContextMenu = forwardRef<
   }));
 
   const isDomainInAllowList = isCookieDomainInAllowList(
-    _domain,
+    dotPrefixedDomain,
     domainsInAllowList
   );
 
@@ -132,10 +131,10 @@ const RowContextMenu = forwardRef<
 
       removeSelectedRow();
       await onAllowListClick(
-        _domain,
+        dotPrefixedDomain,
         tabUrl || '',
         isIncognito,
-        domainsInAllowList.has(_domain),
+        domainsInAllowList.has(dotPrefixedDomain),
         domainsInAllowList,
         setDomainsInAllowListCallback
       );
@@ -143,7 +142,7 @@ const RowContextMenu = forwardRef<
       await reloadCurrentTab();
     },
     [
-      _domain,
+      dotPrefixedDomain,
       domainsInAllowList,
       isIncognito,
       removeSelectedRow,

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useAllowedList/isCookieDomainInAllowList.ts
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useAllowedList/isCookieDomainInAllowList.ts
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * External dependencies.
- */
-import type { CookieTableData } from '@ps-analysis-tool/common';
 
 /**
  * Internal dependencies.
@@ -24,10 +20,10 @@ import type { CookieTableData } from '@ps-analysis-tool/common';
 import getDotPrefixedDomain from './getDotPrefixedDomain';
 
 const isCookieDomainInAllowList = (
-  cookie: CookieTableData,
+  _domain: string,
   domainsInAllowList: Set<string>
 ) => {
-  const domain = getDotPrefixedDomain(cookie.parsedCookie?.domain || '');
+  const domain = getDotPrefixedDomain(_domain);
 
   let isDomainInAllowList = domainsInAllowList.has(domain);
 

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useAllowedList/isCookieDomainInAllowList.ts
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useAllowedList/isCookieDomainInAllowList.ts
@@ -20,17 +20,20 @@
 import getDotPrefixedDomain from './getDotPrefixedDomain';
 
 const isCookieDomainInAllowList = (
-  _domain: string,
+  domain: string,
   domainsInAllowList: Set<string>
 ) => {
-  const domain = getDotPrefixedDomain(_domain);
+  const dotPrefixedDomain = getDotPrefixedDomain(domain);
 
-  let isDomainInAllowList = domainsInAllowList.has(domain);
+  let isDomainInAllowList = domainsInAllowList.has(dotPrefixedDomain);
 
   if (!isDomainInAllowList) {
     isDomainInAllowList = [...domainsInAllowList].some((storedDomain) => {
       // For example xyz.bbc.com and .bbc.com
-      return domain.endsWith(storedDomain) && domain !== storedDomain;
+      return (
+        dotPrefixedDomain.endsWith(storedDomain) &&
+        dotPrefixedDomain !== storedDomain
+      );
     });
   }
 

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useAllowedList/setParentDomain.ts
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useAllowedList/setParentDomain.ts
@@ -27,6 +27,7 @@ const setParentDomain = async (
   let parentDomainValue = '';
 
   if (!allowListSessionStorage || allowListSessionStorage?.length === 0) {
+    setter(() => '');
     return;
   }
 

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/useHighlighting.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/useHighlighting.tsx
@@ -23,6 +23,7 @@ import { getCookieKey, type TabCookies } from '@ps-analysis-tool/common';
  * Internal dependencies.
  */
 import isCookieDomainInAllowList from '../useAllowedList/isCookieDomainInAllowList';
+import getDotPrefixedDomain from '../useAllowedList/getDotPrefixedDomain';
 
 const useHighlighting = (
   cookies: TabCookies,
@@ -34,10 +35,12 @@ const useHighlighting = (
       Object.values(cookiesToProcess).reduce((acc, cookie) => {
         const key = getCookieKey(cookie.parsedCookie) as string;
 
+        const domain = getDotPrefixedDomain(cookie.parsedCookie?.domain || '');
+
         acc[key] = {
           ...cookie,
           isDomainInAllowList: isCookieDomainInAllowList(
-            cookie,
+            domain,
             domainsInAllowList
           ),
         };

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/useHighlighting.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/useHighlighting.tsx
@@ -37,7 +37,7 @@ const useHighlighting = (
         acc[key] = {
           ...cookie,
           isDomainInAllowList: isCookieDomainInAllowList(
-            cookie.parsedCookie.domain || '',
+            cookie.parsedCookie?.domain || '',
             domainsInAllowList
           ),
         };

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/useHighlighting.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/useHighlighting.tsx
@@ -23,7 +23,6 @@ import { getCookieKey, type TabCookies } from '@ps-analysis-tool/common';
  * Internal dependencies.
  */
 import isCookieDomainInAllowList from '../useAllowedList/isCookieDomainInAllowList';
-import getDotPrefixedDomain from '../useAllowedList/getDotPrefixedDomain';
 
 const useHighlighting = (
   cookies: TabCookies,
@@ -35,12 +34,10 @@ const useHighlighting = (
       Object.values(cookiesToProcess).reduce((acc, cookie) => {
         const key = getCookieKey(cookie.parsedCookie) as string;
 
-        const domain = getDotPrefixedDomain(cookie.parsedCookie?.domain || '');
-
         acc[key] = {
           ...cookie,
           isDomainInAllowList: isCookieDomainInAllowList(
-            domain,
+            cookie.parsedCookie.domain || '',
             domainsInAllowList
           ),
         };

--- a/packages/extension/src/view/devtools/components/cookies/tests/rowContextMenu.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/tests/rowContextMenu.tsx
@@ -77,7 +77,9 @@ describe('RowContextMenu', () => {
       );
     });
 
-    const rowContextMenu = await screen.findByText('Add Domain to Allow List');
+    const rowContextMenu = await screen.findByText(
+      'Allow Domain During Session'
+    );
 
     expect(rowContextMenu).toBeVisible();
   });


### PR DESCRIPTION
## Description

- In the allow list feature, an added allowed domain is stored in `chrome.contentSettings` for the current browser session. However, this created an issue when the user creates multiple windows while using PSAT, as the content setting gets cleared each time a new chrome window is opened.
- Fix parent domain issue reported by QA
- Update context menu text from "Add Domain to Allow List" to "Allow Domain During Session"

## Relevant Technical Choices

- Count number of windows before clearing content  to ensure that we do not clear it on new window open.
- Do not clear content settings on install


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] ~This code is covered by unit tests to verify that it works as intended~. (NA)
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Related #376 
