### PR TITLE
Fix: Show unmapped cookies from CDP in `Unknown Frames`

### DIFF
--- a/packages/common/src/constants/index.ts
+++ b/packages/common/src/constants/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 export const UNKNOWN_FRAME_KEY = 'Unknown Frames';
-export const UNMAPPED_FRAME_KEY = 'Unmapped Frames';
+export const UNMAPPED_COOKIE_KEY = 'Unmapped Cookies';

--- a/packages/common/src/constants/index.ts
+++ b/packages/common/src/constants/index.ts
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 export const UNKNOWN_FRAME_KEY = 'Unknown Frames';
+export const ORPHANED_COOKIE_KEY = 'Orphaned Cookies';
 export const UNMAPPED_COOKIE_KEY = 'Unmapped Cookies';

--- a/packages/common/src/constants/index.ts
+++ b/packages/common/src/constants/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export const UNKNOWN_FRAME_KEY = 'Unknown Frames';
+export const UNMAPPED_FRAME_KEY = 'Unmapped Frames';

--- a/packages/common/src/utils/filterCookiesByFrame.ts
+++ b/packages/common/src/utils/filterCookiesByFrame.ts
@@ -56,7 +56,7 @@ const filterCookiesByFrame = (
       if (
         !hasFrame &&
         cookie.frameIdList !== undefined &&
-        cookie.frameIdList?.length > 0
+        cookie.frameIdList?.length >= 0
       ) {
         frameFilteredCookies[key] = cookie;
       }

--- a/packages/common/src/utils/filterCookiesByFrame.ts
+++ b/packages/common/src/utils/filterCookiesByFrame.ts
@@ -16,7 +16,7 @@
 /**
  * Internal dependencies.
  */
-import { UNKNOWN_FRAME_KEY, UNMAPPED_COOKIE_KEY } from '../constants';
+import { ORPHANED_COOKIE_KEY, UNMAPPED_COOKIE_KEY } from '../constants';
 import { CookieTableData } from '../cookies.types';
 
 interface Cookies {
@@ -62,7 +62,7 @@ const filterCookiesByFrame = (
         ) {
           frameFilteredCookies[key] = cookie;
         } else if (
-          frameUrl === UNKNOWN_FRAME_KEY &&
+          frameUrl === ORPHANED_COOKIE_KEY &&
           cookie.frameIdList?.length > 0
         ) {
           frameFilteredCookies[key] = cookie;

--- a/packages/common/src/utils/filterCookiesByFrame.ts
+++ b/packages/common/src/utils/filterCookiesByFrame.ts
@@ -55,6 +55,7 @@ const filterCookiesByFrame = (
           hasFrame = true;
         }
       });
+
       if (!hasFrame && cookie.frameIdList !== undefined) {
         if (
           frameUrl === UNMAPPED_FRAME_KEY &&

--- a/packages/common/src/utils/filterCookiesByFrame.ts
+++ b/packages/common/src/utils/filterCookiesByFrame.ts
@@ -32,7 +32,6 @@ const filterCookiesByFrame = (
   tabFrames: TabFrames | null,
   frameUrl: string | null
 ) => {
-  console.log(frameUrl);
   const frameFilteredCookies: { [key: string]: CookieTableData } = {};
   if (!cookies || !frameUrl || !tabFrames || !tabFrames[frameUrl]) {
     return Object.values(frameFilteredCookies);

--- a/packages/common/src/utils/filterCookiesByFrame.ts
+++ b/packages/common/src/utils/filterCookiesByFrame.ts
@@ -16,6 +16,7 @@
 /**
  * Internal dependencies.
  */
+import { UNKNOWN_FRAME_KEY, UNMAPPED_FRAME_KEY } from '../constants';
 import { CookieTableData } from '../cookies.types';
 
 interface Cookies {
@@ -31,6 +32,7 @@ const filterCookiesByFrame = (
   tabFrames: TabFrames | null,
   frameUrl: string | null
 ) => {
+  console.log(frameUrl);
   const frameFilteredCookies: { [key: string]: CookieTableData } = {};
   if (!cookies || !frameUrl || !tabFrames || !tabFrames[frameUrl]) {
     return Object.values(frameFilteredCookies);
@@ -53,12 +55,18 @@ const filterCookiesByFrame = (
           hasFrame = true;
         }
       });
-      if (
-        !hasFrame &&
-        cookie.frameIdList !== undefined &&
-        cookie.frameIdList?.length >= 0
-      ) {
-        frameFilteredCookies[key] = cookie;
+      if (!hasFrame && cookie.frameIdList !== undefined) {
+        if (
+          frameUrl === UNMAPPED_FRAME_KEY &&
+          cookie.frameIdList?.length === 0
+        ) {
+          frameFilteredCookies[key] = cookie;
+        } else if (
+          frameUrl === UNKNOWN_FRAME_KEY &&
+          cookie.frameIdList?.length > 0
+        ) {
+          frameFilteredCookies[key] = cookie;
+        }
       }
     });
   }

--- a/packages/common/src/utils/filterCookiesByFrame.ts
+++ b/packages/common/src/utils/filterCookiesByFrame.ts
@@ -16,7 +16,7 @@
 /**
  * Internal dependencies.
  */
-import { UNKNOWN_FRAME_KEY, UNMAPPED_FRAME_KEY } from '../constants';
+import { UNKNOWN_FRAME_KEY, UNMAPPED_COOKIE_KEY } from '../constants';
 import { CookieTableData } from '../cookies.types';
 
 interface Cookies {
@@ -58,7 +58,7 @@ const filterCookiesByFrame = (
 
       if (!hasFrame && cookie.frameIdList !== undefined) {
         if (
-          frameUrl === UNMAPPED_FRAME_KEY &&
+          frameUrl === UNMAPPED_COOKIE_KEY &&
           cookie.frameIdList?.length === 0
         ) {
           frameFilteredCookies[key] = cookie;

--- a/packages/design-system/src/components/sidebar/sidebarChild.tsx
+++ b/packages/design-system/src/components/sidebar/sidebarChild.tsx
@@ -17,7 +17,11 @@
  * External dependencies.
  */
 import React, { useEffect, useRef } from 'react';
-import { ArrowDown, ArrowDownWhite } from '@ps-analysis-tool/design-system';
+import {
+  ArrowDown,
+  ArrowDownWhite,
+  InfoIcon,
+} from '@ps-analysis-tool/design-system';
 
 /**
  * Internal dependencies.
@@ -128,7 +132,20 @@ const SidebarChild = ({
             )}
           </div>
         )}
-        <p className="whitespace-nowrap pr-1">{sidebarItem.title}</p>
+        <p className="flex flex-row items-center justify-center whitespace-nowrap gap-x-1 pr-1">
+          {sidebarItem.title}
+          {sidebarItem.infoIconDescription ? (
+            <span title={sidebarItem.infoIconDescription}>
+              <InfoIcon
+                className={`${
+                  isKeySelected(itemKey) && isSidebarFocused
+                    ? 'fill-white'
+                    : 'fill-gray'
+                }`}
+              />
+            </span>
+          ) : null}
+        </p>
         <div
           className="absolute"
           style={{

--- a/packages/design-system/src/components/sidebar/useSidebar/index.tsx
+++ b/packages/design-system/src/components/sidebar/useSidebar/index.tsx
@@ -33,6 +33,7 @@ export type SidebarItemValue = {
   title: string;
   children: SidebarItems;
   popupTitle?: string;
+  infoIconDescription?: string;
   extraInterfaceToTitle?: React.ReactNode;
   dropdownOpen?: boolean;
   panel?: React.ReactNode;

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -164,7 +164,7 @@ const App: React.FC = () => {
 
           if (url === UNMAPPED_COOKIE_KEY) {
             popupTitle = infoIconDescription =
-              'We could not map these cookies to any frame.';
+              'Cookies that could not be mapped to any frame.';
           }
 
           acc[url] = {

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -31,7 +31,7 @@ import {
 import {
   UNKNOWN_FRAME_KEY,
   type CookieTableData,
-  UNMAPPED_FRAME_KEY,
+  UNMAPPED_COOKIE_KEY,
 } from '@ps-analysis-tool/common';
 
 /**
@@ -144,7 +144,7 @@ const App: React.FC = () => {
       );
       psData.children['cookies'].children = Object.keys(tabFrames || {})
         .filter((url) => {
-          return url === UNKNOWN_FRAME_KEY || url === UNMAPPED_FRAME_KEY
+          return url === UNKNOWN_FRAME_KEY || url === UNMAPPED_COOKIE_KEY
             ? frameHasCookies[url]
             : true;
         })

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -29,7 +29,7 @@ import {
   ToastMessage,
 } from '@ps-analysis-tool/design-system';
 import {
-  UNKNOWN_FRAME_KEY,
+  ORPHANED_COOKIE_KEY,
   type CookieTableData,
   UNMAPPED_COOKIE_KEY,
 } from '@ps-analysis-tool/common';
@@ -144,13 +144,13 @@ const App: React.FC = () => {
       );
       psData.children['cookies'].children = Object.keys(tabFrames || {})
         .filter((url) => {
-          return url === UNKNOWN_FRAME_KEY || url === UNMAPPED_COOKIE_KEY
+          return url === ORPHANED_COOKIE_KEY || url === UNMAPPED_COOKIE_KEY
             ? frameHasCookies[url]
             : true;
         })
         .reduce<SidebarItems>((acc, url) => {
           let popupTitle = `Cookies used by frames from ${url}`;
-          if (url === UNKNOWN_FRAME_KEY) {
+          if (url === ORPHANED_COOKIE_KEY) {
             popupTitle =
               'Frames that set these cookies were removed from the DOM, leaving these cookies orphaned.';
           }

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -156,13 +156,15 @@ const App: React.FC = () => {
         })
         .reduce<SidebarItems>((acc, url) => {
           let popupTitle = `Cookies used by frames from ${url}`;
+          let infoIconDescription = '';
           if (url === ORPHANED_COOKIE_KEY) {
-            popupTitle =
+            popupTitle = infoIconDescription =
               'Frames that set these cookies were removed from the DOM, leaving these cookies orphaned.';
           }
 
           if (url === UNMAPPED_COOKIE_KEY) {
-            popupTitle = 'We could not map these cookies to any frame.';
+            popupTitle = infoIconDescription =
+              'We could not map these cookies to any frame.';
           }
 
           acc[url] = {
@@ -171,6 +173,7 @@ const App: React.FC = () => {
             panel: <Cookies setFilteredCookies={setFilteredCookies} />,
             icon: <CookieIcon />,
             selectedIcon: <CookieIconWhite />,
+            infoIconDescription,
             children: {},
             isBlurred: !frameHasCookies?.[url],
           };

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -149,9 +149,19 @@ const App: React.FC = () => {
             : true;
         })
         .reduce<SidebarItems>((acc, url) => {
+          let popupTitle = `Cookies used by frames from ${url}`;
+          if (url === UNKNOWN_FRAME_KEY) {
+            popupTitle =
+              'Frames that set these cookies were removed from the DOM, leaving these cookies orphaned.';
+          }
+
+          if (url === UNMAPPED_COOKIE_KEY) {
+            popupTitle = 'We could not map these cookies to any frame.';
+          }
+
           acc[url] = {
             title: url,
-            popupTitle: `Cookies used by frames from ${url}`,
+            popupTitle,
             panel: <Cookies setFilteredCookies={setFilteredCookies} />,
             icon: <CookieIcon />,
             selectedIcon: <CookieIconWhite />,

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -144,9 +144,15 @@ const App: React.FC = () => {
       );
       psData.children['cookies'].children = Object.keys(tabFrames || {})
         .filter((url) => {
-          return url === ORPHANED_COOKIE_KEY || url === UNMAPPED_COOKIE_KEY
-            ? frameHasCookies[url]
-            : true;
+          if (url === ORPHANED_COOKIE_KEY) {
+            return frameHasCookies[url];
+          }
+
+          if (url === UNMAPPED_COOKIE_KEY) {
+            return frameHasCookies[url];
+          }
+
+          return true;
         })
         .reduce<SidebarItems>((acc, url) => {
           let popupTitle = `Cookies used by frames from ${url}`;

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -31,6 +31,7 @@ import {
 import {
   UNKNOWN_FRAME_KEY,
   type CookieTableData,
+  UNMAPPED_FRAME_KEY,
 } from '@ps-analysis-tool/common';
 
 /**
@@ -143,7 +144,9 @@ const App: React.FC = () => {
       );
       psData.children['cookies'].children = Object.keys(tabFrames || {})
         .filter((url) => {
-          return url === UNKNOWN_FRAME_KEY ? frameHasCookies[url] : true;
+          return url === UNKNOWN_FRAME_KEY || url === UNMAPPED_FRAME_KEY
+            ? frameHasCookies[url]
+            : true;
         })
         .reduce<SidebarItems>((acc, url) => {
           acc[url] = {

--- a/packages/extension/src/view/devtools/components/cookies/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/index.tsx
@@ -26,6 +26,7 @@ import { LibraryDetection } from '@ps-analysis-tool/library-detection';
 import {
   UNKNOWN_FRAME_KEY,
   type CookieTableData,
+  UNMAPPED_FRAME_KEY,
 } from '@ps-analysis-tool/common';
 
 /**
@@ -71,7 +72,9 @@ const Cookies = ({ setFilteredCookies }: CookiesProps) => {
     () =>
       Object.fromEntries(
         Object.entries(tabFrames || {}).filter(([url]) =>
-          url === UNKNOWN_FRAME_KEY ? frameHasCookies[url] : true
+          url === UNKNOWN_FRAME_KEY || url === UNMAPPED_FRAME_KEY
+            ? frameHasCookies[url]
+            : true
         )
       ),
     [tabFrames, frameHasCookies]

--- a/packages/extension/src/view/devtools/components/cookies/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/index.tsx
@@ -26,7 +26,7 @@ import { LibraryDetection } from '@ps-analysis-tool/library-detection';
 import {
   UNKNOWN_FRAME_KEY,
   type CookieTableData,
-  UNMAPPED_FRAME_KEY,
+  UNMAPPED_COOKIE_KEY,
 } from '@ps-analysis-tool/common';
 
 /**
@@ -72,7 +72,7 @@ const Cookies = ({ setFilteredCookies }: CookiesProps) => {
     () =>
       Object.fromEntries(
         Object.entries(tabFrames || {}).filter(([url]) =>
-          url === UNKNOWN_FRAME_KEY || url === UNMAPPED_FRAME_KEY
+          url === UNKNOWN_FRAME_KEY || url === UNMAPPED_COOKIE_KEY
             ? frameHasCookies[url]
             : true
         )

--- a/packages/extension/src/view/devtools/components/cookies/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/index.tsx
@@ -71,11 +71,17 @@ const Cookies = ({ setFilteredCookies }: CookiesProps) => {
   const processedTabFrames = useMemo(
     () =>
       Object.fromEntries(
-        Object.entries(tabFrames || {}).filter(([url]) =>
-          url === ORPHANED_COOKIE_KEY || url === UNMAPPED_COOKIE_KEY
-            ? frameHasCookies[url]
-            : true
-        )
+        Object.entries(tabFrames || {}).filter(([url]) => {
+          if (url === ORPHANED_COOKIE_KEY) {
+            return frameHasCookies[url];
+          }
+
+          if (url === UNMAPPED_COOKIE_KEY) {
+            return frameHasCookies[url];
+          }
+
+          return true;
+        })
       ),
     [tabFrames, frameHasCookies]
   );

--- a/packages/extension/src/view/devtools/components/cookies/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/index.tsx
@@ -24,7 +24,7 @@ import {
 } from '@ps-analysis-tool/design-system';
 import { LibraryDetection } from '@ps-analysis-tool/library-detection';
 import {
-  UNKNOWN_FRAME_KEY,
+  ORPHANED_COOKIE_KEY,
   type CookieTableData,
   UNMAPPED_COOKIE_KEY,
 } from '@ps-analysis-tool/common';
@@ -72,7 +72,7 @@ const Cookies = ({ setFilteredCookies }: CookiesProps) => {
     () =>
       Object.fromEntries(
         Object.entries(tabFrames || {}).filter(([url]) =>
-          url === UNKNOWN_FRAME_KEY || url === UNMAPPED_COOKIE_KEY
+          url === ORPHANED_COOKIE_KEY || url === UNMAPPED_COOKIE_KEY
             ? frameHasCookies[url]
             : true
         )

--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -210,7 +210,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
         }
       });
 
-      if (!hasFrame && cookie.frameIdList?.length) {
+      if (!hasFrame && cookie.frameIdList && cookie.frameIdList?.length >= 0) {
         acc[UNKNOWN_FRAME_KEY] = true;
       }
 

--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -30,6 +30,7 @@ import {
   type TabCookies,
   type TabFrames,
   UNKNOWN_FRAME_KEY,
+  UNMAPPED_FRAME_KEY,
 } from '@ps-analysis-tool/common';
 
 /**
@@ -171,6 +172,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
         })
       );
       modifiedTabFrames[UNKNOWN_FRAME_KEY] = { frameIds: [] };
+      modifiedTabFrames[UNMAPPED_FRAME_KEY] = { frameIds: [] };
       setTabFrames(modifiedTabFrames);
     },
     []
@@ -210,8 +212,12 @@ export const Provider = ({ children }: PropsWithChildren) => {
         }
       });
 
-      if (!hasFrame && cookie.frameIdList && cookie.frameIdList?.length >= 0) {
+      if (!hasFrame && cookie.frameIdList && cookie.frameIdList?.length > 0) {
         acc[UNKNOWN_FRAME_KEY] = true;
+      }
+
+      if (!hasFrame && cookie.frameIdList && cookie.frameIdList?.length >= 0) {
+        acc[UNMAPPED_FRAME_KEY] = true;
       }
 
       return acc;

--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -29,7 +29,7 @@ import { noop } from '@ps-analysis-tool/design-system';
 import {
   type TabCookies,
   type TabFrames,
-  UNKNOWN_FRAME_KEY,
+  ORPHANED_COOKIE_KEY,
   UNMAPPED_COOKIE_KEY,
 } from '@ps-analysis-tool/common';
 
@@ -171,7 +171,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
           return tabFrame;
         })
       );
-      modifiedTabFrames[UNKNOWN_FRAME_KEY] = { frameIds: [] };
+      modifiedTabFrames[ORPHANED_COOKIE_KEY] = { frameIds: [] };
       modifiedTabFrames[UNMAPPED_COOKIE_KEY] = { frameIds: [] };
       setTabFrames(modifiedTabFrames);
     },
@@ -213,7 +213,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
       });
 
       if (!hasFrame && cookie.frameIdList && cookie.frameIdList?.length > 0) {
-        acc[UNKNOWN_FRAME_KEY] = true;
+        acc[ORPHANED_COOKIE_KEY] = true;
       }
 
       if (!hasFrame && cookie.frameIdList && cookie.frameIdList?.length >= 0) {

--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -30,7 +30,7 @@ import {
   type TabCookies,
   type TabFrames,
   UNKNOWN_FRAME_KEY,
-  UNMAPPED_FRAME_KEY,
+  UNMAPPED_COOKIE_KEY,
 } from '@ps-analysis-tool/common';
 
 /**
@@ -172,7 +172,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
         })
       );
       modifiedTabFrames[UNKNOWN_FRAME_KEY] = { frameIds: [] };
-      modifiedTabFrames[UNMAPPED_FRAME_KEY] = { frameIds: [] };
+      modifiedTabFrames[UNMAPPED_COOKIE_KEY] = { frameIds: [] };
       setTabFrames(modifiedTabFrames);
     },
     []
@@ -217,7 +217,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
       }
 
       if (!hasFrame && cookie.frameIdList && cookie.frameIdList?.length >= 0) {
-        acc[UNMAPPED_FRAME_KEY] = true;
+        acc[UNMAPPED_COOKIE_KEY] = true;
       }
 
       return acc;

--- a/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncCookieStore/index.tsx
@@ -216,7 +216,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
         acc[ORPHANED_COOKIE_KEY] = true;
       }
 
-      if (!hasFrame && cookie.frameIdList && cookie.frameIdList?.length >= 0) {
+      if (!hasFrame && cookie.frameIdList && cookie.frameIdList?.length === 0) {
         acc[UNMAPPED_COOKIE_KEY] = true;
       }
 


### PR DESCRIPTION
## Description
In this PR we aim to show the unmapped cookies that were received by CDP in the `Unknown frames` section.

## Relevant Technical Choices

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:
- This majorly happens because `chrome.webRequest.onBeforeSendHeaders` doesn't capture the blocked request cookies because the browser excludes them even before being added to the request header.
- Since these excluded cookies were blocked from being read from `chrome.webRequest.onBeforeSendHeaders`.
- Now CDP receives the `extraInformation` of blocked cookies of a particular request. It sets the data for the cookie in the store. Since we do not yet have the association of this cookie with the `frameId` we do not show these cookies in the cookies table.

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~~[ ] This code is covered by unit tests to verify that it works as intended.~~ NA
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #524 
