### PR TITLE
Fix: Allow listed rows to highlight after frame change

### DIFF
--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/useHighlighting.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/useHighlighting.tsx
@@ -54,7 +54,7 @@ const useHighlighting = (
       }
       return prevState;
     });
-  }, [cookies, handleHighlighting, setTableData]);
+  }, [cookies, handleHighlighting, setTableData, domainsInAllowList?.size]);
 };
 
 export default useHighlighting;


### PR DESCRIPTION
## Description
It was observed that when any domain is allowed, and we move out of the frame to another frame and revisit, the green color disappears for a bit.

## Relevant Technical Choices

- Add `domainsInAllowList.size` as a dependency under `useHighlighting` hook. 

## Testing Instructions

- Go to any frame for example on https://www.nationalgeographic.com/ and allow list some cookies.
- Go to cookies landing page and come back to the same frame. Same allow listed cookies should be highlighted.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended~. NA
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
