### PR TITLE
Fix: Add mock UA string

### DIFF
--- a/packages/cli/src/utils/browserManagement/index.ts
+++ b/packages/cli/src/utils/browserManagement/index.ts
@@ -80,6 +80,11 @@ export class BrowserManagement {
       throw new Error('Browser not intialized');
     }
     const sitePage = await this.browser.newPage();
+
+    await sitePage.setUserAgent(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36'
+    );
+
     sitePage.setViewport({
       width: 1440,
       height: 790,


### PR DESCRIPTION
## Description

Some websites may have scraping bot protection which works based on UA string. Before navigating to a page we can mock the UA string using [page.setUserAgent](https://pptr.dev/api/puppeteer.page.setuseragent)

## Testing Instructions
Run CLI in a Debian-based system. Before this fix, https://edition.cnn.com was known not to save many cookies when the CLI was used in Mac or Windows-based systems. After this fix CLI should report similar number of cookies as an analysis run in other OS.


## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
