### PR TITLE
Style Fix: Rearrange and rename components in CLI dashboard.

### DIFF
--- a/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/index.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/index.tsx
@@ -59,6 +59,8 @@ const CookiesLandingContainer = ({
         associatedCookiesCount={Object.values(tabFrames).length}
         showMessageBoxBody={false}
         showBlockedCookiesSection
+        cookieClassificationTitle="Cookie Categories"
+        showDivider={false}
       >
         <div className="flex flex-col">
           <h3 className="text-xs font-bold text-darkest-gray dark:text-bright-gray uppercase">

--- a/packages/design-system/src/components/cookiesLanding/cookieLandingHeaderContainer.tsx
+++ b/packages/design-system/src/components/cookiesLanding/cookieLandingHeaderContainer.tsx
@@ -24,6 +24,7 @@ import React from 'react';
 import LandingHeader, { type DataMapping } from './landingHeader';
 
 export interface CookiesLandingContainerProps {
+  showDivider: boolean;
   dataMapping?: DataMapping[];
   showLandingHeader?: boolean;
   testId?: string | null;
@@ -32,6 +33,7 @@ export interface CookiesLandingContainerProps {
 }
 
 const CookiesLandingContainer = ({
+  showDivider,
   dataMapping = [],
   showLandingHeader = true,
   testId = 'cookie-landing-insights',
@@ -41,7 +43,9 @@ const CookiesLandingContainer = ({
   return (
     <div className="w-full flex flex-col min-w-[40rem]">
       <div className="w-full min-w-[40rem]" data-testid={testId}>
-        {showLandingHeader && <LandingHeader dataMapping={dataMapping} />}
+        {showLandingHeader && (
+          <LandingHeader showDivider={showDivider} dataMapping={dataMapping} />
+        )}
         {description && (
           <div className="text-center px-4 flex items-center justify-center -mt-2 mb-10">
             <p className="lg:max-w-[450px] text-gray dark:text-bright-gray">

--- a/packages/design-system/src/components/cookiesLanding/index.tsx
+++ b/packages/design-system/src/components/cookiesLanding/index.tsx
@@ -47,6 +47,8 @@ interface CookiesLandingProps {
   };
   showFramesSection?: boolean;
   description?: React.ReactNode;
+  cookieClassificationTitle?: string;
+  showDivider?: boolean;
 }
 
 const CookiesLanding = ({
@@ -62,6 +64,8 @@ const CookiesLanding = ({
   showHorizontalMatrix = false,
   description = '',
   additionalComponents = {},
+  cookieClassificationTitle,
+  showDivider = true,
 }: CookiesLandingProps) => {
   const cookieStats = prepareCookiesCount(tabCookies);
   const cookiesStatsComponents = prepareCookieStatsComponents(cookieStats);
@@ -98,6 +102,7 @@ const CookiesLanding = ({
       data-testid="cookies-landing"
     >
       <CookiesLandingContainer
+        showDivider={showDivider}
         dataMapping={cookieClassificationDataMapping}
         testId="cookies-insights"
       >
@@ -112,6 +117,7 @@ const CookiesLanding = ({
               />
             ))}
         <CookiesMatrix
+          title={cookieClassificationTitle}
           tabCookies={tabCookies}
           componentData={cookiesStatsComponents.legend}
           tabFrames={tabFrames}
@@ -119,10 +125,10 @@ const CookiesLanding = ({
           showHorizontalMatrix={showHorizontalMatrix}
           associatedCookiesCount={associatedCookiesCount}
         />
-        {children && <div className="mt-8">{children}</div>}
       </CookiesLandingContainer>
       {showBlockedCookiesSection && (
         <CookiesLandingContainer
+          showDivider={showDivider}
           description={description}
           dataMapping={blockedCookieDataMapping}
           testId="blocked-cookies-insights"
@@ -140,16 +146,18 @@ const CookiesLanding = ({
               />
             </>
           )}
+          {children && <div className="mt-8">{children}</div>}
         </CookiesLandingContainer>
       )}
       {/* TODO: This is not scalable. Refactor code so that components can be added from the the extension or dashboard package. */}
-      {Object.keys(additionalComponents).length &&
+      {Boolean(Object.keys(additionalComponents).length) &&
         Object.keys(additionalComponents).map((key: string) => {
           const Component = additionalComponents[key];
           return <Component key={key} />;
         })}
       {showFramesSection && (
         <CookiesLandingContainer
+          showDivider={showDivider}
           dataMapping={frameStateCreator.dataMapping}
           testId="frames-insights"
         >

--- a/packages/design-system/src/components/cookiesLanding/landingHeader/index.tsx
+++ b/packages/design-system/src/components/cookiesLanding/landingHeader/index.tsx
@@ -17,6 +17,7 @@
  * External dependencies.
  */
 import React from 'react';
+import classnames from 'classnames';
 import { CirclePieChart } from '@ps-analysis-tool/design-system';
 
 export interface DataMapping {
@@ -29,13 +30,21 @@ export interface DataMapping {
 }
 
 interface LandingHeaderProps {
+  showDivider: boolean;
   dataMapping?: DataMapping[];
 }
 
-const LandingHeader = ({ dataMapping = [] }: LandingHeaderProps) => {
+const LandingHeader = ({
+  dataMapping = [],
+  showDivider,
+}: LandingHeaderProps) => {
   return (
     <div
-      className="flex justify-center border-t border-hex-gray pt-5 pb-5 dark:border-quartz"
+      className={classnames({
+        'flex justify-center border-hex-gray pt-5 pb-5 dark:border-quartz':
+          true,
+        'border-t': showDivider,
+      })}
       data-testid="cookies-landing-header"
     >
       <div className="lg:max-w-[729px] flex gap-9 px-4">


### PR DESCRIPTION
## Description

- Rename "Cookie Classification" to "Cookie Categories".
- Move the Comparative Insights information under the Blocked Cookies section.

## Screenshot/Screencast
![Screenshot 2024-02-01 at 1 03 11 PM](https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/53055971/e45aacbb-354d-48ad-ba70-e133dd68f602)


## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).


