### PR TITLE
HotFix: Persist data using global variable

### DIFF
--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -291,6 +291,10 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   syncCookieStore = new SynchnorousCookieStore();
   syncCookieStore?.clear();
 
+  setInterval(() => {
+    chrome.storage.local.get();
+  }, 28000);
+
   // @todo Send tab data of the active tab only, also if sending only the difference would make it any faster.
   setInterval(() => {
     if (Object.keys(syncCookieStore?.tabsData ?? {}).length === 0) {

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -291,6 +291,8 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   syncCookieStore = new SynchnorousCookieStore();
   syncCookieStore?.clear();
 
+  // @see https://developer.chrome.com/blog/longer-esw-lifetimes#whats_changed
+  // Doing this to keep the service worker alive so that we dont loose unnecessary data and introduce any unnecessary bug.
   setInterval(() => {
     chrome.storage.local.get();
   }, 28000);


### PR DESCRIPTION
## Description
This PR aims to solve the 0 cookie issue by calling the chrome.storage.local.get after every 28 seconds, so that the service worker doesn't idle and sleep.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:
Choices were made after reading the following doc.
https://developer.chrome.com/blog/longer-esw-lifetimes#whats_changed

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

Partially addresses #471 
