### PR TITLE
Fix: add conditional rendering in technology details panel

### DIFF
--- a/packages/cli-dashboard/src/components/siteReport/tabs/technologies/index.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/technologies/index.tsx
@@ -146,7 +146,7 @@ const Technologies = ({ selectedSite }: TechnologiesProps) => {
                 </p>
               </>
             )}
-            {selectedRow.name && (
+            {selectedRow.description && (
               <>
                 <p className="font-bold text-granite-gray dark:text-manatee mb-1">
                   Description

--- a/packages/cli-dashboard/src/components/siteReport/tabs/technologies/index.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/technologies/index.tsx
@@ -146,16 +146,14 @@ const Technologies = ({ selectedSite }: TechnologiesProps) => {
                 </p>
               </>
             )}
-            {selectedRow.description && (
-              <>
-                <p className="font-bold text-granite-gray dark:text-manatee mb-1">
-                  Description
-                </p>
-                <p className="text-outer-space-crayola dark:text-bright-gray">
-                  {selectedRow.description}
-                </p>
-              </>
-            )}
+            <>
+              <p className="font-bold text-granite-gray dark:text-manatee mb-1">
+                Description
+              </p>
+              <p className="text-outer-space-crayola dark:text-bright-gray">
+                {selectedRow?.description || 'No description available.'}
+              </p>
+            </>
           </div>
         ) : (
           <div className="h-full p-8 flex items-center">


### PR DESCRIPTION
## Description

Add a "No description available" text in technology table. 

## Screenshot/Screencast


<img width="1223" alt="Screenshot 2024-02-16 at 1 04 29 PM" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/53055971/ace0073a-2b61-4de4-aada-2fed707ed880">

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially Addresses #471
