### PR TITLE
Feature: Enable CDP and multi-tab using query parameters

### DIFF
--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -288,6 +288,9 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
       allowedNumberOfTabs: queryParams.psat_multitab ? 'unlimited' : 'single',
       isUsingCDP: Boolean(queryParams.psat_cdp),
     });
+
+    globalIsUsingCDP = Boolean(queryParams.psat_cdp);
+    tabMode = queryParams.psat_multitab ? 'unlimited' : 'single';
   }
 
   syncCookieStore?.updateUrl(tabId, tab.url);

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -35,6 +35,7 @@ import { ALLOWED_NUMBER_OF_TABS } from '../constants';
 import SynchnorousCookieStore from '../store/synchnorousCookieStore';
 import canProcessCookies from '../utils/canProcessCookies';
 import { getTab } from '../utils/getTab';
+import getQueryParams from '../utils/getQueryParams';
 import reloadCurrentTab from '../utils/reloadCurrentTab';
 
 let cookieDB: CookieDatabase | null = null;
@@ -278,6 +279,15 @@ chrome.runtime.onStartup.addListener(async () => {
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (!tab.url) {
     return;
+  }
+
+  const queryParams = getQueryParams(tab.url);
+
+  if (queryParams.psat_cdp || queryParams.psat_multitab) {
+    await chrome.storage.sync.set({
+      allowedNumberOfTabs: queryParams.psat_multitab ? 'unlimited' : 'single',
+      isUsingCDP: Boolean(queryParams.psat_cdp),
+    });
   }
 
   syncCookieStore?.updateUrl(tabId, tab.url);

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -285,12 +285,13 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
   if (queryParams.psat_cdp || queryParams.psat_multitab) {
     await chrome.storage.sync.set({
-      allowedNumberOfTabs: queryParams.psat_multitab ? 'unlimited' : 'single',
-      isUsingCDP: Boolean(queryParams.psat_cdp),
+      allowedNumberOfTabs:
+        queryParams.psat_multitab === 'on' ? 'unlimited' : 'single',
+      isUsingCDP: queryParams.psat_cdp === 'on',
     });
 
-    globalIsUsingCDP = Boolean(queryParams.psat_cdp);
-    tabMode = queryParams.psat_multitab ? 'unlimited' : 'single';
+    globalIsUsingCDP = queryParams.psat_cdp === 'on';
+    tabMode = queryParams.psat_multitab === 'on' ? 'unlimited' : 'single';
   }
 
   syncCookieStore?.updateUrl(tabId, tab.url);

--- a/packages/extension/src/utils/getQueryParams.ts
+++ b/packages/extension/src/utils/getQueryParams.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const getQueryParams = (urlString: string) => {
+  const params = {
+    psat_cdp: '',
+    psat_multitab: '',
+  };
+
+  if (!urlString) {
+    return params;
+  }
+
+  try {
+    const url = new URL(urlString);
+    const urlParams = url.searchParams;
+
+    params.psat_cdp = urlParams.get('psat_cdp') || '';
+    params.psat_multitab = urlParams.get('psat_multitab') || '';
+  } catch (error) {
+    // Fail silently.
+  }
+
+  return params;
+};
+
+export default getQueryParams;

--- a/packages/extension/src/utils/tests/getQueryParams.ts
+++ b/packages/extension/src/utils/tests/getQueryParams.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies.
+ */
+import getQueryParams from '../getQueryParams';
+
+describe('Test getQueryParams', () => {
+  test('should return empty params object if no URL string is provided', () => {
+    const params = getQueryParams('');
+
+    expect(params).toEqual({
+      psat_cdp: '',
+      psat_multitab: '',
+    });
+  });
+
+  test('should return params object with values extracted from the URL string', () => {
+    const urlString = 'https://example.com/?psat_cdp=on&psat_multitab=on';
+    const params = getQueryParams(urlString);
+
+    expect(params).toEqual({
+      psat_cdp: 'on',
+      psat_multitab: 'on',
+    });
+  });
+
+  test('should return default params if URL string is invalid', () => {
+    const urlString = 'invalid_url';
+    const params = getQueryParams(urlString);
+
+    expect(params).toEqual({
+      psat_cdp: '',
+      psat_multitab: '',
+    });
+  });
+});

--- a/packages/extension/src/view/devtools/stateProviders/syncSettingsStore/index.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/syncSettingsStore/index.tsx
@@ -206,6 +206,9 @@ export const Provider = ({ children }: PropsWithChildren) => {
         Object.keys(changes.allowedNumberOfTabs).includes('newValue')
       ) {
         setAllowedNumberOfTabs(changes?.allowedNumberOfTabs?.newValue);
+        setAllowedNumberOfTabsForSettingsPageDisplay(
+          changes?.allowedNumberOfTabs?.newValue
+        );
       }
 
       if (
@@ -213,6 +216,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
         Object.keys(changes.isUsingCDP).includes('newValue')
       ) {
         setIsUsingCDP(changes?.isUsingCDP?.newValue);
+        setIsUsingCDPForSettingsPageDisplay(changes?.isUsingCDP?.newValue);
       }
     },
     []

--- a/packages/extension/src/view/popup/stateProviders/syncCookieStore/index.tsx
+++ b/packages/extension/src/view/popup/stateProviders/syncCookieStore/index.tsx
@@ -338,6 +338,9 @@ export const Provider = ({ children }: PropsWithChildren) => {
         Object.keys(changes.allowedNumberOfTabs).includes('newValue')
       ) {
         setAllowedNumberOfTabs(changes?.allowedNumberOfTabs?.newValue);
+        setAllowedNumberOfTabsForSettingsDisplay(
+          changes?.allowedNumberOfTabs?.newValue
+        );
       }
 
       if (
@@ -345,6 +348,7 @@ export const Provider = ({ children }: PropsWithChildren) => {
         Object.keys(changes.isUsingCDP).includes('newValue')
       ) {
         setIsUsingCDP(changes?.isUsingCDP?.newValue);
+        setIsUsingCDPForSettingsDisplay(changes?.isUsingCDP?.newValue);
       }
     },
     []


### PR DESCRIPTION
## Description

Enable CDP and multi-tab using query parameters, so that we can enable these settings when using [CLI commands ](https://github.com/GoogleChromeLabs/ps-analysis-tool/wiki/Evaluation-Environment#spinning-chrome-instances-from-command-line)

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

- Go to any website like example.com and turn off CDP and mutlitab settings from PSAT settings section.
- Now go the some website like example.com and use the following query params https://example.com/?psat_cdp=on&psat_multitab=on
- The CDP and multi-tab settings should not be on.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
