### PR TITLE
[Main] Disable auto opening of Chrome DevTools by default for all tabs

### DIFF
--- a/bin/chrome_launcher.sh
+++ b/bin/chrome_launcher.sh
@@ -24,7 +24,6 @@ if [[ "$(uname)" == "Darwin" ]]; then
           --no-default-browser-check \
           --no-first-run \
           --start-maximized \
-          --auto-open-devtools-for-tabs \
           --user-data-dir="${DATA_DIR}" \
           --silent-debugger-extension-api \
           "$@" https://example.com >/dev/null 2>&1 && rm -rf "${DATA_DIR}" &
@@ -39,7 +38,6 @@ elif [[ "$(uname)" == "Linux" ]]; then
         --no-default-browser-check \
         --no-first-run \
         --start-maximized \
-        --auto-open-devtools-for-tabs \
         --user-data-dir="${DATA_DIR}" \
         --silent-debugger-extension-api \
         "$@" https://example.com >/dev/null 2>&1 && rm -rf "${DATA_DIR}" &


### PR DESCRIPTION
## Description

Disables **auto-opening** of Chrome DevTools by default for all tabs
