### PR TITLE
Maintain selected row’s background color in row selection

### DIFF
--- a/packages/design-system/src/components/table/components/tableBody/bodyRow.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/bodyRow.tsx
@@ -75,7 +75,7 @@ const BodyRow = ({
           ? 'dark:bg-flagged-row-even-dark bg-flagged-row-even-light'
           : 'dark:bg-flagged-row-odd-dark bg-flagged-row-odd-light'
         : isRowFocused
-        ? 'bg-gainsboro dark:bg-outer-space'
+        ? 'bg-selection-yellow-dark dark:bg-selection-yellow-light'
         : 'bg-royal-blue text-white dark:bg-medium-persian-blue dark:text-chinese-silver'),
     isDomainInAllowList &&
       !isBlocked &&
@@ -84,7 +84,7 @@ const BodyRow = ({
           ? 'dark:bg-jungle-green-dark bg-leaf-green-dark'
           : 'dark:bg-jungle-green-light bg-leaf-green-light'
         : isRowFocused
-        ? 'bg-gainsboro dark:bg-outer-space'
+        ? 'bg-selection-green-dark dark:bg-selection-green-light'
         : 'bg-royal-blue text-white dark:bg-medium-persian-blue dark:text-chinese-silver'),
     cookieKey !== selectedKey &&
       !isBlocked &&

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -189,6 +189,10 @@ module.exports = {
       'leaf-green-dark': '#87DFB2',
       'eerie-black': '#1F1F1F0F',
       'light-yellow': '#FEFCE0',
+      'selection-green-light': '#117347',
+      'selection-green-dark': '#74d47e',
+      'selection-yellow-light': '#8b8f18',
+      'selection-yellow-dark': '#dbdb48',
     },
     borderColor: {
       ...colors,


### PR DESCRIPTION
## Description

As we highlight the selected row in grey background color, it looses its original color during selection. This PR aims to change the selection color for each row.

## Relevant Technical Choices

- Update selection classes

<!-- Please describe your changes. -->

## Testing Instructions

- Visit any website for example bbc.com
- Allow list any third-party cookie so that its background becomes green.
- Check if the selection color is working as shown in the screencast.

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast


https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/6297436/126d74da-5f06-4064-9cc4-16771e2c4a66



<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~ NA
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
