### PR TITLE
Fix: CLI not quitting after generating output.

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -224,7 +224,7 @@ const startDashboardServer = async (dir: string) => {
 
   if (outDir) {
     await saveCSVReports(path.resolve(outputDir), result);
-    return;
+    process.exit(0);
   }
 
   startDashboardServer(

--- a/packages/cli/src/procedures/analyzeCookieUrls.ts
+++ b/packages/cli/src/procedures/analyzeCookieUrls.ts
@@ -45,7 +45,7 @@ export const analyzeCookiesUrls = async (
   await browser.initializeBrowser(true);
   const analysisCookieData = await browser.analyzeCookieUrls(urls);
 
-  return analysisCookieData.map(({ pageUrl, cookieData }) => {
+  const res = analysisCookieData.map(({ pageUrl, cookieData }) => {
     Object.entries(cookieData).forEach(([, frameData]) => {
       const frameCookies = frameData.frameCookies;
       Object.entries(frameCookies).forEach(([key, cookie]) => {
@@ -72,4 +72,7 @@ export const analyzeCookiesUrls = async (
       cookieData,
     };
   });
+
+  await browser.deinitialize();
+  return res;
 };


### PR DESCRIPTION
## Description

It was observed that the CLI does not quit if the option to generate data into a directory is chosen. This PR fixes that.

## Relevant Technical Choices
- Add a browser de-initialization call after the cookie analysis is done.
- Add a `process.exit()` call to force the process to quit after the analysis is done.

<!-- Please describe your changes. -->

## Testing Instructions

- Follow the instruction in the `README.md` to build the cli.
- Use the command `npm run cli -- -u https://bbc.com/ -d ./bbc` to get an analysis report
- After the analysis is done the terminal process should end.

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

