### PR TITLE
Fix: keep service worker alive

### DIFF
--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -688,12 +688,6 @@ chrome.runtime.onMessage.addListener(async (request) => {
 chrome.windows.onCreated.addListener(async () => {
   const totalWindows = await chrome.windows.getAll();
 
-  // @see https://developer.chrome.com/blog/longer-esw-lifetimes#whats_changed
-  // Doing this to keep the service worker alive so that we dont loose any data and introduce any bug.
-  setInterval(() => {
-    chrome.storage.local.get();
-  }, 28000);
-
   // We do not want to clear content settings if a user has create one more window.
   if (totalWindows.length < 2) {
     chrome.contentSettings.cookies.clear({});

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -688,6 +688,12 @@ chrome.runtime.onMessage.addListener(async (request) => {
 chrome.windows.onCreated.addListener(async () => {
   const totalWindows = await chrome.windows.getAll();
 
+  // @see https://developer.chrome.com/blog/longer-esw-lifetimes#whats_changed
+  // Doing this to keep the service worker alive so that we dont loose any data and introduce any bug.
+  setInterval(() => {
+    chrome.storage.local.get();
+  }, 28000);
+
   // We do not want to clear content settings if a user has create one more window.
   if (totalWindows.length < 2) {
     chrome.contentSettings.cookies.clear({});

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -245,6 +245,12 @@ chrome.runtime.onStartup.addListener(async () => {
     syncCookieStore = new SynchnorousCookieStore();
   }
 
+  // @see https://developer.chrome.com/blog/longer-esw-lifetimes#whats_changed
+  // Doing this to keep the service worker alive so that we dont loose any data and introduce any bug.
+  setInterval(() => {
+    chrome.storage.local.get();
+  }, 28000);
+
   if (Object.keys(storage).includes('allowedNumberOfTabs')) {
     tabMode = storage.allowedNumberOfTabs;
   }

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -251,6 +251,17 @@ chrome.runtime.onStartup.addListener(async () => {
     chrome.storage.local.get();
   }, 28000);
 
+  // @todo Send tab data of the active tab only, also if sending only the difference would make it any faster.
+  setInterval(() => {
+    if (Object.keys(syncCookieStore?.tabsData ?? {}).length === 0) {
+      return;
+    }
+
+    Object.keys(syncCookieStore?.tabsData ?? {}).forEach((key) => {
+      syncCookieStore?.sendUpdatedDataToPopupAndDevTools(Number(key));
+    });
+  }, 1200);
+
   if (Object.keys(storage).includes('allowedNumberOfTabs')) {
     tabMode = storage.allowedNumberOfTabs;
   }


### PR DESCRIPTION
## Description
This PR aims to keep the service worker alive in case the profile with the extension is started.

## Relevant Technical Choices
- Add an interval for sending updated data from the service worker to the DevTools when re-opening a profile with the installed extension.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
Partially addresses #509 
