### PR TITLE
Fix: Process ccTLDs and update UI in RWS

### DIFF
--- a/packages/extension/src/view/devtools/components/siteBoundaries/relatedWebsiteSets/insights/index.tsx
+++ b/packages/extension/src/view/devtools/components/siteBoundaries/relatedWebsiteSets/insights/index.tsx
@@ -113,7 +113,16 @@ const Insights = () => {
                   {insightsData.isccTLD ? (
                     <p className="text-sm">
                       This site is a ccTLD of{' '}
-                      {insightsData.relatedWebsiteSet?.ccTLDParent}.
+                      <a
+                        href={insightsData.relatedWebsiteSet?.ccTLDParent}
+                        target="_blank"
+                        referrerPolicy="no-referrer"
+                        className="cursor-pointer hover:opacity-80 text-blue-500 underline dark:text-blue-400"
+                        rel="noreferrer"
+                      >
+                        {insightsData.relatedWebsiteSet?.ccTLDParent}
+                      </a>
+                      .
                     </p>
                   ) : (
                     <>

--- a/packages/extension/src/view/devtools/components/siteBoundaries/relatedWebsiteSets/insights/index.tsx
+++ b/packages/extension/src/view/devtools/components/siteBoundaries/relatedWebsiteSets/insights/index.tsx
@@ -110,18 +110,28 @@ const Insights = () => {
               </p>
               {!insightsData.primary ? (
                 <>
-                  {Object.entries(
-                    insightsData.relatedWebsiteSet?.rationaleBySite || {}
-                  )
-                    .filter(
-                      ([domain]) => getDomain(domain) === insightsData.domain
-                    )
-                    .map(([domain, value]) => (
-                      <p key={domain} className="text-sm">
-                        Rationale:{' '}
-                        <span className="underline">{value as string}</span>
-                      </p>
-                    ))}
+                  {insightsData.isccTLD ? (
+                    <p className="text-sm">
+                      This site is a ccTLD of{' '}
+                      {insightsData.relatedWebsiteSet?.ccTLDParent}.
+                    </p>
+                  ) : (
+                    <>
+                      {Object.entries(
+                        insightsData.relatedWebsiteSet?.rationaleBySite || {}
+                      )
+                        .filter(
+                          ([domain]) =>
+                            getDomain(domain) === insightsData.domain
+                        )
+                        .map(([domain, value]) => (
+                          <p key={domain} className="text-sm">
+                            Rationale:{' '}
+                            <span className="underline">{value as string}</span>
+                          </p>
+                        ))}
+                    </>
+                  )}
                 </>
               ) : (
                 <p>

--- a/packages/extension/src/view/devtools/components/siteBoundaries/relatedWebsiteSets/insights/utils/checkURLInRWS.ts
+++ b/packages/extension/src/view/devtools/components/siteBoundaries/relatedWebsiteSets/insights/utils/checkURLInRWS.ts
@@ -24,21 +24,23 @@ import { getDomain } from 'tldts';
  */
 import fetchRWSInfo from '../../../../../../../utils/fetchRWSInfo';
 import getInspectedTabDomain from './getInspectedTabDomain';
-import type { RelatedWebsiteSetType } from '../../../../../../../@types';
-import findRWSURLSets from '../../../../../../../utils/findRWSURLSets';
+import findRWSURLSets, {
+  type RWSSetOutputType,
+} from '../../../../../../../utils/findRWSURLSets';
 
 export type CheckURLInRWSOutputType = {
   isURLInRWS: boolean;
   primary?: boolean;
   domain?: string;
-  relatedWebsiteSet?: RelatedWebsiteSetType;
+  isccTLD?: boolean;
+  relatedWebsiteSet?: RWSSetOutputType;
 };
 
 const checkURLInRWS = async () => {
   const tabDomain = (await getInspectedTabDomain()) || '';
-  const rwsSets: RelatedWebsiteSetType[] = (await fetchRWSInfo()).sets || [];
+  const rwsSets: RWSSetOutputType[] = (await fetchRWSInfo()).sets || [];
 
-  const urlInRWS: RelatedWebsiteSetType | undefined = findRWSURLSets(
+  const urlInRWS: RWSSetOutputType | undefined = findRWSURLSets(
     tabDomain,
     rwsSets
   );
@@ -53,6 +55,15 @@ const checkURLInRWS = async () => {
     return {
       isURLInRWS: true,
       primary: true,
+      domain: tabDomain,
+      relatedWebsiteSet: urlInRWS,
+    } as CheckURLInRWSOutputType;
+  }
+
+  if (urlInRWS.ccTLDParent) {
+    return {
+      isURLInRWS: true,
+      isccTLD: true,
       domain: tabDomain,
       relatedWebsiteSet: urlInRWS,
     } as CheckURLInRWSOutputType;


### PR DESCRIPTION
## Description
This PR fixes the issue where ccTLDs were not processed while scanning through the RWS set.
- It updates the logic to retrieve the ccTLDs, scan them, and return the required data to the component.
- Adds UI to show the parent of the ccTLD on the RWS landing page's insight section.
<!-- What do we want to achieve with this PR? -->


<!-- Please describe your changes. -->


<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->


<!-- Any other information. -->

## Screenshot/Screencast
<img width="676" alt="Screenshot 2024-02-23 at 9 34 33 PM" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/fc7db087-2432-4c59-a249-bbbf4a3aec6b">

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #525 
