### PR TITLE
Fix: Update filters comparator

### DIFF
--- a/packages/cli-dashboard/src/hooks/useCookieListing.tsx/index.tsx
+++ b/packages/cli-dashboard/src/hooks/useCookieListing.tsx/index.tsx
@@ -27,6 +27,10 @@ import {
   calculateEffectiveExpiryDate,
   type CookieTableData,
 } from '@ps-analysis-tool/common';
+
+/**
+ * Internal dependencies
+ */
 import calculateDynamicFilterValues from './utils/calculateDynamicFilterValues';
 import calculateBlockedReasonsFilterValues from './utils/calculateBlockedReasonsFilterValues';
 
@@ -154,7 +158,7 @@ const useCookieListing = (
         },
         useGenericPersistenceKey: true,
         comparator: (value: InfoType, filterValue: string) => {
-          const val = value as boolean;
+          const val = Boolean(value);
           return val === (filterValue === 'First Party');
         },
       },
@@ -174,7 +178,7 @@ const useCookieListing = (
         },
         useGenericPersistenceKey: true,
         comparator: (value: InfoType, filterValue: string) => {
-          const val = value as boolean;
+          const val = Boolean(value);
           return val === (filterValue === 'True');
         },
       },
@@ -211,7 +215,7 @@ const useCookieListing = (
         },
         useGenericPersistenceKey: true,
         comparator: (value: InfoType, filterValue: string) => {
-          const val = value as boolean;
+          const val = Boolean(value);
           return val === (filterValue === 'True');
         },
       },

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
@@ -250,7 +250,7 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
         },
         useGenericPersistenceKey: true,
         comparator: (value: InfoType, filterValue: string) => {
-          const val = value as boolean;
+          const val = Boolean(value);
           return val === (filterValue === 'First Party');
         },
       },
@@ -270,7 +270,7 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
         },
         useGenericPersistenceKey: true,
         comparator: (value: InfoType, filterValue: string) => {
-          const val = value as boolean;
+          const val = Boolean(value);
           return val === (filterValue === 'True');
         },
       },
@@ -307,7 +307,7 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
         },
         useGenericPersistenceKey: true,
         comparator: (value: InfoType, filterValue: string) => {
-          const val = value as boolean;
+          const val = Boolean(value);
           return val === (filterValue === 'True');
         },
       },


### PR DESCRIPTION
## Description
This PR updates the comparator of table filters to coercion an `undefined` value to a Boolean value.
- At times while selecting the HttpOnly filter's false value, the count of rows present was incorrect due to the `undefined` value present whose comparison was not handled in comparators.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open any website that has an `Unmapped Cookies` frame.
- Open the frame and open the filters sidebar.
- Find the HttpOnly filter, and click on false.
- You'll see the correct count of rows present.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/7b298072-c112-4037-a1bf-8d1492e4fda1


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
