### PR TITLE
Fix: Library detection section occasional infinite loading

### DIFF
--- a/packages/library-detection/src/core/stateProvider/index.tsx
+++ b/packages/library-detection/src/core/stateProvider/index.tsx
@@ -93,12 +93,8 @@ export const LibraryDetectionProvider = ({ children }: PropsWithChildren) => {
 
   // It is attached, next time the tab is updated or reloaded.
   const onTabUpdate = useCallback(
-    (
-      changingTabId: number,
-      changeInfo: chrome.tabs.TabChangeInfo,
-      tab: chrome.tabs.Tab
-    ) => {
-      if (tab.active && Number(changingTabId) === Number(tabId.current)) {
+    (changingTabId: number, changeInfo: chrome.tabs.TabChangeInfo) => {
+      if (Number(changingTabId) === Number(tabId.current)) {
         if (changeInfo.status === 'complete') {
           setIsCurrentTabLoading(false);
         } else if (changeInfo.status === 'loading') {


### PR DESCRIPTION
## Description

We've encountered an issue with the loader on the cookie landing screen's "known breakages" section, where it fails to deactivate under specific circumstances.

## Relevant Technical Choices

The root cause was identified as a conditional check for the active tab status before executing the loader's deactivation logic. If the tab being monitored transitions from a loading to a completed state while the user is focused on another tab, the loader remains active, and the intended detection logic does not execute. To address this, we've removed the active tab check, allowing the deactivation logic to run irrespective of tab focus.

## Testing Instructions

To replicate the issue, follow these steps:

1. Open two browser tabs.
2. Navigate to [example.com](https://example.com) on Tab 1 and access the PSAT extension's cookie landing page.
3. Open [linkedin.com](https://linkedin.com/) on Tab 2 without activating DevTools.
4. Return to Tab 1 and change the URL to [bbc.com](https://bbc.com). Observe the loader in the known-breakages section as the page loads.
5. Before bbc.com finishes loading on Tab 1, switch to Tab 2. Ensure Tab 1 completes loading while you are active on Tab 2.
6. After about 30 seconds, go back to Tab 1 to check if the loader is still active.
7. If the issue does not reproduce, consult the additional information section below.

## Additional Information:

The issue has a 50% chance of occurring. If not reproducible initially, try throttling your network speed to a slower setting and attempt multiple times.

## Screenshot/Screencast

![image](https://github.com/rtCamp/ps-analysis-tool-internal/assets/4833367/4b1a5ef2-1631-49ee-b0ef-207060906e15)


## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] ~This code is covered by unit tests to verify that it works as intended.~ NA
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).


## Fixes
https://github.com/GoogleChromeLabs/ps-analysis-tool/issues/471#issuecomment-1926242443
