### PR TITLE
Fix: Remove unmapped orphan cookies.

### DIFF
--- a/packages/common/src/utils/filterCookiesByFrame.ts
+++ b/packages/common/src/utils/filterCookiesByFrame.ts
@@ -35,6 +35,7 @@ const filterCookiesByFrame = (
   if (!cookies || !frameUrl || !tabFrames || !tabFrames[frameUrl]) {
     return Object.values(frameFilteredCookies);
   }
+
   let tabFramesIDMap: number[] = [];
 
   Object.keys(tabFrames)?.forEach((url) => {
@@ -60,6 +61,7 @@ const filterCookiesByFrame = (
       });
 
       if (!hasFrame && cookie?.frameIdList) {
+        //For UnMapped Cookies
         if (
           cookie.frameIdList &&
           cookie.frameIdList.length === 0 &&
@@ -77,20 +79,14 @@ const filterCookiesByFrame = (
           }
         }
 
+        //For Orphaned Cookies
         if (
           cookie.frameIdList &&
           cookie.frameIdList.length > 0 &&
           cookie.parsedCookie.domain
         ) {
-          const domainToCheck = cookie.parsedCookie.domain.startsWith('.')
-            ? cookie.parsedCookie.domain.slice(1)
-            : cookie.parsedCookie.domain;
-          if (frameUrl.includes(domainToCheck)) {
+          if (tabFrames[frameUrl].frameIds.includes(0)) {
             frameFilteredCookies[key] = cookie;
-          } else {
-            if (tabFramesIDMap.includes(0)) {
-              frameFilteredCookies[key] = cookie;
-            }
           }
         }
       }

--- a/packages/design-system/src/components/table/useTable/index.tsx
+++ b/packages/design-system/src/components/table/useTable/index.tsx
@@ -45,6 +45,7 @@ export type TableColumn = {
   accessorKey: string;
   cell?: (info: InfoType, details?: TableData) => React.JSX.Element | InfoType;
   enableHiding?: boolean;
+  isHiddenByDefault?: boolean;
   enableBodyCellPrefixIcon?: boolean;
   bodyCellPrefixIcon?: (row: TableRow) => React.JSX.Element;
   showBodyCellPrefixIcon?: (row: TableRow) => boolean;

--- a/packages/design-system/src/components/table/useTable/useColumnVisibility/index.tsx
+++ b/packages/design-system/src/components/table/useTable/useColumnVisibility/index.tsx
@@ -41,6 +41,16 @@ const useColumnVisibility = (
   const [hiddenKeys, setHiddenKeys] = useState<Set<string>>(new Set());
   const [isDataLoading, setIsDataLoading] = useState(true);
 
+  useEffect(() => {
+    setHiddenKeys(() => {
+      const _hiddenKeys = columns.filter(
+        ({ isHiddenByDefault }) => isHiddenByDefault
+      );
+
+      return new Set(_hiddenKeys.map(({ accessorKey }) => accessorKey));
+    });
+  }, [columns]);
+
   const hideColumn = useCallback((key: string) => {
     setHiddenKeys((prev) => new Set(prev.add(key)));
   }, []);
@@ -103,14 +113,13 @@ const useColumnVisibility = (
 
   useEffect(() => {
     if (tablePersistentSettingsKey) {
-      setHiddenKeys(new Set());
-
       const data = getPreferences(
         tablePersistentSettingsKey,
         'columnsVisibility'
       );
 
       if (data) {
+        setHiddenKeys(new Set());
         const _hiddenKeys = Object.entries(data)
           .filter(([, hidden]) => hidden)
           .map(([key]) => key);

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
@@ -88,7 +88,7 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
             {!info ? 'Third Party' : 'First Party'}
           </p>
         ),
-        widthWeightagePercentage: 6.6,
+        widthWeightagePercentage: 6,
       },
       {
         header: 'Domain',
@@ -106,13 +106,13 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
         header: 'SameSite',
         accessorKey: 'parsedCookie.samesite',
         cell: (info: InfoType) => <span className="capitalize">{info}</span>,
-        widthWeightagePercentage: 6.5,
+        widthWeightagePercentage: 6,
       },
       {
         header: 'Category',
         accessorKey: 'analytics.category',
         cell: (info: InfoType) => info,
-        widthWeightagePercentage: 7,
+        widthWeightagePercentage: 7.5,
       },
       {
         header: 'Platform',
@@ -173,10 +173,11 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
       {
         header: 'Orphaned Cookie',
         accessorKey: 'frameIdList',
+        isHiddenByDefault: true,
         cell: (info: InfoType) => (
           <OrphanedUnMappedInfoDisplay frameIdList={info as number[]} />
         ),
-        widthWeightagePercentage: 7,
+        widthWeightagePercentage: 7.6,
       },
       {
         header: 'Unmapped Cookie',

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
@@ -178,6 +178,20 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
         ),
         widthWeightagePercentage: 7,
       },
+      {
+        header: 'Unmapped Cookie',
+        accessorKey: 'frameIdList',
+        cell: (info: InfoType) => (
+          <p className="flex justify-center items-center">
+            {(info as number[]).length === 0 ? (
+              <span className="font-serif">✓</span>
+            ) : (
+              ''
+            )}
+          </p>
+        ),
+        widthWeightagePercentage: 7,
+      },
     ],
     [isUsingCDP]
   );

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
@@ -171,27 +171,13 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
         widthWeightagePercentage: 3.4,
       },
       {
-        header: 'Orphaned Cookie',
+        header: 'Orphaned/Unmapped Cookie',
         accessorKey: 'frameIdList',
         isHiddenByDefault: true,
         cell: (info: InfoType) => (
           <OrphanedUnMappedInfoDisplay frameIdList={info as number[]} />
         ),
         widthWeightagePercentage: 7.6,
-      },
-      {
-        header: 'Unmapped Cookie',
-        accessorKey: 'frameIdList',
-        cell: (info: InfoType) => (
-          <p className="flex justify-center items-center">
-            {(info as number[]).length === 0 ? (
-              <span className="font-serif">✓</span>
-            ) : (
-              ''
-            )}
-          </p>
-        ),
-        widthWeightagePercentage: 7,
       },
     ],
     [isUsingCDP]

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/orphanedUnMappedInfoDisplay.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/orphanedUnMappedInfoDisplay.tsx
@@ -33,6 +33,10 @@ const OrphanedUnMappedInfoDisplay = ({
     return <></>;
   }
 
+  if (frameIdList.length === 0) {
+    return <span className="font-serif">Unmapped Cookie</span>;
+  }
+
   let tabFramesIDMap: Set<number> = new Set();
 
   Object.keys(tabFrames).forEach((url) => {
@@ -50,7 +54,10 @@ const OrphanedUnMappedInfoDisplay = ({
     }
   });
 
-  return hasFrame ? '' : <span className="font-serif">✓</span>;
+  if (!hasFrame) {
+    return <span>Orphaned Cookie</span>;
+  }
+  return <></>;
 };
 
 export default OrphanedUnMappedInfoDisplay;

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/orphanedUnMappedInfoDisplay.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/orphanedUnMappedInfoDisplay.tsx
@@ -30,11 +30,11 @@ const OrphanedUnMappedInfoDisplay = ({
   const tabFrames = useCookieStore(({ state }) => state.tabFrames);
 
   if (!tabFrames) {
-    return <></>;
+    return <span>{''}</span>;
   }
 
   if (frameIdList.length === 0) {
-    return <span className="font-serif">Unmapped Cookie</span>;
+    return <span>Unmapped Cookie</span>;
   }
 
   let tabFramesIDMap: Set<number> = new Set();
@@ -48,6 +48,7 @@ const OrphanedUnMappedInfoDisplay = ({
   });
 
   let hasFrame = true;
+
   frameIdList.forEach((id) => {
     if (!tabFramesIDMap.has(id)) {
       hasFrame = false;
@@ -57,7 +58,7 @@ const OrphanedUnMappedInfoDisplay = ({
   if (!hasFrame) {
     return <span>Orphaned Cookie</span>;
   }
-  return <></>;
+  return <span>{''}</span>;
 };
 
 export default OrphanedUnMappedInfoDisplay;


### PR DESCRIPTION
## Description
The PR aims to remove orphan cookies and unmapped cookies from the sidebar list.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices
- The unmapped cookies to appropriate frames by matching the frameURL with the domain.
- The Orphaned cookies are added to the top frame.

## Testing Instructions
- Clone this branch.
- Go to the terminal and run `npm start`
- In the sidebar, you should not see `Orphaned Cookie` or `Unmapped Cookie`.
- Cookies which were being shown in `unmapped cookies` will now be shown in frames with matching domains.
- Cookies which were `orphaned` will be shown in the top frame

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [ ] I have thoroughly tested this code to the best of my abilities.
- [ ] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
