### PR TITLE
Fix: Inconsistency of CDP switch state.

### DIFF
--- a/packages/extension/src/view/popup/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/popup/stateProviders/syncCookieStore/index.tsx
@@ -241,11 +241,10 @@ export const Provider = ({ children }: PropsWithChildren) => {
 
   const sessionStoreChangeListener = useCallback(
     (changes: { [key: string]: chrome.storage.StorageChange }) => {
-      if (
-        Object.keys(changes).includes('allowedNumberOfTabs') &&
-        Object.keys(changes.allowedNumberOfTabs).includes('newValue')
-      ) {
-        setAllowedNumberOfTabs(changes?.allowedNumberOfTabs?.newValue);
+      if (changes?.['allowedNumberOfTabs']?.['newValue']) {
+        setAllowedNumberOfTabsForSettingsDisplay(
+          changes?.allowedNumberOfTabs?.newValue
+        );
         setSettingsChanged(true);
       }
 
@@ -253,7 +252,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
         Object.keys(changes).includes('isUsingCDP') &&
         Object.keys(changes.isUsingCDP).includes('newValue')
       ) {
-        setIsUsingCDP(changes?.isUsingCDP?.newValue);
+        setIsUsingCDPForSettingsDisplay(changes?.isUsingCDP?.newValue);
         setSettingsChanged(true);
       }
     },


### PR DESCRIPTION
## Description
This PR aims to fix a few issues including inconsistency in the CDP state in the settings page of `DevTools` and `Popup`. 

## Testing Instructions
- Clone this PR and in the terminal run `npm start`.
- Open a fresh Chrome profile and install the PSAT extension.
- Oen any site and check the state of the CDP switch is inconsistent in the PSAT DevTools page and the PSAT popup.


## Screenshot/Screencast
<img width="1440" alt="Screenshot 2024-03-12 at 17 20 27" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/59614577/c0c5f05f-cd8d-426d-8ad2-3e7da531dc51">

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
