### PR TITLE
Fix: Library detection miscellaneous QA issues

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -30,6 +30,7 @@ export { default as cookieIssueDetails } from './data/cookieExclusionAndWarningR
 export { default as parseResponseReceivedExtraInfo } from './utils/parseResponseReceivedExtraInfo';
 export { default as parseRequestWillBeSentExtraInfo } from './utils/parseRequestWillBeSentExtraInfo';
 export { default as getDomainFromUrl } from './utils/getDomainFromUrl';
+export { default as extractUrl } from './utils/extractUrl';
 export { default as noop } from './utils/noop';
 export { default as getDevToolWorker } from './worker/devToolWorker';
 export { default as executeTaskInDevToolWorker } from './worker/executeTaskInDevToolWorker';

--- a/packages/common/src/utils/extractUrl.ts
+++ b/packages/common/src/utils/extractUrl.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies.
+ */
+import { parse } from 'tldts';
+
+/**
+ * Extracts the URL from the given string.
+ * @param url - The string containing the URL.
+ * @returns The extracted URL or an empty string if the URL cannot be parsed.
+ */
+export default function extractUrl(url: string) {
+  const parsedUrl = parse(url);
+  return parsedUrl || '';
+}

--- a/packages/library-detection/src/components/libraryDetection/index.tsx
+++ b/packages/library-detection/src/components/libraryDetection/index.tsx
@@ -74,7 +74,7 @@ const LibraryDetection = memo(function LibraryDetection() {
 
           const parsedUrl = extractUrl(tabDomain);
 
-          const parsedTabDomain = parsedUrl?.hostname;
+          const parsedTabDomain = parsedUrl?.domain;
 
           const isCurrentDomainExceptionDomain =
             config?.exceptions?.[parsedTabDomain as string] &&
@@ -84,7 +84,7 @@ const LibraryDetection = memo(function LibraryDetection() {
           if (isCurrentDomainExceptionDomain) {
             matches = filterMatchesBasedOnExceptions(
               tabDomain,
-              config, //TODO: revist this after testing
+              config?.exceptions, //TODO: revist this after testing
               matches
             );
           }

--- a/packages/library-detection/src/components/libraryDetection/index.tsx
+++ b/packages/library-detection/src/components/libraryDetection/index.tsx
@@ -38,13 +38,13 @@ import { extractUrl } from '@ps-analysis-tool/common';
 const LibraryDetection = memo(function LibraryDetection() {
   useLibraryDetection();
 
-  const { libraryMatches, showLoader, tabDomain } = useLibraryDetectionContext(
-    ({ state }) => ({
+  const { libraryMatches, showLoader, tabDomain, isCurrentTabLoading } =
+    useLibraryDetectionContext(({ state }) => ({
       libraryMatches: state.libraryMatches,
       showLoader: state.showLoader,
       tabDomain: state.tabDomain,
-    })
-  );
+      isCurrentTabLoading: state.isCurrentTabLoading,
+    }));
 
   const names = Object.keys(libraryMatches);
 
@@ -108,7 +108,9 @@ const LibraryDetection = memo(function LibraryDetection() {
         <>
           <ProgressBar additionalStyles="w-1/3 mx-auto h-full" />
           <p className="text-center dark:text-bright-gray">
-            Checking libraries for any known breakages on the page..
+            {isCurrentTabLoading
+              ? 'Waiting for the page to load..'
+              : 'Checking libraries for any known breakages on the page..'}
           </p>
         </>
       ) : (

--- a/packages/library-detection/src/components/libraryDetection/index.tsx
+++ b/packages/library-detection/src/components/libraryDetection/index.tsx
@@ -28,7 +28,12 @@ import {
  */
 import LIBRARIES from '../../config';
 import type { LibraryData, DetectedSignature } from '../../types';
-import { useLibraryDetection, useLibraryDetectionContext } from '../../core';
+import {
+  filterMatchesBasedOnExceptions,
+  useLibraryDetection,
+  useLibraryDetectionContext,
+} from '../../core';
+import { extractUrl } from '@ps-analysis-tool/common';
 
 const LibraryDetection = memo(function LibraryDetection() {
   useLibraryDetection();
@@ -66,14 +71,21 @@ const LibraryDetection = memo(function LibraryDetection() {
             libraryMatches && libraryMatches[config.name as keyof LibraryData]
               ? libraryMatches[config.name as keyof LibraryData]?.matches
               : [];
+
+          const parsedUrl = extractUrl(tabDomain);
+
+          const parsedTabDomain = parsedUrl?.hostname;
+
           const isCurrentDomainExceptionDomain =
-            config?.exceptions?.[tabDomain] &&
-            config?.exceptions?.[tabDomain]?.length > 0;
+            config?.exceptions?.[parsedTabDomain as string] &&
+            config?.exceptions?.[parsedTabDomain as string]?.signatures
+              ?.length > 0;
 
           if (isCurrentDomainExceptionDomain) {
-            matches = matches.filter(
-              (match) =>
-                !config.exceptions?.[tabDomain].includes(match.feature.text)
+            matches = filterMatchesBasedOnExceptions(
+              tabDomain,
+              config, //TODO: revist this after testing
+              matches
             );
           }
 

--- a/packages/library-detection/src/components/libraryDetection/index.tsx
+++ b/packages/library-detection/src/components/libraryDetection/index.tsx
@@ -33,10 +33,11 @@ import { useLibraryDetection, useLibraryDetectionContext } from '../../core';
 const LibraryDetection = memo(function LibraryDetection() {
   useLibraryDetection();
 
-  const { libraryMatches, showLoader } = useLibraryDetectionContext(
+  const { libraryMatches, showLoader, tabDomain } = useLibraryDetectionContext(
     ({ state }) => ({
       libraryMatches: state.libraryMatches,
       showLoader: state.showLoader,
+      tabDomain: state.tabDomain,
     })
   );
 
@@ -61,10 +62,20 @@ const LibraryDetection = memo(function LibraryDetection() {
           const Component = config.component as React.FC<{
             matches: DetectedSignature[];
           }>;
-          const matches =
+          let matches =
             libraryMatches && libraryMatches[config.name as keyof LibraryData]
               ? libraryMatches[config.name as keyof LibraryData]?.matches
               : [];
+          const isCurrentDomainExceptionDomain =
+            config?.exceptions?.[tabDomain] &&
+            config?.exceptions?.[tabDomain]?.length > 0;
+
+          if (isCurrentDomainExceptionDomain) {
+            matches = matches.filter(
+              (match) =>
+                !config.exceptions?.[tabDomain].includes(match.feature.text)
+            );
+          }
 
           return <Component key={config.name} matches={matches} />;
         })}

--- a/packages/library-detection/src/config.ts
+++ b/packages/library-detection/src/config.ts
@@ -26,6 +26,8 @@ import {
   GSI_HELP_URL,
   GIS_DOMAINS_TO_SKIP,
   GSI_DOMAINS_TO_SKIP,
+  GSIv2_EXCEPTIONS,
+  GIS_EXCEPTIONS,
 } from './libraries';
 
 const LIBRARIES = [
@@ -36,6 +38,7 @@ const LIBRARIES = [
       strongMatches: GSI_V2_SIGNATURE_STRONG_MATCHES,
       weakMatches: GSI_V2_SIGNATURE_WEAK_MATCHES,
     },
+    exceptions: GSIv2_EXCEPTIONS,
     domainsToSkip: GSI_DOMAINS_TO_SKIP,
     helpUrl: GSI_HELP_URL,
   },
@@ -46,6 +49,7 @@ const LIBRARIES = [
       strongMatches: [],
       weakMatches: GIS_SIGNATURE_WEAK_MATCHES,
     },
+    exceptions: GIS_EXCEPTIONS,
     domainsToSkip: GIS_DOMAINS_TO_SKIP,
     helpUrl: GIS_HELP_URL,
   },

--- a/packages/library-detection/src/core/filterMatchesBasedOnExceptions.ts
+++ b/packages/library-detection/src/core/filterMatchesBasedOnExceptions.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies.
+ */
+import { extractUrl } from '@ps-analysis-tool/common';
+/**
+ * Internal dependencies.
+ */
+
+import type { Config, DetectedSignature } from '../types';
+
+/**
+ * Filters the given matches based on the exceptions defined in the configuration.
+ * @param domain - The domain for which the matches are filtered.
+ * @param config - The configuration object containing the exceptions.
+ * @param matches - The array of detected signatures to be filtered.
+ * @returns The filtered array of matches.
+ */
+const filterMatchesBasedOnExceptions = (
+  domain: string,
+  config: Config,
+  matches: DetectedSignature[]
+) => {
+  const parsedUrl = extractUrl(domain);
+  const parsedTabDomain = parsedUrl?.hostname;
+  const parsedSubDomain = parsedUrl?.subdomain;
+  let filteredMatches = { ...matches };
+
+  const isCurrentDomainExceptionDomain =
+    config?.exceptions?.[parsedTabDomain as string] &&
+    config?.exceptions?.[parsedTabDomain as string]?.signatures?.length > 0;
+
+  if (
+    (isCurrentDomainExceptionDomain && !parsedSubDomain) ||
+    (isCurrentDomainExceptionDomain &&
+      parsedSubDomain &&
+      config.exceptions?.[parsedTabDomain as string]?.subDomains.includes(
+        parsedSubDomain
+      ))
+  ) {
+    filteredMatches = matches.filter(
+      (match: DetectedSignature) =>
+        !config.exceptions?.[parsedTabDomain as string]?.signatures?.includes(
+          match.feature.text
+        )
+    );
+  }
+
+  return filteredMatches;
+};
+
+export default filterMatchesBasedOnExceptions;

--- a/packages/library-detection/src/core/filterMatchesBasedOnExceptions.ts
+++ b/packages/library-detection/src/core/filterMatchesBasedOnExceptions.ts
@@ -22,40 +22,40 @@ import { extractUrl } from '@ps-analysis-tool/common';
  * Internal dependencies.
  */
 
-import type { Config, DetectedSignature } from '../types';
+import type { DetectedSignature, ExceptionUrls } from '../types';
 
 /**
  * Filters the given matches based on the exceptions defined in the configuration.
  * @param domain - The domain for which the matches are filtered.
- * @param config - The configuration object containing the exceptions.
+ * @param exceptions - The configuration object containing the exceptions.
  * @param matches - The array of detected signatures to be filtered.
  * @returns The filtered array of matches.
  */
 const filterMatchesBasedOnExceptions = (
   domain: string,
-  config: Config,
+  exceptions: ExceptionUrls,
   matches: DetectedSignature[]
 ) => {
   const parsedUrl = extractUrl(domain);
-  const parsedTabDomain = parsedUrl?.hostname;
+  const parsedTabDomain = parsedUrl?.domain;
   const parsedSubDomain = parsedUrl?.subdomain;
-  let filteredMatches = { ...matches };
+  let filteredMatches: DetectedSignature[] = [...matches];
 
   const isCurrentDomainExceptionDomain =
-    config?.exceptions?.[parsedTabDomain as string] &&
-    config?.exceptions?.[parsedTabDomain as string]?.signatures?.length > 0;
+    exceptions?.[parsedTabDomain as string] &&
+    exceptions?.[parsedTabDomain as string]?.signatures?.length > 0;
 
   if (
     (isCurrentDomainExceptionDomain && !parsedSubDomain) ||
     (isCurrentDomainExceptionDomain &&
       parsedSubDomain &&
-      config.exceptions?.[parsedTabDomain as string]?.subDomains.includes(
+      exceptions?.[parsedTabDomain as string]?.subDomains.includes(
         parsedSubDomain
       ))
   ) {
     filteredMatches = matches.filter(
       (match: DetectedSignature) =>
-        !config.exceptions?.[parsedTabDomain as string]?.signatures?.includes(
+        !exceptions?.[parsedTabDomain as string]?.signatures?.includes(
           match.feature.text
         )
     );

--- a/packages/library-detection/src/core/hooks/useLibraryDetection.ts
+++ b/packages/library-detection/src/core/hooks/useLibraryDetection.ts
@@ -33,7 +33,7 @@ import { sumUpDetectionResults, useLibraryDetectionContext } from '..';
 import type { LibraryData, ResourceTreeItem } from '../../types';
 
 // The delay after the page load, because some scripts arrive right after the page load.
-const LOADING_DELAY = 4000;
+const LOADING_DELAY = 2000;
 
 /**
  * Custom hook that handles the library detection logic.

--- a/packages/library-detection/src/core/index.ts
+++ b/packages/library-detection/src/core/index.ts
@@ -20,4 +20,5 @@ export { default as sumUpDetectionResults } from './sumUpDetectionResults';
 export { default as filterResources } from './filterResources';
 export { default as getInlineScriptContent } from './getInlineScriptContent';
 export { default as useLibraryDetection } from './hooks/useLibraryDetection';
+export { default as filterMatchesBasedOnExceptions } from './filterMatchesBasedOnExceptions';
 export * from './stateProvider';

--- a/packages/library-detection/src/core/tests/filterMatchesBasedOnExceptions.ts
+++ b/packages/library-detection/src/core/tests/filterMatchesBasedOnExceptions.ts
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies.
+ */
+import filterMatchesBasedOnExceptions from '../filterMatchesBasedOnExceptions';
+
+describe('Should filter signatures given in exception for the given domain only', () => {
+  it('Should filter only the given signature from the given main domain', () => {
+    const exceptions = {
+      'linkedin.com': {
+        signatures: ['opt_out_or_no_session'],
+        subDomains: [],
+      },
+    };
+    const domain = '.linkedin.com';
+
+    const matches = [
+      {
+        feature: {
+          type: 'link',
+          text: 'GoogleAuth',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+      {
+        feature: {
+          type: 'link',
+          text: 'opt_out_or_no_session',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+    ];
+
+    const expectedResult = [
+      {
+        feature: {
+          type: 'link',
+          text: 'GoogleAuth',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+    ];
+
+    expect(filterMatchesBasedOnExceptions(domain, exceptions, matches)).toEqual(
+      expectedResult
+    );
+  });
+
+  it("Shouldn't filter from the subdomain ", () => {
+    const exceptions = {
+      'linkedin.com': {
+        signatures: ['opt_out_or_no_session'],
+        subDomains: [],
+      },
+    };
+    const domain = 'in.linkedin.com';
+
+    const matches = [
+      {
+        feature: {
+          type: 'link',
+          text: 'GoogleAuth',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+      {
+        feature: {
+          type: 'link',
+          text: 'opt_out_or_no_session',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+    ];
+
+    expect(filterMatchesBasedOnExceptions(domain, exceptions, matches)).toEqual(
+      matches
+    );
+  });
+
+  it('should filter from subdomain if subdomain is given in exception ', () => {
+    const exceptions = {
+      'linkedin.com': {
+        signatures: ['opt_out_or_no_session'],
+        subDomains: ['in'],
+      },
+    };
+    const domain = 'in.linkedin.com';
+
+    const matches = [
+      {
+        feature: {
+          type: 'link',
+          text: 'GoogleAuth',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+      {
+        feature: {
+          type: 'link',
+          text: 'opt_out_or_no_session',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+    ];
+
+    const expectedResult = [
+      {
+        feature: {
+          type: 'link',
+          text: 'GoogleAuth',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+    ];
+
+    expect(filterMatchesBasedOnExceptions(domain, exceptions, matches)).toEqual(
+      expectedResult
+    );
+  });
+
+  it('should filter all signatures from subdomain if subdomain is given in exception ', () => {
+    const exceptions = {
+      'linkedin.com': {
+        signatures: ['opt_out_or_no_session', 'GoogleAuth'],
+        subDomains: ['in'],
+      },
+    };
+    const domain = 'in.linkedin.com';
+
+    const matches = [
+      {
+        feature: {
+          type: 'link',
+          text: 'GoogleAuth',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+      {
+        feature: {
+          type: 'link',
+          text: 'opt_out_or_no_session',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+    ];
+
+    const expectedResult = [];
+
+    expect(filterMatchesBasedOnExceptions(domain, exceptions, matches)).toEqual(
+      expectedResult
+    );
+  });
+
+  it('should filter nothing if its not specified in the exception ', () => {
+    const exceptions = {};
+    const domain = 'in.linkedin.com';
+
+    const matches = [
+      {
+        feature: {
+          type: 'link',
+          text: 'GoogleAuth',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+      {
+        feature: {
+          type: 'link',
+          text: 'opt_out_or_no_session',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+    ];
+
+    expect(filterMatchesBasedOnExceptions(domain, exceptions, matches)).toEqual(
+      matches
+    );
+  });
+
+  it('should from main domain even if subDomain is present and not given as input ', () => {
+    const exceptions = {
+      'linkedin.com': {
+        signatures: ['opt_out_or_no_session', 'GoogleAuth'],
+        subDomains: ['in'],
+      },
+    };
+    const domain = 'linkedin.com';
+
+    const matches = [
+      {
+        feature: {
+          type: 'link',
+          text: 'GoogleAuth',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+      {
+        feature: {
+          type: 'link',
+          text: 'opt_out_or_no_session',
+          url: 'https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in',
+        },
+      },
+    ];
+
+    const expectedResult = [];
+
+    expect(filterMatchesBasedOnExceptions(domain, exceptions, matches)).toEqual(
+      expectedResult
+    );
+  });
+});

--- a/packages/library-detection/src/libraries/gis/constants.ts
+++ b/packages/library-detection/src/libraries/gis/constants.ts
@@ -13,6 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { ExceptionUrls } from '../../types';
+
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 export const GIS_SIGNATURE_WEAK_MATCHES = [
   {
     signature: 'google.accounts.id.prompt(', // XXX add check for optional callback parameter
@@ -51,11 +68,9 @@ export const GIS_HELP_URL =
 
 export const GIS_DOMAINS_TO_SKIP = ['accounts.google.com', 'gstatic.com'];
 
-export const GIS_EXCEPTIONS: {
-  [key: string]: { signatures: string[]; subDomains: string[] };
-} = {
+export const GIS_EXCEPTIONS: ExceptionUrls = {
   'cnn.com': {
     signatures: ['isDisplayed('],
-    subDomains: ['edition.cnn.com', 'www.cnn.com', 'cnn.com'],
+    subDomains: ['edition'],
   },
 };

--- a/packages/library-detection/src/libraries/gis/constants.ts
+++ b/packages/library-detection/src/libraries/gis/constants.ts
@@ -50,3 +50,13 @@ export const GIS_HELP_URL =
   'https://developers.google.com/identity/gsi/web/guides/migration';
 
 export const GIS_DOMAINS_TO_SKIP = ['accounts.google.com', 'gstatic.com'];
+
+// For EXCEPTIONS www is considered as a subdomain. For example, www.cnn.com is considered as a subdomain of cnn.com, if its required please add it to the exceptions list.
+export const GIS_EXCEPTIONS: { [key: string]: string[] } = {
+  'cnn.com': ['isDisplayed('],
+  'www.cnn.com': ['isDisplayed('],
+  'edition.cnn.com': ['isDisplayed('],
+  'www.edition.cnn.com': ['isDisplayed('],
+};
+
+export const GSIv2_EXCEPTIONS: { [key: string]: string[] } = {};

--- a/packages/library-detection/src/libraries/gis/constants.ts
+++ b/packages/library-detection/src/libraries/gis/constants.ts
@@ -51,12 +51,11 @@ export const GIS_HELP_URL =
 
 export const GIS_DOMAINS_TO_SKIP = ['accounts.google.com', 'gstatic.com'];
 
-// For EXCEPTIONS www is considered as a subdomain. For example, www.cnn.com is considered as a subdomain of cnn.com, if its required please add it to the exceptions list.
-export const GIS_EXCEPTIONS: { [key: string]: string[] } = {
-  'cnn.com': ['isDisplayed('],
-  'www.cnn.com': ['isDisplayed('],
-  'edition.cnn.com': ['isDisplayed('],
-  'www.edition.cnn.com': ['isDisplayed('],
+export const GIS_EXCEPTIONS: {
+  [key: string]: { signatures: string[]; subDomains: string[] };
+} = {
+  'cnn.com': {
+    signatures: ['isDisplayed('],
+    subDomains: ['edition.cnn.com', 'www.cnn.com', 'cnn.com'],
+  },
 };
-
-export const GSIv2_EXCEPTIONS: { [key: string]: string[] } = {};

--- a/packages/library-detection/src/libraries/gsi/constants.ts
+++ b/packages/library-detection/src/libraries/gsi/constants.ts
@@ -13,6 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { ExceptionUrls } from '../../types';
+
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 export const GSI_V2_SIGNATURE_WEAK_MATCHES = [
   /* These signatures indicate use of OpenID Connect ID token for user sign-in,
    * link to the user authentication migration guide for user sign-in. */
@@ -164,3 +181,5 @@ export const GSI_HELP_URL =
   'https://developers.google.com/identity/gsi/web/guides/migration';
 
 export const GSI_DOMAINS_TO_SKIP = ['accounts.google.com', 'gstatic.com'];
+
+export const GSIv2_EXCEPTIONS: ExceptionUrls = {};

--- a/packages/library-detection/src/types.ts
+++ b/packages/library-detection/src/types.ts
@@ -36,6 +36,11 @@ export type Config = {
   signatures: SignaturesConfig[];
   domainsToSkip: string[];
   helpUrl: string;
+  exceptions?: ExceptionUrls;
+};
+
+export type ExceptionUrls = {
+  [key: string]: { signatures: string[]; subDomains: string[] };
 };
 
 export type ScriptTagUnderCheck = {


### PR DESCRIPTION
## Description

1. It was suggested to reduce the loading delay of the known breakage section to 2 seconds. Additionally, the loader should display the message "Waiting for the page to load..." while the page is loading.
2. The issue was reported for false positive results on [cnn.com](http://cnn.com/). Sometimes it was observed that GIS feature `isDisplayed()` is being shown on [cnn.com](http://cnn.com/) under the known-breakages section.

## Relevant Technical Choices

A new configuration with the name `exception` has been added, which follows the following format:

```
{
  "domain": ["string"]
}
```


If a match is found, results corresponding to the specified domain name will be excluded from the detected results.

## Testing Instructions

This issue occurs infrequently. According to QA feedback, it primarily happens when the CDP is activated and a tab with the same URL is closed and then reopened.


## Screenshot/Screencast

![image](https://github.com/rtCamp/ps-analysis-tool-internal/assets/4833367/e713988a-300b-492d-ae99-4140589c8b74)


## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).


Fixes https://github.com/GoogleChromeLabs/ps-analysis-tool/issues/471#issuecomment-1926242443

Props: @manoj-makkuboy 