### PR TITLE
Fix: Refresh page on context invalidate

### DIFF
--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -47,6 +47,7 @@ import './app.css';
 import { Cookies } from './components';
 import useFrameOverlay from './hooks/useFrameOverlay';
 import { getCurrentTabId } from '../../utils/getCurrentTabId';
+import { useSettingsStore } from './stateProviders/syncSettingsStore';
 
 const App: React.FC = () => {
   const [sidebarWidth, setSidebarWidth] = useState(200);
@@ -75,6 +76,10 @@ const App: React.FC = () => {
     setIsInspecting: actions.setIsInspecting,
     canStartInspecting: state.canStartInspecting,
     tabUrl: state.tabUrl,
+  }));
+
+  const { allowedNumberOfTabs } = useSettingsStore(({ state }) => ({
+    allowedNumberOfTabs: state.allowedNumberOfTabs,
   }));
 
   const listenToMouseChange = useCallback(() => {
@@ -273,7 +278,11 @@ const App: React.FC = () => {
     (async () => {
       const localStorageFlag = localStorage.getItem('contextInvalidated');
 
-      if (localStorageFlag && localStorageFlag === 'true') {
+      if (
+        localStorageFlag &&
+        localStorageFlag === 'true' &&
+        allowedNumberOfTabs === 'unlimited'
+      ) {
         const tabId = await getCurrentTabId();
 
         if (tabId) {
@@ -282,7 +291,7 @@ const App: React.FC = () => {
         }
       }
     })();
-  }, []);
+  }, [allowedNumberOfTabs]);
 
   useFrameOverlay(filteredCookies, handleUpdate);
 

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -46,6 +46,7 @@ import { useCookieStore } from './stateProviders/syncCookieStore';
 import './app.css';
 import { Cookies } from './components';
 import useFrameOverlay from './hooks/useFrameOverlay';
+import { getCurrentTabId } from '../../utils/getCurrentTabId';
 
 const App: React.FC = () => {
   const [sidebarWidth, setSidebarWidth] = useState(200);
@@ -80,6 +81,7 @@ const App: React.FC = () => {
     if (contextInvalidatedRef.current) {
       if (!chrome.runtime?.id) {
         setContextInvalidated(true);
+        localStorage.setItem('contextInvalidated', 'true');
       }
     }
   }, [setContextInvalidated]);
@@ -266,6 +268,19 @@ const App: React.FC = () => {
     },
     [updateSelectedItemKey]
   );
+
+  useEffect(() => {
+    (async () => {
+      const localStorageFlag = localStorage.getItem('contextInvalidated');
+      if (localStorageFlag && localStorageFlag === 'true') {
+        const tabId = await getCurrentTabId();
+        if (tabId) {
+          chrome.tabs.reload(Number(tabId));
+          localStorage.removeItem('contextInvalidated');
+        }
+      }
+    })();
+  }, []);
 
   useFrameOverlay(filteredCookies, handleUpdate);
 

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -272,8 +272,10 @@ const App: React.FC = () => {
   useEffect(() => {
     (async () => {
       const localStorageFlag = localStorage.getItem('contextInvalidated');
+
       if (localStorageFlag && localStorageFlag === 'true') {
         const tabId = await getCurrentTabId();
+
         if (tabId) {
           chrome.tabs.reload(Number(tabId));
           localStorage.removeItem('contextInvalidated');


### PR DESCRIPTION
## Description
In a multi-tab environment, it was noticed that when the extension is updated or refreshed the count resets to zero and will only increase once any network request with a cookie is processed. On a static site, the count stays at 0 because it doesn't send or receive so the count will stay 0 indefinitely.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Clone this branch. In the terminal `npm start`.
- Go to any page and open PSAT to enable `multi-tab` debugging.
- Now on the extensions page refresh the extension.
- On the page with PSAT. Click on the refresh panel once it appears you should see the page being refreshed.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/59614577/c642b61f-8d0b-4186-b2b9-321482f76a44


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #462 
