### PR TITLE
Two-step process for toggling CDP state

### DIFF
--- a/packages/design-system/src/components/button/index.tsx
+++ b/packages/design-system/src/components/button/index.tsx
@@ -60,7 +60,7 @@ const Button = ({
           name={name}
           onClick={onClick ? onClick : undefined}
           className={classNames(
-            'rounded flex items-center text-center py-1.5 px-2 text-white dark:bg-google-blue bg-smurf-blue hover:bg-beteleguese dark:hover:bg-bright-navy-blue dark:text-raisin-black',
+            'rounded flex items-center text-center py-3.5 px-9 xs:py-4 xs:px-2 text-white dark:bg-google-blue bg-smurf-blue hover:bg-beteleguese dark:hover:bg-bright-navy-blue dark:text-raisin-black',
             extraClasses
           )}
         >

--- a/packages/design-system/src/components/button/index.tsx
+++ b/packages/design-system/src/components/button/index.tsx
@@ -60,7 +60,7 @@ const Button = ({
           name={name}
           onClick={onClick ? onClick : undefined}
           className={classNames(
-            'rounded flex items-center text-center py-1.5 px-4 text-white dark:bg-google-blue bg-smurf-blue hover:bg-beteleguese dark:hover:bg-bright-navy-blue dark:text-raisin-black',
+            'rounded flex items-center text-center py-1.5 px-2 text-white dark:bg-google-blue bg-smurf-blue hover:bg-beteleguese dark:hover:bg-bright-navy-blue dark:text-raisin-black',
             extraClasses
           )}
         >

--- a/packages/design-system/src/components/button/index.tsx
+++ b/packages/design-system/src/components/button/index.tsx
@@ -25,7 +25,7 @@ interface ButtonProps {
   onClick?: () => void;
   loading?: boolean;
   type?: 'button' | 'submit' | 'reset';
-  variant?: 'primary' | 'secondary' | 'danger' | 'small';
+  variant?: 'primary' | 'secondary' | 'danger' | 'small' | 'large';
   extraClasses?: string;
 }
 const Button = ({
@@ -36,30 +36,86 @@ const Button = ({
   variant = 'primary',
   extraClasses = '',
 }: ButtonProps) => {
-  return (
-    <button
-      data-test-id="button"
-      type={type}
-      name={name}
-      onClick={onClick ? onClick : undefined}
-      className={classNames(
-        'rounded flex items-center text-center',
-        extraClasses,
-        {
-          'py-1 px-2 font-medium': variant !== 'small',
-          'py-0.5 px-1.5 text-xs': variant === 'small',
-          'text-white dark:bg-baby-blue-eyes bg-sapphire hover:bg-tufts-blue dark:hover:bg-pale-cornflower-blue dark:text-raisin-black':
-            ['primary', 'small'].includes(variant),
-          'bg-transparent dark:bg-transparent dark:text-bright-gray text-raisin-black active:opacity-60 hover:opacity-80':
-            variant === 'secondary',
-          'text-white dark:text-white dark:bg-red-500 bg-red-500 hover:bg-red-600':
-            variant === 'danger',
-        }
-      )}
-    >
-      {text}
-    </button>
-  );
+  switch (variant) {
+    case 'small':
+      return (
+        <button
+          data-test-id="button"
+          type={type}
+          name={name}
+          onClick={onClick ? onClick : undefined}
+          className={classNames(
+            'rounded flex items-center text-center py-0.5 px-1.5 text-xs text-white dark:bg-baby-blue-eyes bg-sapphire hover:bg-tufts-blue dark:hover:bg-pale-cornflower-blue dark:text-raisin-black',
+            extraClasses
+          )}
+        >
+          {text}
+        </button>
+      );
+    case 'large':
+      return (
+        <button
+          data-test-id="button"
+          type={type}
+          name={name}
+          onClick={onClick ? onClick : undefined}
+          className={classNames(
+            'rounded flex items-center text-center py-3.5 px-9 text-white dark:bg-google-blue bg-smurf-blue hover:bg-beteleguese dark:hover:bg-bright-navy-blue dark:text-raisin-black',
+            extraClasses
+          )}
+        >
+          {text}
+        </button>
+      );
+    case 'primary':
+      return (
+        <button
+          data-test-id="button"
+          type={type}
+          name={name}
+          onClick={onClick ? onClick : undefined}
+          className={classNames(
+            'rounded flex items-center text-center py-1 px-2 font-medium text-white dark:bg-baby-blue-eyes bg-sapphire hover:bg-tufts-blue dark:hover:bg-pale-cornflower-blue dark:text-raisin-black',
+            extraClasses
+          )}
+        >
+          {text}
+        </button>
+      );
+    case 'secondary':
+      return (
+        <button
+          data-test-id="button"
+          type={type}
+          name={name}
+          onClick={onClick ? onClick : undefined}
+          className={classNames(
+            'rounded flex items-center text-center py-1 px-2 font-medium bg-transparent dark:bg-transparent dark:text-bright-gray text-raisin-black active:opacity-60 hover:opacity-80',
+            extraClasses
+          )}
+        >
+          {text}
+        </button>
+      );
+    case 'danger':
+      return (
+        <button
+          data-test-id="button"
+          type={type}
+          name={name}
+          onClick={onClick ? onClick : undefined}
+          className={classNames(
+            'rounded flex items-center text-center py-1 px-2 font-medium text-white dark:text-white dark:bg-red-500 bg-red-500 hover:bg-red-600',
+            extraClasses
+          )}
+        >
+          {text}
+        </button>
+      );
+    default:
+  }
+
+  return <></>;
 };
 
 export default Button;

--- a/packages/design-system/src/components/button/index.tsx
+++ b/packages/design-system/src/components/button/index.tsx
@@ -60,7 +60,7 @@ const Button = ({
           name={name}
           onClick={onClick ? onClick : undefined}
           className={classNames(
-            'rounded flex items-center text-center py-3.5 px-9 xs:py-4 xs:px-2 text-white dark:bg-google-blue bg-smurf-blue hover:bg-beteleguese dark:hover:bg-bright-navy-blue dark:text-raisin-black',
+            'font-medium rounded-xs flex items-center text-center sm:max-2xl:py-3.5 xxs:p-2 sm:max-2xl:px-9 xs:py-4 xs:px-2 text-white dark:bg-google-blue bg-smurf-blue hover:bg-beteleguese dark:hover:bg-bright-navy-blue dark:text-raisin-black',
             extraClasses
           )}
         >

--- a/packages/design-system/src/components/button/index.tsx
+++ b/packages/design-system/src/components/button/index.tsx
@@ -60,7 +60,7 @@ const Button = ({
           name={name}
           onClick={onClick ? onClick : undefined}
           className={classNames(
-            'font-medium rounded-xs flex items-center text-center sm:max-2xl:py-3.5 xxs:p-2 sm:max-2xl:px-9 xs:py-4 xs:px-2 text-white dark:bg-google-blue bg-smurf-blue hover:bg-beteleguese dark:hover:bg-bright-navy-blue dark:text-raisin-black',
+            'font-medium rounded-xs flex items-center text-center md:py-3.5 md:px-9 xxs:max-sm:p-2 xs:max-md:py-4 sm:max-md:px-2 text-white dark:bg-google-blue bg-smurf-blue hover:bg-beteleguese dark:hover:bg-bright-navy-blue dark:text-raisin-black',
             extraClasses
           )}
         >

--- a/packages/design-system/src/components/button/index.tsx
+++ b/packages/design-system/src/components/button/index.tsx
@@ -60,7 +60,7 @@ const Button = ({
           name={name}
           onClick={onClick ? onClick : undefined}
           className={classNames(
-            'rounded flex items-center text-center py-3.5 px-9 text-white dark:bg-google-blue bg-smurf-blue hover:bg-beteleguese dark:hover:bg-bright-navy-blue dark:text-raisin-black',
+            'rounded flex items-center text-center py-1.5 px-4 text-white dark:bg-google-blue bg-smurf-blue hover:bg-beteleguese dark:hover:bg-bright-navy-blue dark:text-raisin-black',
             extraClasses
           )}
         >

--- a/packages/design-system/src/components/button/index.tsx
+++ b/packages/design-system/src/components/button/index.tsx
@@ -113,9 +113,8 @@ const Button = ({
         </button>
       );
     default:
+      return <></>;
   }
-
-  return <></>;
 };
 
 export default Button;

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -40,6 +40,7 @@ export * from './table';
 export { default as SearchInput } from './searchInput';
 export * from './sidebar';
 export { default as InspectButton } from './inspectButton';
+export { default as ToastMessage } from './toastMessage';
 export {
   default as CookiesLandingContainer,
   type CookiesLandingContainerProps,

--- a/packages/design-system/src/components/toastMessage/index.tsx
+++ b/packages/design-system/src/components/toastMessage/index.tsx
@@ -26,14 +26,27 @@ import Button from '../button';
 interface ToastMessageProps {
   text: string;
   onClick: () => void;
+  additionalStyles?: string;
+  textAdditionalStyles?: string;
+  variant?: 'primary' | 'secondary' | 'danger' | 'small';
 }
 
-const ToastMessage = ({ text, onClick }: ToastMessageProps) => {
+const ToastMessage = ({
+  text,
+  onClick,
+  additionalStyles = '',
+  textAdditionalStyles = '',
+  variant = 'primary',
+}: ToastMessageProps) => {
   return (
-    <div className="flex flex-row w-full absolute z-2 left-0 bottom-0 items-center justify-between bg-white dark:bg-raisin-black pb-2">
-      <div className="w-5/6 dark:text-white pl-4">{text}</div>
+    <div
+      className={`${additionalStyles} flex flex-row w-full absolute z-2 left-0 bottom-0 items-center justify-between bg-white dark:bg-raisin-black`}
+    >
+      <div className={`w-5/6 dark:text-white ${textAdditionalStyles}`}>
+        {text}
+      </div>
       <div className="w-1/6">
-        <Button text="Reload All Tabs" onClick={onClick} />
+        <Button text="Reload All Tabs" onClick={onClick} variant={variant} />
       </div>
     </div>
   );

--- a/packages/design-system/src/components/toastMessage/index.tsx
+++ b/packages/design-system/src/components/toastMessage/index.tsx
@@ -42,13 +42,15 @@ const ToastMessage = ({
 }: ToastMessageProps) => {
   return (
     <div
-      className={`${additionalStyles} sticky flex flex-row w-full z-2 left-0 bottom-0 items-center justify-between bg-white dark:bg-charleston-green shadow-xxs py-4`}
+      className={`${additionalStyles} w-full z-2 bg-white dark:bg-charleston-green shadow-xxs`}
     >
-      <div className={`w-5/6 dark:text-white ${textAdditionalStyles}`}>
-        {text}
-      </div>
-      <div className="w-1/6">
-        <Button text={buttonText} onClick={onClick} variant={variant} />
+      <div className="flex items-center justify-between p-4">
+        <div className={`w-5/6 dark:text-white ${textAdditionalStyles}`}>
+          {text}
+        </div>
+        <div className="w-1/6">
+          <Button text={buttonText} onClick={onClick} variant={variant} />
+        </div>
       </div>
     </div>
   );

--- a/packages/design-system/src/components/toastMessage/index.tsx
+++ b/packages/design-system/src/components/toastMessage/index.tsx
@@ -16,7 +16,7 @@
 /**
  * External dependencies.
  */
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 /**
  * Internal dependencies.
@@ -31,29 +31,34 @@ interface ToastMessageProps {
   variant?: 'primary' | 'secondary' | 'danger' | 'small' | 'large';
   buttonText?: string;
 }
-
-const ToastMessage = ({
-  text,
-  onClick,
-  additionalStyles = '',
-  textAdditionalStyles = '',
-  variant = 'large',
-  buttonText = 'Reload',
-}: ToastMessageProps) => {
-  return (
-    <div
-      className={`${additionalStyles} absolute inset-x-0 bottom-0 w-full z-2 bg-white dark:bg-charleston-green shadow-xxs`}
-    >
-      <div className="flex items-center justify-between p-4">
-        <div className={`w-5/6 dark:text-white ${textAdditionalStyles}`}>
-          {text}
-        </div>
-        <div className="w-1/6">
-          <Button text={buttonText} onClick={onClick} variant={variant} />
+const ToastMessage = forwardRef<HTMLDivElement, ToastMessageProps>(
+  function ToastMessage(
+    {
+      text,
+      onClick,
+      additionalStyles = '',
+      textAdditionalStyles = '',
+      variant = 'large',
+      buttonText = 'Reload',
+    }: ToastMessageProps,
+    ref
+  ) {
+    return (
+      <div
+        ref={ref}
+        className={`${additionalStyles} absolute inset-x-0 bottom-0 w-full z-2 bg-white dark:bg-charleston-green shadow-xxs`}
+      >
+        <div className="flex items-center justify-between p-4">
+          <div className={`w-5/6 dark:text-white ${textAdditionalStyles}`}>
+            {text}
+          </div>
+          <div className="w-1/6">
+            <Button text={buttonText} onClick={onClick} variant={variant} />
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+);
 
 export default ToastMessage;

--- a/packages/design-system/src/components/toastMessage/index.tsx
+++ b/packages/design-system/src/components/toastMessage/index.tsx
@@ -29,6 +29,7 @@ interface ToastMessageProps {
   additionalStyles?: string;
   textAdditionalStyles?: string;
   variant?: 'primary' | 'secondary' | 'danger' | 'small' | 'large';
+  buttonText?: string;
 }
 
 const ToastMessage = ({
@@ -37,6 +38,7 @@ const ToastMessage = ({
   additionalStyles = '',
   textAdditionalStyles = '',
   variant = 'large',
+  buttonText = 'Reload All Tabs',
 }: ToastMessageProps) => {
   return (
     <div
@@ -46,7 +48,7 @@ const ToastMessage = ({
         {text}
       </div>
       <div className="w-1/6">
-        <Button text="Reload All Tabs" onClick={onClick} variant={variant} />
+        <Button text={buttonText} onClick={onClick} variant={variant} />
       </div>
     </div>
   );

--- a/packages/design-system/src/components/toastMessage/index.tsx
+++ b/packages/design-system/src/components/toastMessage/index.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies.
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies.
+ */
+import Button from '../button';
+
+interface ToastMessageProps {
+  text: string;
+  onClick: () => void;
+}
+
+const ToastMessage = ({ text, onClick }: ToastMessageProps) => {
+  return (
+    <div className="flex flex-row w-full absolute z-2 left-0 bottom-0 items-center justify-between bg-white dark:bg-raisin-black pb-2">
+      <div className="w-5/6 dark:text-white pl-4">{text}</div>
+      <div className="w-1/6">
+        <Button text="Reload All Tabs" onClick={onClick} />
+      </div>
+    </div>
+  );
+};
+
+export default ToastMessage;

--- a/packages/design-system/src/components/toastMessage/index.tsx
+++ b/packages/design-system/src/components/toastMessage/index.tsx
@@ -28,7 +28,7 @@ interface ToastMessageProps {
   onClick: () => void;
   additionalStyles?: string;
   textAdditionalStyles?: string;
-  variant?: 'primary' | 'secondary' | 'danger' | 'small';
+  variant?: 'primary' | 'secondary' | 'danger' | 'small' | 'large';
 }
 
 const ToastMessage = ({
@@ -36,7 +36,7 @@ const ToastMessage = ({
   onClick,
   additionalStyles = '',
   textAdditionalStyles = '',
-  variant = 'primary',
+  variant = 'large',
 }: ToastMessageProps) => {
   return (
     <div

--- a/packages/design-system/src/components/toastMessage/index.tsx
+++ b/packages/design-system/src/components/toastMessage/index.tsx
@@ -42,7 +42,7 @@ const ToastMessage = ({
 }: ToastMessageProps) => {
   return (
     <div
-      className={`${additionalStyles} flex flex-row w-full absolute z-2 left-0 bottom-0 items-center justify-between bg-white dark:bg-charleston-green shadow-xxs py-4`}
+      className={`${additionalStyles} sticky flex flex-row w-full z-2 left-0 bottom-0 items-center justify-between bg-white dark:bg-charleston-green shadow-xxs py-4`}
     >
       <div className={`w-5/6 dark:text-white ${textAdditionalStyles}`}>
         {text}

--- a/packages/design-system/src/components/toastMessage/index.tsx
+++ b/packages/design-system/src/components/toastMessage/index.tsx
@@ -42,7 +42,7 @@ const ToastMessage = ({
 }: ToastMessageProps) => {
   return (
     <div
-      className={`${additionalStyles} w-full z-2 bg-white dark:bg-charleston-green shadow-xxs`}
+      className={`${additionalStyles} absolute inset-x-0 bottom-0 w-full z-2 bg-white dark:bg-charleston-green shadow-xxs`}
     >
       <div className="flex items-center justify-between p-4">
         <div className={`w-5/6 dark:text-white ${textAdditionalStyles}`}>

--- a/packages/design-system/src/components/toastMessage/index.tsx
+++ b/packages/design-system/src/components/toastMessage/index.tsx
@@ -40,7 +40,7 @@ const ToastMessage = ({
 }: ToastMessageProps) => {
   return (
     <div
-      className={`${additionalStyles} flex flex-row w-full absolute z-2 left-0 bottom-0 items-center justify-between bg-white dark:bg-charleston-green shadow-xxs py-3`}
+      className={`${additionalStyles} flex flex-row w-full absolute z-2 left-0 bottom-0 items-center justify-between bg-white dark:bg-charleston-green shadow-xxs py-4`}
     >
       <div className={`w-5/6 dark:text-white ${textAdditionalStyles}`}>
         {text}

--- a/packages/design-system/src/components/toastMessage/index.tsx
+++ b/packages/design-system/src/components/toastMessage/index.tsx
@@ -38,7 +38,7 @@ const ToastMessage = ({
   additionalStyles = '',
   textAdditionalStyles = '',
   variant = 'large',
-  buttonText = 'Reload All Tabs',
+  buttonText = 'Reload',
 }: ToastMessageProps) => {
   return (
     <div

--- a/packages/design-system/src/components/toastMessage/index.tsx
+++ b/packages/design-system/src/components/toastMessage/index.tsx
@@ -40,7 +40,7 @@ const ToastMessage = ({
 }: ToastMessageProps) => {
   return (
     <div
-      className={`${additionalStyles} flex flex-row w-full absolute z-2 left-0 bottom-0 items-center justify-between bg-white dark:bg-raisin-black`}
+      className={`${additionalStyles} flex flex-row w-full absolute z-2 left-0 bottom-0 items-center justify-between bg-white dark:bg-charleston-green shadow-xxs py-3`}
     >
       <div className={`w-5/6 dark:text-white ${textAdditionalStyles}`}>
         {text}

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -267,11 +267,7 @@ chrome.runtime.onStartup.addListener(async () => {
  * @see https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onUpdated
  */
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-  if (!tab.url) {
-    return;
-  }
-
-  if (['loading', 'complete'].includes(changeInfo.status ?? '') && tab.url) {
+  if (changeInfo.status === 'loading' && tab.url) {
     syncCookieStore?.updateUrl(tabId, tab.url);
     syncCookieStore?.removeCookieData(tabId);
   }

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -115,14 +115,8 @@ chrome.webRequest.onResponseStarted.addListener(
         },
         []
       );
-      const currentTab = await getTab(tabId);
 
-      if (
-        !cookies ||
-        (cookies && cookies?.length === 0) ||
-        currentTab?.pendingUrl ||
-        currentTab?.url !== tabUrl
-      ) {
+      if (!cookies || (cookies && cookies?.length === 0)) {
         return;
       }
 
@@ -191,14 +185,8 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
         },
         []
       );
-      const currentTab = await getTab(tabId);
 
-      if (
-        !cookies ||
-        (cookies && cookies?.length === 0) ||
-        currentTab?.pendingUrl ||
-        currentTab?.url !== tabUrl
-      ) {
+      if (!cookies || (cookies && cookies?.length === 0)) {
         return;
       }
 
@@ -246,6 +234,10 @@ chrome.tabs.onRemoved.addListener((tabId) => {
   syncCookieStore?.removeTabData(tabId);
 });
 
+/**
+ * Fires when a profile with extension is started.
+ * @see https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onStartup
+ */
 chrome.runtime.onStartup.addListener(async () => {
   const storage = await chrome.storage.sync.get();
 
@@ -267,8 +259,13 @@ chrome.runtime.onStartup.addListener(async () => {
  * @see https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onUpdated
  */
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  if (!tab.url) {
+    return;
+  }
+
+  syncCookieStore?.updateUrl(tabId, tab.url);
+
   if (changeInfo.status === 'loading' && tab.url) {
-    syncCookieStore?.updateUrl(tabId, tab.url);
     syncCookieStore?.removeCookieData(tabId);
   }
 

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -627,7 +627,10 @@ chrome.runtime.onMessage.addListener(async (request) => {
     );
   }
 
-  if (request?.type === 'DevTools::ServiceWorker::RELOAD_ALL_TABS') {
+  if (
+    request?.type === 'DevTools::ServiceWorker::RELOAD_ALL_TABS' ||
+    request?.type === 'Popup::ServiceWorker::RELOAD_ALL_TABS'
+  ) {
     const sessionStorage = await chrome.storage.session.get();
     if (Object.keys(sessionStorage).includes('allowedNumberOfTabs')) {
       tabMode = sessionStorage.allowedNumberOfTabs;

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -115,8 +115,14 @@ chrome.webRequest.onResponseStarted.addListener(
         },
         []
       );
+      const currentTab = await getTab(tabId);
 
-      if (!cookies || (cookies && cookies?.length === 0)) {
+      if (
+        !cookies ||
+        (cookies && cookies?.length === 0) ||
+        currentTab?.pendingUrl ||
+        currentTab?.url !== tabUrl
+      ) {
         return;
       }
 
@@ -185,8 +191,14 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
         },
         []
       );
+      const currentTab = await getTab(tabId);
 
-      if (!cookies || (cookies && cookies?.length === 0)) {
+      if (
+        !cookies ||
+        (cookies && cookies?.length === 0) ||
+        currentTab?.pendingUrl ||
+        currentTab?.url !== tabUrl
+      ) {
         return;
       }
 
@@ -259,9 +271,8 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     return;
   }
 
-  syncCookieStore?.updateUrl(tabId, tab.url);
-
-  if (changeInfo.status === 'loading' && tab.url) {
+  if (['loading', 'complete'].includes(changeInfo.status ?? '') && tab.url) {
+    syncCookieStore?.updateUrl(tabId, tab.url);
     syncCookieStore?.removeCookieData(tabId);
   }
 

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -621,13 +621,22 @@ chrome.runtime.onMessage.addListener(async (request) => {
   }
 
   if (request?.type === 'DevTools::ServiceWorker::RELOAD_ALL_TABS') {
-    globalIsUsingCDP = request.payload.isUsingCDP;
-    tabMode = request.payload.allowedNumberOfTabs;
+    const sessionStorage = await chrome.storage.session.get();
+    if (Object.keys(sessionStorage).includes('allowedNumberOfTabs')) {
+      tabMode = sessionStorage.allowedNumberOfTabs;
+    }
 
-    const storage = await chrome.storage.sync.get();
+    if (Object.keys(sessionStorage).includes('isUsingCDP')) {
+      globalIsUsingCDP = sessionStorage.isUsingCDP;
+    }
+
+    await chrome.storage.session.set({
+      allowedNumberOfTabs: tabMode,
+      isUsingCDP: globalIsUsingCDP,
+      pendingReload: false,
+    });
 
     await chrome.storage.sync.set({
-      ...storage,
       allowedNumberOfTabs: tabMode,
       isUsingCDP: globalIsUsingCDP,
     });

--- a/packages/extension/src/utils/canProcessCookies.ts
+++ b/packages/extension/src/utils/canProcessCookies.ts
@@ -33,7 +33,7 @@ export default function canProcessCookies(
     return false;
   }
 
-  const _isSingleTabProcessingMode = tabMode && tabMode !== 'unlimited';
+  const _isSingleTabProcessingMode = tabMode !== 'unlimited';
 
   if (_isSingleTabProcessingMode) {
     if (currentTabId?.toString() !== tabToRead) {

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -328,7 +328,7 @@ const App: React.FC = () => {
                     additionalStyles={`text-sm`}
                     text="For settings to take effect please reload all tab(s)."
                     onClick={handleSettingsChange}
-                    textAdditionalStyles="text-sm"
+                    textAdditionalStyles="xxs:p-1 xxs:text-xxs sm:max-2xl:text-xs leading-5"
                   />
                 )}
               </div>

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -48,6 +48,30 @@ const App: React.FC = () => {
   const [sidebarWidth, setSidebarWidth] = useState(200);
   const [sidebarData, setSidebarData] = useState(TABS);
   const contextInvalidatedRef = useRef(null);
+  const [toastMessageWidth, setToastMessageWidth] = useState(
+    (window.innerWidth || document.body.clientWidth) - 200
+  );
+
+  useEffect(() => {
+    let isWindowResized = false;
+    const onWindowResize = () => {
+      isWindowResized = true;
+
+      const width =
+        (window.innerWidth || document.body.clientWidth) - sidebarWidth;
+
+      setToastMessageWidth(width);
+    };
+
+    if (!isWindowResized) {
+      setToastMessageWidth(
+        (window.innerWidth || document.body.clientWidth) - sidebarWidth
+      );
+    }
+
+    window.addEventListener('resize', onWindowResize);
+    return () => window.removeEventListener('resize', onWindowResize);
+  }, [sidebarWidth]);
 
   const {
     contextInvalidated,
@@ -295,14 +319,19 @@ const App: React.FC = () => {
           <main className="h-full flex-1 overflow-auto">
             <div className="min-w-[40rem] h-full relative z-1">
               {activePanel}
-              {settingsChanged && (
-                <ToastMessage
-                  additionalStyles="pb-2 text-sm"
-                  text="To get accurate data and allow settings to take effect we need to reload all tab(s)."
-                  onClick={handleSettingsChange}
-                  textAdditionalStyles="pl-4"
-                />
-              )}
+              <div
+                className="fixed right-0 bottom-0"
+                style={{ width: toastMessageWidth + 'px' }}
+              >
+                {settingsChanged && (
+                  <ToastMessage
+                    additionalStyles={`text-sm`}
+                    text="To get accurate data and allow settings to take effect we need to reload all tab(s)."
+                    onClick={handleSettingsChange}
+                    textAdditionalStyles="text-sm"
+                  />
+                )}
+              </div>
             </div>
           </main>
         </div>

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -74,6 +74,9 @@ const App: React.FC = () => {
     frameHasCookies: state.frameHasCookies,
   }));
 
+  const mainRef = useRef<HTMLElement>(null);
+  const toastMessageRef = useRef<HTMLDivElement>(null);
+
   const { allowedNumberOfTabs, settingsChanged, handleSettingsChange } =
     useSettingsStore(({ state, actions }) => ({
       allowedNumberOfTabs: state.allowedNumberOfTabs,
@@ -292,10 +295,20 @@ const App: React.FC = () => {
               visibleWidth={sidebarWidth}
             />
           </Resizable>
-          <main className="h-full flex-1 overflow-auto relative">
+          <main
+            ref={mainRef}
+            onScroll={() => {
+              if (mainRef.current && toastMessageRef.current) {
+                toastMessageRef.current.style.bottom =
+                  '-' + mainRef.current.scrollTop + 'px';
+              }
+            }}
+            className="h-full flex-1 overflow-auto relative"
+          >
             <div className="min-w-[40rem] h-full z-1">{activePanel}</div>
             {settingsChanged && (
               <ToastMessage
+                ref={toastMessageRef}
                 additionalStyles="text-sm"
                 text="For settings to take effect please reload all tab(s)."
                 onClick={handleSettingsChange}

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -299,9 +299,11 @@ const App: React.FC = () => {
       )}
       {settingsChanged && (
         <ToastMessage
+          additionalStyles="pb-2"
           text="To get accurate data we need to reload all open tabs. Please click
         on Reload to reload all open tabs."
           onClick={handleSettingsChange}
+          textAdditionalStyles="pl-4"
         />
       )}
     </div>

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -297,8 +297,7 @@ const App: React.FC = () => {
             {settingsChanged && (
               <ToastMessage
                 additionalStyles="pb-2 text-sm"
-                text="To get accurate data we need to reload all open tabs. Please click
-        on Reload to reload all open tabs."
+                text="To get accurate data we need to reload all open tabs."
                 onClick={handleSettingsChange}
                 textAdditionalStyles="pl-4"
               />

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -256,11 +256,11 @@ const App: React.FC = () => {
 
   return (
     <div
-      className="w-full h-screen overflow-hidden bg-white dark:bg-raisin-black relative"
+      className="w-full h-screen overflow-hidden bg-white dark:bg-raisin-black"
       ref={contextInvalidatedRef}
     >
       {contextInvalidated && (
-        <div className="flex flex-col items-center justify-center w-full h-full z-1">
+        <div className="flex flex-col items-center justify-center w-full h-full">
           <ExtensionReloadNotification />
         </div>
       )}
@@ -292,19 +292,19 @@ const App: React.FC = () => {
               visibleWidth={sidebarWidth}
             />
           </Resizable>
-          <main className="h-full flex-1 overflow-auto">
-            <div className="min-w-[40rem] h-full">{activePanel}</div>
+          <main className="h-full flex-1 overflow-auto relative">
+            <div className="min-w-[40rem] h-full z-1">{activePanel}</div>
+            {settingsChanged && (
+              <ToastMessage
+                additionalStyles="pb-2"
+                text="To get accurate data we need to reload all open tabs. Please click
+        on Reload to reload all open tabs."
+                onClick={handleSettingsChange}
+                textAdditionalStyles="pl-4"
+              />
+            )}
           </main>
         </div>
-      )}
-      {settingsChanged && (
-        <ToastMessage
-          additionalStyles="pb-2"
-          text="To get accurate data we need to reload all open tabs. Please click
-        on Reload to reload all open tabs."
-          onClick={handleSettingsChange}
-          textAdditionalStyles="pl-4"
-        />
       )}
     </div>
   );

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -48,30 +48,6 @@ const App: React.FC = () => {
   const [sidebarWidth, setSidebarWidth] = useState(200);
   const [sidebarData, setSidebarData] = useState(TABS);
   const contextInvalidatedRef = useRef(null);
-  const [toastMessageWidth, setToastMessageWidth] = useState(
-    (window.innerWidth || document.body.clientWidth) - 200
-  );
-
-  useEffect(() => {
-    let isWindowResized = false;
-    const onWindowResize = () => {
-      isWindowResized = true;
-
-      const width =
-        (window.innerWidth || document.body.clientWidth) - sidebarWidth;
-
-      setToastMessageWidth(width);
-    };
-
-    if (!isWindowResized) {
-      setToastMessageWidth(
-        (window.innerWidth || document.body.clientWidth) - sidebarWidth
-      );
-    }
-
-    window.addEventListener('resize', onWindowResize);
-    return () => window.removeEventListener('resize', onWindowResize);
-  }, [sidebarWidth]);
 
   const {
     contextInvalidated,
@@ -316,23 +292,16 @@ const App: React.FC = () => {
               visibleWidth={sidebarWidth}
             />
           </Resizable>
-          <main className="h-full flex-1 overflow-auto">
-            <div className="min-w-[40rem] h-full relative z-1">
-              {activePanel}
-              <div
-                className="fixed right-0 bottom-0"
-                style={{ width: toastMessageWidth + 'px' }}
-              >
-                {settingsChanged && (
-                  <ToastMessage
-                    additionalStyles={`text-sm`}
-                    text="For settings to take effect please reload all tab(s)."
-                    onClick={handleSettingsChange}
-                    textAdditionalStyles="xxs:p-1 xxs:text-xxs sm:max-2xl:text-xsm leading-5"
-                  />
-                )}
-              </div>
-            </div>
+          <main className="h-full flex-1 overflow-auto relative">
+            <div className="min-w-[40rem] h-full z-1">{activePanel}</div>
+            {settingsChanged && (
+              <ToastMessage
+                additionalStyles="text-sm"
+                text="For settings to take effect please reload all tab(s)."
+                onClick={handleSettingsChange}
+                textAdditionalStyles="xxs:p-1 xxs:text-xxs sm:max-2xl:text-xsm leading-5"
+              />
+            )}
           </main>
         </div>
       )}

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -328,7 +328,7 @@ const App: React.FC = () => {
                     additionalStyles={`text-sm`}
                     text="For settings to take effect please reload all tab(s)."
                     onClick={handleSettingsChange}
-                    textAdditionalStyles="xxs:p-1 xxs:text-xxs sm:max-2xl:text-xs leading-5"
+                    textAdditionalStyles="xxs:p-1 xxs:text-xxs sm:max-2xl:text-xsm leading-5"
                   />
                 )}
               </div>

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -326,7 +326,7 @@ const App: React.FC = () => {
                 {settingsChanged && (
                   <ToastMessage
                     additionalStyles={`text-sm`}
-                    text="To get accurate data and allow settings to take effect we need to reload all tab(s)."
+                    text="For settings to take effect please reload all tab(s)."
                     onClick={handleSettingsChange}
                     textAdditionalStyles="text-sm"
                   />

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -292,16 +292,18 @@ const App: React.FC = () => {
               visibleWidth={sidebarWidth}
             />
           </Resizable>
-          <main className="h-full flex-1 overflow-auto relative">
-            <div className="min-w-[40rem] h-full z-1">{activePanel}</div>
-            {settingsChanged && (
-              <ToastMessage
-                additionalStyles="pb-2 text-sm"
-                text="To get accurate data we need to reload all open tabs."
-                onClick={handleSettingsChange}
-                textAdditionalStyles="pl-4"
-              />
-            )}
+          <main className="h-full flex-1 overflow-auto">
+            <div className="min-w-[40rem] h-full relative z-1">
+              {activePanel}
+              {settingsChanged && (
+                <ToastMessage
+                  additionalStyles="pb-2 text-sm"
+                  text="To get accurate data and allow settings to take effect we need to reload all tab(s)."
+                  onClick={handleSettingsChange}
+                  textAdditionalStyles="pl-4"
+                />
+              )}
+            </div>
           </main>
         </div>
       )}

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -26,6 +26,7 @@ import {
   useSidebar,
   type SidebarItems,
   InspectButton,
+  ToastMessage,
 } from '@ps-analysis-tool/design-system';
 import {
   UNKNOWN_FRAME_KEY,
@@ -73,9 +74,12 @@ const App: React.FC = () => {
     frameHasCookies: state.frameHasCookies,
   }));
 
-  const { allowedNumberOfTabs } = useSettingsStore(({ state }) => ({
-    allowedNumberOfTabs: state.allowedNumberOfTabs,
-  }));
+  const { allowedNumberOfTabs, settingsChanged, handleSettingsChange } =
+    useSettingsStore(({ state, actions }) => ({
+      allowedNumberOfTabs: state.allowedNumberOfTabs,
+      settingsChanged: state.settingsChanged,
+      handleSettingsChange: actions.handleSettingsChange,
+    }));
 
   const listenToMouseChange = useCallback(() => {
     if (contextInvalidatedRef.current) {
@@ -252,16 +256,16 @@ const App: React.FC = () => {
 
   return (
     <div
-      className="w-full h-screen overflow-hidden bg-white dark:bg-raisin-black"
+      className="w-full h-screen overflow-hidden bg-white dark:bg-raisin-black relative"
       ref={contextInvalidatedRef}
     >
       {contextInvalidated && (
-        <div className="flex flex-col items-center justify-center w-full h-full">
+        <div className="flex flex-col items-center justify-center w-full h-full z-1">
           <ExtensionReloadNotification />
         </div>
       )}
       {!contextInvalidated && (
-        <div className="w-full h-full flex flex-row">
+        <div className="w-full h-full flex flex-row z-1">
           <Resizable
             size={{ width: sidebarWidth, height: '100%' }}
             defaultSize={{ width: '200px', height: '100%' }}
@@ -292,6 +296,13 @@ const App: React.FC = () => {
             <div className="min-w-[40rem] h-full">{activePanel}</div>
           </main>
         </div>
+      )}
+      {settingsChanged && (
+        <ToastMessage
+          text="To get accurate data we need to reload all open tabs. Please click
+        on Reload to reload all open tabs."
+          onClick={handleSettingsChange}
+        />
       )}
     </div>
   );

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -296,7 +296,7 @@ const App: React.FC = () => {
             <div className="min-w-[40rem] h-full z-1">{activePanel}</div>
             {settingsChanged && (
               <ToastMessage
-                additionalStyles="pb-2"
+                additionalStyles="pb-2 text-sm"
                 text="To get accurate data we need to reload all open tabs. Please click
         on Reload to reload all open tabs."
                 onClick={handleSettingsChange}

--- a/packages/extension/src/view/devtools/components/settings/components/settingsContainer.tsx
+++ b/packages/extension/src/view/devtools/components/settings/components/settingsContainer.tsx
@@ -38,8 +38,8 @@ interface settingsToReturnObject {
 const SettingsContainer = () => {
   const { allowedNumberOfTabs, isUsingCDP, setIsUsingCDP, setProcessingMode } =
     useSettingsStore(({ state, actions }) => ({
-      allowedNumberOfTabs: state.allowedNumberOfTabs,
-      isUsingCDP: state.isUsingCDP,
+      allowedNumberOfTabs: state.allowedNumberOfTabsForSettingsPageDisplay,
+      isUsingCDP: state.isUsingCDPForSettingsPageDisplay,
       setProcessingMode: actions.setProcessingMode,
       setIsUsingCDP: actions.setIsUsingCDP,
     }));

--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -300,6 +300,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
         );
         isCurrentTabBeingListenedToRef.current =
           tabId?.toString() === message?.payload?.tabId;
+        setTabToRead(message?.payload?.tabId?.toString() || null);
         setTabFrames(null);
         setLoading(false);
         setCanStartInspecting(false);

--- a/packages/extension/src/view/devtools/stateProviders/syncSettingsStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncSettingsStore/index.tsx
@@ -131,6 +131,11 @@ export const Provider = ({ children }: PropsWithChildren) => {
       } else {
         setIsUsingCDPForSettingsPageDisplay(currentSettings.isUsingCDP);
       }
+    } else {
+      setAllowedNumberOfTabsForSettingsPageDisplay(
+        currentSettings.allowedNumberOfTabs
+      );
+      setIsUsingCDPForSettingsPageDisplay(currentSettings.isUsingCDP);
     }
 
     if (Object.keys(currentSettings).includes('allowedNumberOfTabs')) {

--- a/packages/extension/src/view/devtools/stateProviders/syncSettingsStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncSettingsStore/index.tsx
@@ -99,27 +99,30 @@ export const Provider = ({ children }: PropsWithChildren) => {
 
   const intitialSync = useCallback(async () => {
     const sessionStorage = await chrome.storage.session.get();
+    let settingsStoreSet = false;
 
     if (Object.keys(sessionStorage).includes('pendingReload')) {
       setSettingsChanged(sessionStorage?.pendingReload);
+      settingsStoreSet = true;
+    }
+    const currentSettings = await chrome.storage.sync.get();
 
-      if (Object.keys(sessionStorage).includes('allowedNumberOfTabs')) {
-        setAllowedNumberOfTabs(sessionStorage?.allowedNumberOfTabs);
-      }
-
-      if (Object.keys(sessionStorage).includes('isUsingCDP')) {
-        setIsUsingCDP(sessionStorage?.isUsingCDP);
-      }
+    if (
+      settingsStoreSet &&
+      Object.keys(sessionStorage).includes('allowedNumberOfTabs')
+    ) {
+      setAllowedNumberOfTabs(sessionStorage?.allowedNumberOfTabs);
     } else {
-      const currentSettings = await chrome.storage.sync.get();
+      setAllowedNumberOfTabs(currentSettings?.allowedNumberOfTabs);
+    }
 
-      if (Object.keys(currentSettings).includes('allowedNumberOfTabs')) {
-        setAllowedNumberOfTabs(currentSettings?.allowedNumberOfTabs);
-      }
-
-      if (Object.keys(currentSettings).includes('isUsingCDP')) {
-        setIsUsingCDP(currentSettings?.isUsingCDP);
-      }
+    if (
+      settingsStoreSet &&
+      Object.keys(sessionStorage).includes('isUsingCDP')
+    ) {
+      setIsUsingCDP(sessionStorage?.isUsingCDP);
+    } else {
+      setIsUsingCDP(currentSettings?.isUsingCDP);
     }
 
     chrome.tabs.query({}, (tabs) => {

--- a/packages/extension/src/view/devtools/stateProviders/syncSettingsStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncSettingsStore/index.tsx
@@ -98,6 +98,10 @@ export const Provider = ({ children }: PropsWithChildren) => {
     useState<SettingStoreContext['state']['OSInformation']>(null);
 
   const intitialSync = useCallback(async () => {
+    const localStoragePersistance = localStorage.getItem('settingsChanged');
+
+    setSettingsChanged(localStoragePersistance === 'true');
+
     const currentSettings = await chrome.storage.sync.get();
 
     if (Object.keys(currentSettings).includes('allowedNumberOfTabs')) {
@@ -168,11 +172,13 @@ export const Provider = ({ children }: PropsWithChildren) => {
         changes?.allowedNumberOfTabs?.newValue
       ) {
         setAllowedNumberOfTabs(changes?.allowedNumberOfTabs?.newValue);
+        localStorage.setItem('settingsChanged', 'true');
         setSettingsChanged(true);
       }
 
       if (changes?.isUsingCDP) {
         setIsUsingCDP(changes?.isUsingCDP?.newValue);
+        localStorage.setItem('settingsChanged', 'true');
         setSettingsChanged(true);
       }
     },
@@ -184,6 +190,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
       await chrome.runtime.sendMessage({
         type: 'DevTools::ServiceWorker::RELOAD_ALL_TABS',
       });
+      localStorage.setItem('settingsChanged', 'false');
       setSettingsChanged(false);
     }
   }, [settingsChanged]);

--- a/packages/extension/src/view/devtools/stateProviders/syncSettingsStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncSettingsStore/index.tsx
@@ -98,10 +98,6 @@ export const Provider = ({ children }: PropsWithChildren) => {
     useState<SettingStoreContext['state']['OSInformation']>(null);
 
   const intitialSync = useCallback(async () => {
-    const localStoragePersistance = localStorage.getItem('settingsChanged');
-
-    setSettingsChanged(localStoragePersistance === 'true');
-
     const currentSettings = await chrome.storage.sync.get();
 
     if (Object.keys(currentSettings).includes('allowedNumberOfTabs')) {
@@ -145,24 +141,15 @@ export const Provider = ({ children }: PropsWithChildren) => {
     }
   }, [OSInformation]);
 
-  const setProcessingMode = useCallback(async (newState: boolean) => {
+  const setProcessingMode = useCallback((newState: boolean) => {
     const valueToBeSet: boolean | string = newState ? 'unlimited' : 'single';
-
-    const currentSettings = await chrome.storage.sync.get();
-    chrome.storage.sync.set({
-      ...currentSettings,
-      allowedNumberOfTabs: valueToBeSet,
-    });
+    setAllowedNumberOfTabs(valueToBeSet);
+    setSettingsChanged(true);
   }, []);
 
   const _setUsingCDP = useCallback((newValue: boolean) => {
-    chrome.runtime.sendMessage({
-      type: 'DevTools::ServiceWorker::CHANGE_CDP_SETTING',
-      payload: {
-        isUsingCDP: newValue,
-      },
-    });
     setIsUsingCDP(newValue);
+    setSettingsChanged(true);
   }, []);
 
   const storeChangeListener = useCallback(
@@ -172,14 +159,10 @@ export const Provider = ({ children }: PropsWithChildren) => {
         changes?.allowedNumberOfTabs?.newValue
       ) {
         setAllowedNumberOfTabs(changes?.allowedNumberOfTabs?.newValue);
-        localStorage.setItem('settingsChanged', 'true');
-        setSettingsChanged(true);
       }
 
       if (changes?.isUsingCDP) {
         setIsUsingCDP(changes?.isUsingCDP?.newValue);
-        localStorage.setItem('settingsChanged', 'true');
-        setSettingsChanged(true);
       }
     },
     []
@@ -187,10 +170,21 @@ export const Provider = ({ children }: PropsWithChildren) => {
 
   const handleSettingsChange = useCallback(async () => {
     if (settingsChanged) {
+      const newProcessingMode = localStorage.getItem('allowedNumberOfTabs');
+      const newCDPMode = localStorage.getItem('isUsingCDP');
+
       await chrome.runtime.sendMessage({
         type: 'DevTools::ServiceWorker::RELOAD_ALL_TABS',
+        payload: {
+          allowedNumberOfTabs: newProcessingMode,
+          isUsingCDP: newCDPMode,
+        },
       });
-      localStorage.setItem('settingsChanged', 'false');
+
+      localStorage.removeItem('settingsChanged');
+      localStorage.removeItem('isUsingCDP');
+      localStorage.removeItem('allowedNumberOfTabs');
+
       setSettingsChanged(false);
     }
   }, [settingsChanged]);

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -81,7 +81,6 @@ const App: React.FC = () => {
             <ToastMessage
               additionalStyles="text-sm"
               text="For settings to take effect please reload all tab(s)."
-              buttonText="Reload"
               onClick={handleSettingsChange}
               textAdditionalStyles="xxs:p-1 text-xxs leading-5"
             />
@@ -121,7 +120,6 @@ const App: React.FC = () => {
             <ToastMessage
               additionalStyles="text-sm"
               text="For settings to take effect please reload all tab(s)."
-              buttonText="Reload"
               onClick={handleSettingsChange}
               textAdditionalStyles="xxs:p-1 text-xxs leading-5"
             />
@@ -152,7 +150,6 @@ const App: React.FC = () => {
             <ToastMessage
               additionalStyles="text-sm"
               text="For settings to take effect please reload all tab(s)."
-              buttonText="Reload"
               onClick={handleSettingsChange}
               textAdditionalStyles="xxs:p-1 text-xxs leading-5"
             />
@@ -200,7 +197,6 @@ const App: React.FC = () => {
           <ToastMessage
             additionalStyles="text-sm"
             text="For settings to take effect please reload all tab(s)."
-            buttonText="Reload"
             onClick={handleSettingsChange}
             textAdditionalStyles="xxs:p-1 text-xxs leading-5"
           />

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -81,10 +81,9 @@ const App: React.FC = () => {
             <ToastMessage
               additionalStyles="text-sm"
               text="For settings to take effect please reload all tab(s)."
-              variant="primary"
               buttonText="Reload"
               onClick={handleSettingsChange}
-              textAdditionalStyles="text-xs"
+              textAdditionalStyles="xxs:p-1 text-xxs leading-5"
             />
           )}
         </div>
@@ -122,10 +121,9 @@ const App: React.FC = () => {
             <ToastMessage
               additionalStyles="text-sm"
               text="For settings to take effect please reload all tab(s)."
-              variant="primary"
               buttonText="Reload"
               onClick={handleSettingsChange}
-              textAdditionalStyles="text-xs"
+              textAdditionalStyles="xxs:p-1 text-xxs leading-5"
             />
           )}
         </div>
@@ -154,10 +152,9 @@ const App: React.FC = () => {
             <ToastMessage
               additionalStyles="text-sm"
               text="For settings to take effect please reload all tab(s)."
-              variant="primary"
               buttonText="Reload"
               onClick={handleSettingsChange}
-              textAdditionalStyles="text-xs"
+              textAdditionalStyles="xxs:p-1 text-xxs leading-5"
             />
           )}
         </div>
@@ -203,10 +200,9 @@ const App: React.FC = () => {
           <ToastMessage
             additionalStyles="text-sm"
             text="For settings to take effect please reload all tab(s)."
-            variant="primary"
             buttonText="Reload"
             onClick={handleSettingsChange}
-            textAdditionalStyles="text-xs"
+            textAdditionalStyles="xxs:p-1 text-xxs leading-5"
           />
         )}
       </div>

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -54,7 +54,7 @@ const App: React.FC = () => {
     returningToSingleTab: state.returningToSingleTab,
     allowedNumberOfTabs: state.allowedNumberOfTabs,
     onChromeUrl: state.onChromeUrl,
-    isUsingCDP: state.isUsingCDP,
+    isUsingCDP: state.isUsingCDPForSettingsDisplay,
     setIsUsingCDP: actions.setIsUsingCDP,
     handleSettingsChange: actions.handleSettingsChange,
     settingsChanged: state.settingsChanged,

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -79,7 +79,7 @@ const App: React.FC = () => {
         {settingsChanged && (
           <ToastMessage
             additionalStyles="pb-2 text-xs"
-            text="To get accurate data we need to reload all open tabs."
+            text="To get accurate data and allow settings to take effect we need to reload all tab(s).."
             variant="small"
             buttonText="Reload"
             onClick={handleSettingsChange}
@@ -118,7 +118,7 @@ const App: React.FC = () => {
         {settingsChanged && (
           <ToastMessage
             additionalStyles="pb-2 text-xs"
-            text="To get accurate data we need to reload all open tabs."
+            text="To get accurate data and allow settings to take effect we need to reload all tab(s).."
             onClick={handleSettingsChange}
             variant="small"
             buttonText="Reload"
@@ -148,7 +148,7 @@ const App: React.FC = () => {
         {settingsChanged && (
           <ToastMessage
             additionalStyles="pb-2 text-xs"
-            text="To get accurate data we need to reload all open tabs."
+            text="To get accurate data and allow settings to take effect we need to reload all tab(s).."
             variant="small"
             buttonText="Reload"
             onClick={handleSettingsChange}
@@ -195,7 +195,7 @@ const App: React.FC = () => {
       {settingsChanged && (
         <ToastMessage
           additionalStyles="pb-2 text-xs"
-          text="To get accurate data we need to reload all open tabs."
+          text="To get accurate data and allow settings to take effect we need to reload all tab(s).."
           variant="small"
           buttonText="Reload"
           onClick={handleSettingsChange}

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -76,16 +76,18 @@ const App: React.FC = () => {
         <p className="text-chart-label text-xs">
           Its emptier than a cookie jar after a midnight snack! 🌌
         </p>
-        {settingsChanged && (
-          <ToastMessage
-            additionalStyles="pb-2 text-xs"
-            text="To get accurate data and allow settings to take effect we need to reload all tab(s).."
-            variant="small"
-            buttonText="Reload"
-            onClick={handleSettingsChange}
-            textAdditionalStyles="pl-4"
-          />
-        )}
+        <div className="absolute right-0 bottom-0 w-full">
+          {settingsChanged && (
+            <ToastMessage
+              additionalStyles="text-sm"
+              text="To get accurate data and allow settings to take effect we need to reload all tab(s)."
+              variant="primary"
+              buttonText="Reload"
+              onClick={handleSettingsChange}
+              textAdditionalStyles="text-xs"
+            />
+          )}
+        </div>
       </div>
     );
   }
@@ -115,16 +117,18 @@ const App: React.FC = () => {
           enabled={isUsingCDP}
         />
         <Button onClick={changeListeningToThisTab} text="Analyze this tab" />
-        {settingsChanged && (
-          <ToastMessage
-            additionalStyles="pb-2 text-xs"
-            text="To get accurate data and allow settings to take effect we need to reload all tab(s).."
-            onClick={handleSettingsChange}
-            variant="small"
-            buttonText="Reload"
-            textAdditionalStyles="pl-4"
-          />
-        )}
+        <div className="absolute right-0 bottom-0 w-full">
+          {settingsChanged && (
+            <ToastMessage
+              additionalStyles="text-sm"
+              text="To get accurate data and allow settings to take effect we need to reload all tab(s)."
+              variant="primary"
+              buttonText="Reload"
+              onClick={handleSettingsChange}
+              textAdditionalStyles="text-xs"
+            />
+          )}
+        </div>
       </div>
     );
   }
@@ -145,16 +149,18 @@ const App: React.FC = () => {
         <p className="text-chart-label text-xs">
           Please try reloading the page
         </p>
-        {settingsChanged && (
-          <ToastMessage
-            additionalStyles="pb-2 text-xs"
-            text="To get accurate data and allow settings to take effect we need to reload all tab(s).."
-            variant="small"
-            buttonText="Reload"
-            onClick={handleSettingsChange}
-            textAdditionalStyles="pl-4"
-          />
-        )}
+        <div className="absolute right-0 bottom-0 w-full">
+          {settingsChanged && (
+            <ToastMessage
+              additionalStyles="text-sm"
+              text="To get accurate data and allow settings to take effect we need to reload all tab(s)."
+              variant="primary"
+              buttonText="Reload"
+              onClick={handleSettingsChange}
+              textAdditionalStyles="text-xs"
+            />
+          )}
+        </div>
       </div>
     );
   }
@@ -192,16 +198,18 @@ const App: React.FC = () => {
           {'Inspect cookies in the "Privacy Sandbox" panel of DevTools'}
         </p>
       </div>
-      {settingsChanged && (
-        <ToastMessage
-          additionalStyles="pb-2 text-xs"
-          text="To get accurate data and allow settings to take effect we need to reload all tab(s).."
-          variant="small"
-          buttonText="Reload"
-          onClick={handleSettingsChange}
-          textAdditionalStyles="pl-4"
-        />
-      )}
+      <div className="absolute right-0 bottom-0 w-full">
+        {settingsChanged && (
+          <ToastMessage
+            additionalStyles="text-sm"
+            text="To get accurate data and allow settings to take effect we need to reload all tab(s)."
+            variant="primary"
+            buttonText="Reload"
+            onClick={handleSettingsChange}
+            textAdditionalStyles="text-xs"
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -80,7 +80,7 @@ const App: React.FC = () => {
           {settingsChanged && (
             <ToastMessage
               additionalStyles="text-sm"
-              text="To get accurate data and allow settings to take effect we need to reload all tab(s)."
+              text="For settings to take effect please reload all tab(s)."
               variant="primary"
               buttonText="Reload"
               onClick={handleSettingsChange}
@@ -121,7 +121,7 @@ const App: React.FC = () => {
           {settingsChanged && (
             <ToastMessage
               additionalStyles="text-sm"
-              text="To get accurate data and allow settings to take effect we need to reload all tab(s)."
+              text="For settings to take effect please reload all tab(s)."
               variant="primary"
               buttonText="Reload"
               onClick={handleSettingsChange}
@@ -153,7 +153,7 @@ const App: React.FC = () => {
           {settingsChanged && (
             <ToastMessage
               additionalStyles="text-sm"
-              text="To get accurate data and allow settings to take effect we need to reload all tab(s)."
+              text="For settings to take effect please reload all tab(s)."
               variant="primary"
               buttonText="Reload"
               onClick={handleSettingsChange}
@@ -202,7 +202,7 @@ const App: React.FC = () => {
         {settingsChanged && (
           <ToastMessage
             additionalStyles="text-sm"
-            text="To get accurate data and allow settings to take effect we need to reload all tab(s)."
+            text="For settings to take effect please reload all tab(s)."
             variant="primary"
             buttonText="Reload"
             onClick={handleSettingsChange}

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -21,8 +21,8 @@ import React from 'react';
 import {
   Button,
   CirclePieChart,
+  InfoIcon,
   ProgressBar,
-  ToastMessage,
   ToggleSwitch,
   prepareCookieStatsComponents,
 } from '@ps-analysis-tool/design-system';
@@ -77,12 +77,19 @@ const App: React.FC = () => {
           Its emptier than a cookie jar after a midnight snack! 🌌
         </p>
         {settingsChanged && (
-          <ToastMessage
-            variant="small"
-            text="To get accurate data we need to reload all open tabs. Please click
+          <div className="flex flex-row gap-x-1.5 top-2 right-2 absolute items-center">
+            <Button
+              variant="small"
+              text="Reload Tabs"
+              onClick={handleSettingsChange}
+            />
+            <span
+              title="To get accurate data we need to reload all open tabs. Please click
         on Reload to reload all open tabs."
-            onClick={handleSettingsChange}
-          />
+            >
+              <InfoIcon />
+            </span>
+          </div>
         )}
       </div>
     );
@@ -114,12 +121,19 @@ const App: React.FC = () => {
         />
         <Button onClick={changeListeningToThisTab} text="Analyze this tab" />
         {settingsChanged && (
-          <ToastMessage
-            variant="small"
-            text="To get accurate data we need to reload all open tabs. Please click
+          <div className="flex flex-row gap-x-1.5 top-2 right-2 absolute items-center">
+            <Button
+              variant="small"
+              text="Reload Tabs"
+              onClick={handleSettingsChange}
+            />
+            <span
+              title="To get accurate data we need to reload all open tabs. Please click
         on Reload to reload all open tabs."
-            onClick={handleSettingsChange}
-          />
+            >
+              <InfoIcon />
+            </span>
+          </div>
         )}
       </div>
     );
@@ -142,12 +156,19 @@ const App: React.FC = () => {
           Please try reloading the page
         </p>
         {settingsChanged && (
-          <ToastMessage
-            variant="small"
-            text="To get accurate data we need to reload all open tabs. Please click
+          <div className="flex flex-row gap-x-1.5 top-2 right-2 absolute items-center">
+            <Button
+              variant="small"
+              text="Reload Tabs"
+              onClick={handleSettingsChange}
+            />
+            <span
+              title="To get accurate data we need to reload all open tabs. Please click
         on Reload to reload all open tabs."
-            onClick={handleSettingsChange}
-          />
+            >
+              <InfoIcon />
+            </span>
+          </div>
         )}
       </div>
     );
@@ -187,12 +208,19 @@ const App: React.FC = () => {
         </p>
       </div>
       {settingsChanged && (
-        <ToastMessage
-          variant="small"
-          text="To get accurate data we need to reload all open tabs. Please click
+        <div className="flex flex-row gap-x-1.5 top-2 right-2 absolute items-center">
+          <Button
+            variant="small"
+            text="Reload Tabs"
+            onClick={handleSettingsChange}
+          />
+          <span
+            title="To get accurate data we need to reload all open tabs. Please click
         on Reload to reload all open tabs."
-          onClick={handleSettingsChange}
-        />
+          >
+            <InfoIcon />
+          </span>
+        </div>
       )}
     </div>
   );

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -22,6 +22,7 @@ import {
   Button,
   CirclePieChart,
   ProgressBar,
+  ToastMessage,
   ToggleSwitch,
   prepareCookieStatsComponents,
 } from '@ps-analysis-tool/design-system';
@@ -44,6 +45,8 @@ const App: React.FC = () => {
     allowedNumberOfTabs,
     isUsingCDP,
     setIsUsingCDP,
+    settingsChanged,
+    handleSettingsChange,
   } = useCookieStore(({ state, actions }) => ({
     cookieStats: state.tabCookieStats,
     isCurrentTabBeingListenedTo: state.isCurrentTabBeingListenedTo,
@@ -53,6 +56,8 @@ const App: React.FC = () => {
     onChromeUrl: state.onChromeUrl,
     isUsingCDP: state.isUsingCDP,
     setIsUsingCDP: actions.setIsUsingCDP,
+    handleSettingsChange: actions.handleSettingsChange,
+    settingsChanged: state.settingsChanged,
     changeListeningToThisTab: actions.changeListeningToThisTab,
   }));
 
@@ -60,7 +65,7 @@ const App: React.FC = () => {
 
   if (onChromeUrl) {
     return (
-      <>
+      <div className="w-full h-full flex justify-center items-center flex-col z-1 relative">
         <ToggleSwitch
           onLabel={cdpLabel}
           additionalStyles="top-2 left-2 absolute"
@@ -71,7 +76,15 @@ const App: React.FC = () => {
         <p className="text-chart-label text-xs">
           Its emptier than a cookie jar after a midnight snack! 🌌
         </p>
-      </>
+        {settingsChanged && (
+          <ToastMessage
+            variant="small"
+            text="To get accurate data we need to reload all open tabs. Please click
+        on Reload to reload all open tabs."
+            onClick={handleSettingsChange}
+          />
+        )}
+      </div>
     );
   }
 
@@ -92,7 +105,7 @@ const App: React.FC = () => {
     allowedNumberOfTabs !== 'unlimited'
   ) {
     return (
-      <>
+      <div className="w-full h-full flex justify-center items-center flex-col z-1">
         <ToggleSwitch
           onLabel={cdpLabel}
           additionalStyles="top-2 left-2 absolute"
@@ -100,7 +113,15 @@ const App: React.FC = () => {
           enabled={isUsingCDP}
         />
         <Button onClick={changeListeningToThisTab} text="Analyze this tab" />
-      </>
+        {settingsChanged && (
+          <ToastMessage
+            variant="small"
+            text="To get accurate data we need to reload all open tabs. Please click
+        on Reload to reload all open tabs."
+            onClick={handleSettingsChange}
+          />
+        )}
+      </div>
     );
   }
 
@@ -109,7 +130,7 @@ const App: React.FC = () => {
     (cookieStats?.firstParty.total === 0 && cookieStats?.thirdParty.total === 0)
   ) {
     return (
-      <>
+      <div className="w-full h-full flex justify-center items-center flex-col z-1">
         <ToggleSwitch
           onLabel={cdpLabel}
           additionalStyles="top-2 left-2 absolute"
@@ -120,13 +141,21 @@ const App: React.FC = () => {
         <p className="text-chart-label text-xs">
           Please try reloading the page
         </p>
-      </>
+        {settingsChanged && (
+          <ToastMessage
+            variant="small"
+            text="To get accurate data we need to reload all open tabs. Please click
+        on Reload to reload all open tabs."
+            onClick={handleSettingsChange}
+          />
+        )}
+      </div>
     );
   }
   const statsComponents = prepareCookieStatsComponents(cookieStats);
 
   return (
-    <>
+    <div className="w-full h-full flex justify-center items-center flex-col z-1">
       <ToggleSwitch
         onLabel={cdpLabel}
         additionalStyles="top-2 left-2 absolute"
@@ -157,7 +186,15 @@ const App: React.FC = () => {
           {'Inspect cookies in the "Privacy Sandbox" panel of DevTools'}
         </p>
       </div>
-    </>
+      {settingsChanged && (
+        <ToastMessage
+          variant="small"
+          text="To get accurate data we need to reload all open tabs. Please click
+        on Reload to reload all open tabs."
+          onClick={handleSettingsChange}
+        />
+      )}
+    </div>
   );
 };
 

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -79,7 +79,7 @@ const App: React.FC = () => {
         {settingsChanged && (
           <ToastMessage
             additionalStyles="pb-2 text-xs"
-            text="To get accurate data we need to reload all open tabs"
+            text="To get accurate data we need to reload all open tabs."
             variant="small"
             buttonText="Reload"
             onClick={handleSettingsChange}
@@ -118,7 +118,7 @@ const App: React.FC = () => {
         {settingsChanged && (
           <ToastMessage
             additionalStyles="pb-2 text-xs"
-            text="To get accurate data we need to reload all open tabs"
+            text="To get accurate data we need to reload all open tabs."
             onClick={handleSettingsChange}
             variant="small"
             buttonText="Reload"
@@ -148,7 +148,7 @@ const App: React.FC = () => {
         {settingsChanged && (
           <ToastMessage
             additionalStyles="pb-2 text-xs"
-            text="To get accurate data we need to reload all open tabs"
+            text="To get accurate data we need to reload all open tabs."
             variant="small"
             buttonText="Reload"
             onClick={handleSettingsChange}
@@ -195,7 +195,7 @@ const App: React.FC = () => {
       {settingsChanged && (
         <ToastMessage
           additionalStyles="pb-2 text-xs"
-          text="To get accurate data we need to reload all open tabs"
+          text="To get accurate data we need to reload all open tabs."
           variant="small"
           buttonText="Reload"
           onClick={handleSettingsChange}

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -21,8 +21,8 @@ import React from 'react';
 import {
   Button,
   CirclePieChart,
-  InfoIcon,
   ProgressBar,
+  ToastMessage,
   ToggleSwitch,
   prepareCookieStatsComponents,
 } from '@ps-analysis-tool/design-system';
@@ -77,19 +77,14 @@ const App: React.FC = () => {
           Its emptier than a cookie jar after a midnight snack! 🌌
         </p>
         {settingsChanged && (
-          <div className="flex flex-row gap-x-1.5 top-2 right-2 absolute items-center">
-            <Button
-              variant="small"
-              text="Reload Tabs"
-              onClick={handleSettingsChange}
-            />
-            <span
-              title="To get accurate data we need to reload all open tabs. Please click
-        on Reload to reload all open tabs."
-            >
-              <InfoIcon />
-            </span>
-          </div>
+          <ToastMessage
+            additionalStyles="pb-2 text-xs"
+            text="To get accurate data we need to reload all open tabs"
+            variant="small"
+            buttonText="Reload"
+            onClick={handleSettingsChange}
+            textAdditionalStyles="pl-4"
+          />
         )}
       </div>
     );
@@ -121,19 +116,14 @@ const App: React.FC = () => {
         />
         <Button onClick={changeListeningToThisTab} text="Analyze this tab" />
         {settingsChanged && (
-          <div className="flex flex-row gap-x-1.5 top-2 right-2 absolute items-center">
-            <Button
-              variant="small"
-              text="Reload Tabs"
-              onClick={handleSettingsChange}
-            />
-            <span
-              title="To get accurate data we need to reload all open tabs. Please click
-        on Reload to reload all open tabs."
-            >
-              <InfoIcon />
-            </span>
-          </div>
+          <ToastMessage
+            additionalStyles="pb-2 text-xs"
+            text="To get accurate data we need to reload all open tabs"
+            onClick={handleSettingsChange}
+            variant="small"
+            buttonText="Reload"
+            textAdditionalStyles="pl-4"
+          />
         )}
       </div>
     );
@@ -156,19 +146,14 @@ const App: React.FC = () => {
           Please try reloading the page
         </p>
         {settingsChanged && (
-          <div className="flex flex-row gap-x-1.5 top-2 right-2 absolute items-center">
-            <Button
-              variant="small"
-              text="Reload Tabs"
-              onClick={handleSettingsChange}
-            />
-            <span
-              title="To get accurate data we need to reload all open tabs. Please click
-        on Reload to reload all open tabs."
-            >
-              <InfoIcon />
-            </span>
-          </div>
+          <ToastMessage
+            additionalStyles="pb-2 text-xs"
+            text="To get accurate data we need to reload all open tabs"
+            variant="small"
+            buttonText="Reload"
+            onClick={handleSettingsChange}
+            textAdditionalStyles="pl-4"
+          />
         )}
       </div>
     );
@@ -208,19 +193,14 @@ const App: React.FC = () => {
         </p>
       </div>
       {settingsChanged && (
-        <div className="flex flex-row gap-x-1.5 top-2 right-2 absolute items-center">
-          <Button
-            variant="small"
-            text="Reload Tabs"
-            onClick={handleSettingsChange}
-          />
-          <span
-            title="To get accurate data we need to reload all open tabs. Please click
-        on Reload to reload all open tabs."
-          >
-            <InfoIcon />
-          </span>
-        </div>
+        <ToastMessage
+          additionalStyles="pb-2 text-xs"
+          text="To get accurate data we need to reload all open tabs"
+          variant="small"
+          buttonText="Reload"
+          onClick={handleSettingsChange}
+          textAdditionalStyles="pl-4"
+        />
       )}
     </div>
   );

--- a/packages/extension/src/view/popup/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/popup/stateProviders/syncCookieStore/index.tsx
@@ -137,12 +137,6 @@ export const Provider = ({ children }: PropsWithChildren) => {
   }, 100);
 
   const _setUsingCDP = useCallback((newValue: boolean) => {
-    chrome.runtime.sendMessage({
-      type: 'Popup::ServiceWorker::CHANGE_CDP_SETTING',
-      payload: {
-        isUsingCDP: newValue,
-      },
-    });
     setIsUsingCDP(newValue);
   }, []);
 
@@ -215,10 +209,18 @@ export const Provider = ({ children }: PropsWithChildren) => {
 
   const handleSettingsChange = useCallback(async () => {
     if (settingsChanged) {
+      const newProcessingMode = localStorage.getItem('allowedNumberOfTabs');
+      const newCDPMode = localStorage.getItem('isUsingCDP');
       await chrome.runtime.sendMessage({
-        type: 'DevTools::ServiceWorker::RELOAD_ALL_TABS',
+        type: 'Popup::ServiceWorker::RELOAD_ALL_TABS',
+        payload: {
+          allowedNumberOfTabs: newProcessingMode,
+          isUsingCDP: newCDPMode,
+        },
       });
-      localStorage.setItem('settingsChanged', 'false');
+      localStorage.removeItem('settingsChanged');
+      localStorage.removeItem('isUsingCDP');
+      localStorage.removeItem('allowedNumberOfTabs');
       setSettingsChanged(false);
     }
   }, [settingsChanged]);
@@ -274,7 +276,6 @@ export const Provider = ({ children }: PropsWithChildren) => {
       }
 
       if (message.type === 'ServiceWorker::TABS_RELOADED') {
-        localStorage.setItem('settingsChanged', 'false');
         setSettingsChanged(false);
       }
     };
@@ -291,12 +292,10 @@ export const Provider = ({ children }: PropsWithChildren) => {
 
     if (Object.keys(extensionStorage).includes('allowedNumberOfTabs')) {
       setAllowedNumberOfTabs(extensionStorage?.allowedNumberOfTabs);
-      localStorage.setItem('settingsChanged', 'true');
       setSettingsChanged(true);
     }
     if (Object.keys(extensionStorage).includes('isUsingCDP')) {
       setIsUsingCDP(extensionStorage?.isUsingCDP);
-      localStorage.setItem('settingsChanged', 'true');
       setSettingsChanged(true);
     }
   }, []);

--- a/packages/extension/src/view/popup/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/popup/stateProviders/syncCookieStore/index.tsx
@@ -246,6 +246,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
         Object.keys(changes.allowedNumberOfTabs).includes('newValue')
       ) {
         setAllowedNumberOfTabs(changes?.allowedNumberOfTabs?.newValue);
+        setSettingsChanged(true);
       }
 
       if (
@@ -253,6 +254,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
         Object.keys(changes.isUsingCDP).includes('newValue')
       ) {
         setIsUsingCDP(changes?.isUsingCDP?.newValue);
+        setSettingsChanged(true);
       }
     },
     []

--- a/packages/extension/src/view/popup/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/popup/stateProviders/syncCookieStore/index.tsx
@@ -146,27 +146,30 @@ export const Provider = ({ children }: PropsWithChildren) => {
 
   const intitialSync = useCallback(async () => {
     const sessionStorage = await chrome.storage.session.get();
+    let settingsStoreSet = false;
 
     if (Object.keys(sessionStorage).includes('pendingReload')) {
       setSettingsChanged(sessionStorage?.pendingReload);
+      settingsStoreSet = true;
+    }
+    const currentSettings = await chrome.storage.sync.get();
 
-      if (Object.keys(sessionStorage).includes('allowedNumberOfTabs')) {
-        setAllowedNumberOfTabs(sessionStorage?.allowedNumberOfTabs);
-      }
-
-      if (Object.keys(sessionStorage).includes('isUsingCDP')) {
-        setIsUsingCDP(sessionStorage?.isUsingCDP);
-      }
+    if (
+      settingsStoreSet &&
+      Object.keys(sessionStorage).includes('allowedNumberOfTabs')
+    ) {
+      setAllowedNumberOfTabs(sessionStorage?.allowedNumberOfTabs);
     } else {
-      const currentSettings = await chrome.storage.sync.get();
+      setAllowedNumberOfTabs(currentSettings?.allowedNumberOfTabs);
+    }
 
-      if (Object.keys(currentSettings).includes('allowedNumberOfTabs')) {
-        setAllowedNumberOfTabs(currentSettings?.allowedNumberOfTabs);
-      }
-
-      if (Object.keys(currentSettings).includes('isUsingCDP')) {
-        setIsUsingCDP(currentSettings?.isUsingCDP);
-      }
+    if (
+      settingsStoreSet &&
+      Object.keys(sessionStorage).includes('isUsingCDP')
+    ) {
+      setIsUsingCDP(sessionStorage?.isUsingCDP);
+    } else {
+      setIsUsingCDP(currentSettings?.isUsingCDP);
     }
 
     const tab = await getCurrentTab();

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -66,7 +66,7 @@ module.exports = {
       ...defaultTheme.fontSize,
       xxxs: '0.625rem', // 10px - Only for edge cases
       xxl: '1.375rem', // 22px
-      xs: '0.9375rem',
+      xsm: '0.9375rem',
       xxs: '0.8125rem',
     },
     fontWeight: {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -55,6 +55,10 @@ module.exports = {
         xs: '480px',
       },
     },
+    borderRadius: {
+      ...defaultTheme.borderRadius,
+      xs: '3px',
+    },
     fontFamily: {
       ...defaultTheme.fontFamily,
     },
@@ -62,6 +66,8 @@ module.exports = {
       ...defaultTheme.fontSize,
       xxxs: '0.625rem', // 10px - Only for edge cases
       xxl: '1.375rem', // 22px
+      xs: '0.9375rem',
+      xxs: '0.8125rem',
     },
     fontWeight: {
       ...defaultTheme.fontWeight,

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -49,6 +49,11 @@ module.exports = {
       animation: {
         'horizontal-spinner': 'horizontal-spinner-keyframes 2s linear infinite',
       },
+      screens: {
+        ...defaultTheme.screens,
+        xxs: '360px',
+        xs: '480px',
+      },
     },
     fontFamily: {
       ...defaultTheme.fontFamily,

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -38,6 +38,7 @@ module.exports = {
       boxShadow: {
         '3xl':
           '0px 38px 90px 0px rgba(0, 0, 0, 0.25), 0px 0px 2px 0px rgba(0, 0, 0, 0.05), 0px 0px 1px 0px rgba(0, 0, 0, 0.60)',
+        xxs: '0 -2px 2px 0 rgba(0, 0, 0, 0.1)',
       },
       keyframes: {
         'horizontal-spinner-keyframes': {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -133,6 +133,9 @@ module.exports = {
     backgroundColor: {
       ...colors,
       primary: '#FFF',
+      'google-blue': '#8AB4F8',
+      'smurf-blue': '#1967D2',
+      beteleguese: '#4285F4',
       'toggle-on': '#5CC971',
       'flagged-row-odd-dark': '#5e5108',
       'flagged-row-even-dark': '#796700',


### PR DESCRIPTION
## Description
This PR aims to remove the automatic reload of tabs if any extension setting is changed. Instead, a message will be shown to the user to click on reload all the tabs for settings to take effect and to get accurate data. This prevents the user from reloading the tab and losing any data.

## Relevant Technical Choices
- Session storage is used to store the data temporarily.
- Until the page is reloaded from our mechanism, the PSAT shows the settings from session storage.
- Once the page is reloaded with our mechanism extension settings storage is set and the PSAT takes value from the extension storage.

## Testing Instructions
- Clone this branch and in the terminal run `npm start`.
- Go to any site and open the settings page. Switch any settings, and you should see a toast message at the bottom.
- You should see the same message in the popup.

## Screenshot/Screencast

https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/59614577/7138ae34-734e-4e8b-8507-4469272fc5dd


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).
