### PR TITLE
Fix: Highlighting logic for undetermined blocking status cookie and create a new column for it

### DIFF
--- a/packages/design-system/src/components/cookieDetails/details.tsx
+++ b/packages/design-system/src/components/cookieDetails/details.tsx
@@ -33,7 +33,6 @@ import {
   OutboundIcon,
   OutboundInboundColoredIcon,
   OutboundInboundIcon,
-  QuestionMark,
 } from '../../icons';
 
 export interface DetailsProps {
@@ -113,19 +112,6 @@ const Details = ({ selectedCookie, isUsingCDP }: DetailsProps) => {
               dangerouslySetInnerHTML={{ __html: blockedReasons ?? '' }}
             />
           </>
-        )}
-
-      {(outboundBlock || inboundBlock) &&
-        !hasValidBlockedReason &&
-        isUsingCDP && (
-          <div className="flex gap-1 items-center mb-4">
-            <QuestionMark className="scale-150 mr-1" />
-            <p className="text-outer-space-crayola dark:text-bright-gray">
-              We detected that the cookie was blocked however we could not
-              detect the reason.
-            </p>
-            <br />
-          </div>
         )}
 
       {selectedCookie?.blockingStatus?.inboundBlock ===

--- a/packages/design-system/src/components/table/components/tableBody/bodyRow.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/bodyRow.tsx
@@ -19,7 +19,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import { BLOCK_STATUS, CookieTableData } from '@ps-analysis-tool/common';
+import { CookieTableData } from '@ps-analysis-tool/common';
 
 /**
  * Internal dependencies.
@@ -59,10 +59,7 @@ const BodyRow = ({
   const cookieKey = getRowObjectKey(row);
   const isBlocked = useIsBlockedToHighlight
     ? (row.originalData as CookieTableData)?.isBlocked
-    : (row.originalData as CookieTableData)?.blockingStatus?.inboundBlock !==
-        BLOCK_STATUS.NOT_BLOCKED ||
-      (row.originalData as CookieTableData)?.blockingStatus?.outboundBlock !==
-        BLOCK_STATUS.NOT_BLOCKED;
+    : Boolean((row.originalData as CookieTableData)?.blockedReasons?.length);
   const isHighlighted = (row.originalData as CookieTableData)?.highlighted;
   const isDomainInAllowList = (row.originalData as CookieTableData)
     ?.isDomainInAllowList;

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
@@ -30,6 +30,8 @@ import {
   type TableColumn,
   type TableFilter,
   type TableRow,
+  type TableData,
+  InfoIcon,
 } from '@ps-analysis-tool/design-system';
 
 /**
@@ -118,7 +120,7 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
         header: 'Platform',
         accessorKey: 'analytics.platform',
         cell: (info: InfoType) => <span>{info ? info : 'Unknown'}</span>,
-        widthWeightagePercentage: 8,
+        widthWeightagePercentage: 7.5,
       },
       {
         header: 'HttpOnly',
@@ -128,7 +130,7 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
             {info ? <span className="font-serif">✓</span> : ''}
           </p>
         ),
-        widthWeightagePercentage: 5,
+        widthWeightagePercentage: 4,
       },
       {
         header: 'Secure',
@@ -138,7 +140,7 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
             {info ? <span className="font-serif">✓</span> : ''}
           </p>
         ),
-        widthWeightagePercentage: 5,
+        widthWeightagePercentage: 4,
       },
       {
         header: 'Value',
@@ -156,19 +158,19 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
         header: 'Expires / Max-Age',
         accessorKey: 'parsedCookie.expires',
         cell: (info: InfoType) => (info ? info : 'Session'),
-        widthWeightagePercentage: 7,
+        widthWeightagePercentage: 6,
       },
       {
         header: 'Priority',
         accessorKey: 'parsedCookie.priority',
         cell: (info: InfoType) => info,
-        widthWeightagePercentage: 5,
+        widthWeightagePercentage: 4,
       },
       {
         header: 'Size',
         accessorKey: 'parsedCookie.size',
         cell: (info: InfoType) => info,
-        widthWeightagePercentage: 3.4,
+        widthWeightagePercentage: 3,
       },
       {
         header: 'Orphaned/Unmapped Cookie',
@@ -177,7 +179,36 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
         cell: (info: InfoType) => (
           <OrphanedUnMappedInfoDisplay frameIdList={info as number[]} />
         ),
-        widthWeightagePercentage: 7.6,
+        widthWeightagePercentage: 6.6,
+      },
+      {
+        header: 'Blocking Status',
+        accessorKey: 'isBlocked',
+        isHiddenByDefault: true,
+        widthWeightagePercentage: 5.4,
+        cell: (_, details: TableData | undefined) => {
+          const cookieData = details as CookieTableData;
+
+          if (
+            !cookieData.blockedReasons?.length &&
+            (cookieData.blockingStatus?.inboundBlock !==
+              BLOCK_STATUS.NOT_BLOCKED ||
+              cookieData.blockingStatus?.outboundBlock !==
+                BLOCK_STATUS.NOT_BLOCKED)
+          ) {
+            return (
+              <span
+                className="flex"
+                title="Please take a look at the network tab to get this cookie's blocking information."
+              >
+                <InfoIcon className="fill-granite-gray" />
+                Undetermined
+              </span>
+            );
+          } else {
+            return <></>;
+          }
+        },
       },
     ],
     [isUsingCDP]

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
@@ -189,12 +189,19 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
         cell: (_, details: TableData | undefined) => {
           const cookieData = details as CookieTableData;
 
+          const isInboundBlocked =
+            cookieData.blockingStatus?.inboundBlock !==
+            BLOCK_STATUS.NOT_BLOCKED;
+          const isOutboundBlocked =
+            cookieData.blockingStatus?.outboundBlock !==
+            BLOCK_STATUS.NOT_BLOCKED;
+          const hasValidBlockedReason =
+            cookieData?.blockedReasons &&
+            cookieData.blockedReasons.length !== 0;
+
           if (
-            !cookieData.blockedReasons?.length &&
-            (cookieData.blockingStatus?.inboundBlock !==
-              BLOCK_STATUS.NOT_BLOCKED ||
-              cookieData.blockingStatus?.outboundBlock !==
-                BLOCK_STATUS.NOT_BLOCKED)
+            (isInboundBlocked || isOutboundBlocked) &&
+            !hasValidBlockedReason
           ) {
             return (
               <span
@@ -205,6 +212,8 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
                 Undetermined
               </span>
             );
+          } else if (hasValidBlockedReason) {
+            return <span className="flex">Blocked</span>;
           } else {
             return <></>;
           }

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
@@ -187,6 +187,10 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
         isHiddenByDefault: true,
         widthWeightagePercentage: 5.4,
         cell: (_, details: TableData | undefined) => {
+          //skip calculation of blocking status when not using CDP
+          if (!isUsingCDP) {
+            return <></>;
+          }
           const cookieData = details as CookieTableData;
 
           const isInboundBlocked =

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/namePrefixIconSelector.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/namePrefixIconSelector.tsx
@@ -24,7 +24,6 @@ import {
   GreenTick,
   InboundIcon,
   OutboundIcon,
-  QuestionMark,
   OutboundInboundIcon,
   OutboundInboundColoredIcon,
 } from '@ps-analysis-tool/design-system';
@@ -53,10 +52,6 @@ const namePrefixIconSelector = ({ originalData }: TableRow) => {
     data?.blockedReasons && data.blockedReasons.length !== 0;
 
   if (!hasValidBlockedReason) {
-    if (isInboundBlocked || isOutboundBlocked) {
-      return <QuestionMark />;
-    }
-
     return <></>;
   }
 


### PR DESCRIPTION
## Description

This cookie changes highlighting logic in the cookie table and adds a new column named "Blocking Status".
The cookies who's blocking status is not determined ( previously signified by a ? icon) will have the value "Undetermined"
in the "Blocking Status" column. Also, such cookies will not be highlighted. the yellow highlight is reserved for blocked cookies.  

## Testing Instructions

- Use the extension as per usual and visit any website.
- Any cookie previously shown with a question mark prefix icon and yellow highlight should have the value "Undetermined" in the newly added column named "Blocking Status"
- The cookie details panel should not have the explainer text for such cookies it has been moved to the tooltip in the table column "Blocking Status".


## Screenshot/Screencast

![Screenshot 2024-03-14 at 11 57 55 AM](https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/53055971/8989cd60-77e8-4ab9-b6ac-7c4ec815b7ba)

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

