### PR TITLE
Fix: Incorrect cookie scope classification

### DIFF
--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -65,7 +65,12 @@ chrome.webRequest.onResponseStarted.addListener(
   (details: chrome.webRequest.WebResponseCacheDetails) => {
     (async () => {
       const { tabId, url, responseHeaders, frameId } = details;
-      const tabUrl = syncCookieStore?.getTabUrl(tabId) ?? '';
+      const tab = await getTab(tabId);
+      let tabUrl = syncCookieStore?.getTabUrl(tabId);
+
+      if (tab && tab.pendingUrl) {
+        tabUrl = tab.pendingUrl;
+      }
 
       if (
         !canProcessCookies(tabMode, tabUrl, tabToRead, tabId, responseHeaders)
@@ -135,7 +140,12 @@ chrome.webRequest.onResponseStarted.addListener(
 chrome.webRequest.onBeforeSendHeaders.addListener(
   ({ url, requestHeaders, tabId, frameId, requestId }) => {
     (async () => {
-      const tabUrl = syncCookieStore?.getTabUrl(tabId) ?? '';
+      const tab = await getTab(tabId);
+      let tabUrl = syncCookieStore?.getTabUrl(tabId);
+
+      if (tab && tab.pendingUrl) {
+        tabUrl = tab.pendingUrl;
+      }
 
       if (
         !canProcessCookies(tabMode, tabUrl, tabToRead, tabId, requestHeaders)

--- a/packages/extension/src/utils/canProcessCookies.ts
+++ b/packages/extension/src/utils/canProcessCookies.ts
@@ -16,7 +16,7 @@
 /**
  * This function will return true if the current request can be processed or and false if it cannot be processed.
  * @param {string} tabMode The mode of processing of the extension.
- * @param {string} tabUrl Current tab url.
+ * @param {string | null | undefined} tabUrl Current tab url.
  * @param {string} tabToRead The current tab being read y extension in case of single processing mode.
  * @param {number} currentTabId The tabId of the current request is associated to.
  * @param {chrome.webRequest.WebResponseHeadersDetails['responseHeaders']} responseHeaders The tabId of the current request is associated to.
@@ -24,7 +24,7 @@
  */
 export default function canProcessCookies(
   tabMode: 'unlimited' | 'single',
-  tabUrl: string | null,
+  tabUrl: string | null | undefined,
   tabToRead: string,
   currentTabId: number,
   responseHeaders: chrome.webRequest.WebResponseHeadersDetails['responseHeaders']


### PR DESCRIPTION
## Description
This PR aims to correct the tool's scope classification and display correct first-party and third-party data.

## Relevant Technical Choices
- The problem happens sometimes because Chrome fires the event for an updated URL after a bit of delay by that time some 1p cookies are classified as 3p because they were being compared with the old tab URL. This PR uses the `pendingURL` if there is any to do the scope classification.

## Testing Instructions
- Clone this branch.
- In the terminal run `npm start`.
- Open a fresh browser instance and start analysing the tab using PSAT.
- Go to `nikkei.com` and check all the cookies that have nikkei.com as domain are being classified as `First Party`.

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
