### PR TITLE
Fix: Normalise cookie key to fix duplicate cookie issue

### DIFF
--- a/packages/common/src/utils/getCookieKey.ts
+++ b/packages/common/src/utils/getCookieKey.ts
@@ -26,8 +26,10 @@ const getCookieKey = (parsedCookie: ParsedCookie) => {
   if (!cookieName || !cookieDomain || !cookiePath) {
     return '';
   }
-
-  return (cookieName + cookieDomain + cookiePath).trim();
+  const domainToUse = cookieDomain.startsWith('.')
+    ? cookieDomain.slice(1)
+    : cookieDomain;
+  return (cookieName + domainToUse + cookiePath).trim();
 };
 
 export default getCookieKey;

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -504,11 +504,7 @@ chrome.debugger.onEvent.addListener((source, method, params) => {
     const { cookie, cookieExclusionReasons, cookieWarningReasons } =
       details.cookieIssueDetails;
 
-    const primaryDomain = cookie?.domain.startsWith('.')
-      ? cookie.domain
-      : '.' + cookie?.domain;
-
-    const secondaryDomain = cookie?.domain.startsWith('.')
+    const domainToUse = cookie?.domain.startsWith('.')
       ? cookie.domain.slice(1)
       : cookie?.domain;
 
@@ -516,9 +512,7 @@ chrome.debugger.onEvent.addListener((source, method, params) => {
     // This is done to capture both NID.google.com/ and NIDgoogle.com/ so that if we find either of the cookie we add issues to the cookie object
     try {
       syncCookieStore?.addCookieExclusionWarningReason(
-        cookie?.name + primaryDomain + cookie?.path,
-        //@ts-ignore since the details has been checked before sending them as parameter.
-        cookie?.name + secondaryDomain + cookie?.path,
+        cookie?.name + domainToUse + cookie?.path,
         cookieExclusionReasons,
         cookieWarningReasons,
         source.tabId

--- a/packages/extension/src/store/synchnorousCookieStore.ts
+++ b/packages/extension/src/store/synchnorousCookieStore.ts
@@ -222,14 +222,12 @@ class SynchnorousCookieStore {
   /**
    * Adds exclusion and warning reasons for a given cookie.
    * @param {string} cookieName Name of the cookie.
-   * @param {string} alternateCookieName Alternate name of the cookie.
    * @param {string[]} exclusionReasons reasons to be added to the blocked reason array.
    * @param {string[]} warningReasons warning reasons to be added to the warning reason array.
    * @param {number} tabId tabId where change has to be made.
    */
   addCookieExclusionWarningReason(
     cookieName: string,
-    alternateCookieName: string,
     exclusionReasons: BlockedReason[],
     warningReasons: Protocol.Audits.CookieWarningReason[],
     tabId: number
@@ -239,11 +237,7 @@ class SynchnorousCookieStore {
     }
 
     // Check if primaryDomain cookie exists
-    if (
-      this.tabsData[tabId] &&
-      this.tabsData[tabId][cookieName] &&
-      !this.tabsData[tabId][alternateCookieName]
-    ) {
+    if (this.tabsData[tabId] && this.tabsData[tabId][cookieName]) {
       this.tabsData[tabId][cookieName].blockedReasons = [
         ...new Set([
           ...(this.tabsData[tabId][cookieName].blockedReasons ?? []),
@@ -262,39 +256,11 @@ class SynchnorousCookieStore {
         exclusionReasons.length > 0 ? true : false;
       this.tabs[tabId].newUpdates++;
       // Check if secondaryDomain cookie exists
-    } else if (
-      this.tabsData[tabId] &&
-      !this.tabsData[tabId][cookieName] &&
-      this.tabsData[tabId][alternateCookieName]
-    ) {
-      this.tabs[tabId].newUpdates++;
-      this.tabsData[tabId][alternateCookieName].blockedReasons = [
-        ...new Set([
-          ...(this.tabsData[tabId][alternateCookieName].blockedReasons ?? []),
-          ...exclusionReasons,
-        ]),
-      ];
-
-      this.tabsData[tabId][alternateCookieName].warningReasons = [
-        ...new Set([
-          ...(this.tabsData[tabId][alternateCookieName].warningReasons ?? []),
-          ...warningReasons,
-        ]),
-      ];
-
-      this.tabsData[tabId][alternateCookieName].isBlocked =
-        exclusionReasons.length > 0 ? true : false;
     } else {
       this.tabs[tabId].newUpdates++;
       // If none of them exists. This case is possible when the cookies hasnt processed and we already have an issue.
       this.tabsData[tabId] = {
         ...this.tabsData[tabId],
-        [alternateCookieName]: {
-          ...(this.tabsData[tabId][alternateCookieName] ?? {}),
-          blockedReasons: [...exclusionReasons],
-          warningReasons: [...warningReasons],
-          isBlocked: exclusionReasons.length > 0 ? true : false,
-        },
         [cookieName]: {
           ...(this.tabsData[tabId][cookieName] ?? {}),
           blockedReasons: [...exclusionReasons],

--- a/packages/extension/src/store/tests/synchnorousCookieStore.ts
+++ b/packages/extension/src/store/tests/synchnorousCookieStore.ts
@@ -44,11 +44,11 @@ describe('SynchnorousCookieStore:', () => {
 
   it('Should add new cookie if cookie doesnt exist', () => {
     expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/']
+      synchnorousCookieStore.tabsData[123456]['_cbcnn.com/']
     ).toBeUndefined();
     synchnorousCookieStore.update(123456, [data.tabCookies['_cb']]);
     expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/']
+      synchnorousCookieStore.tabsData[123456]['_cbcnn.com/']
     ).not.toBeUndefined();
     expect(synchnorousCookieStore.tabs[123456].newUpdates).toBe(1);
   });
@@ -59,11 +59,11 @@ describe('SynchnorousCookieStore:', () => {
     ]);
 
     expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/']?.isBlocked
+      synchnorousCookieStore.tabsData[123456]['_cbcnn.com/']?.isBlocked
     ).toBe(false);
 
     expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/']?.blockedReasons
+      synchnorousCookieStore.tabsData[123456]['_cbcnn.com/']?.blockedReasons
         ?.length
     ).toBe(0);
     expect(synchnorousCookieStore.tabs[123456].newUpdates).toBe(1);
@@ -77,11 +77,11 @@ describe('SynchnorousCookieStore:', () => {
     ]);
 
     expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/']?.isBlocked
+      synchnorousCookieStore.tabsData[123456]['_cbcnn.com/']?.isBlocked
     ).toBe(true);
 
     expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/'].blockedReasons
+      synchnorousCookieStore.tabsData[123456]['_cbcnn.com/'].blockedReasons
     ).toContain('InvalidDomain');
     expect(synchnorousCookieStore.tabs[123456].newUpdates).toBe(2);
   });
@@ -99,7 +99,7 @@ describe('SynchnorousCookieStore:', () => {
     ]);
 
     expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/']?.parsedCookie
+      synchnorousCookieStore.tabsData[123456]['_cbcnn.com/']?.parsedCookie
         ?.partitionKey
     ).toBe('https://bbc.com');
     expect(synchnorousCookieStore.tabs[123456].newUpdates).toBe(1);
@@ -116,7 +116,7 @@ describe('SynchnorousCookieStore:', () => {
     ]);
 
     expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/']?.parsedCookie
+      synchnorousCookieStore.tabsData[123456]['_cbcnn.com/']?.parsedCookie
         ?.partitionKey
     ).toBe('https://bbc.com');
     expect(synchnorousCookieStore.tabs[123456].newUpdates).toBe(2);
@@ -159,7 +159,6 @@ describe('SynchnorousCookieStore:', () => {
 
   it('Should add cookie exclusion reason and warning reason', () => {
     synchnorousCookieStore.addCookieExclusionWarningReason(
-      '_cb.cnn.com/',
       '_cbcnn.com/',
       [],
       ['WarnSameSiteUnspecifiedCrossSiteContext'],
@@ -167,24 +166,15 @@ describe('SynchnorousCookieStore:', () => {
     );
 
     expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/'].warningReasons
-    ).toContain('WarnSameSiteUnspecifiedCrossSiteContext');
-
-    expect(
       synchnorousCookieStore.tabsData[123456]['_cbcnn.com/'].warningReasons
     ).toContain('WarnSameSiteUnspecifiedCrossSiteContext');
 
     synchnorousCookieStore.addCookieExclusionWarningReason(
-      '_cb.cnn.com/',
       '_cbcnn.com/',
       ['ExcludeSameSiteUnspecifiedTreatedAsLax'],
       [],
       123456
     );
-
-    expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/'].blockedReasons
-    ).toContain('ExcludeSameSiteUnspecifiedTreatedAsLax');
 
     expect(
       synchnorousCookieStore.tabsData[123456]['_cbcnn.com/'].blockedReasons
@@ -199,19 +189,19 @@ describe('SynchnorousCookieStore:', () => {
 
   it('Should remove cookie', () => {
     expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/']
+      synchnorousCookieStore.tabsData[123456]['_cbcnn.com/']
     ).toBeUndefined();
 
     synchnorousCookieStore.update(123456, [data.tabCookies['_cb']]);
 
     expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/']
+      synchnorousCookieStore.tabsData[123456]['_cbcnn.com/']
     ).toBeDefined();
 
     synchnorousCookieStore.removeCookieData(123456);
 
     expect(
-      synchnorousCookieStore.tabsData[123456]['_cb.cnn.com/']
+      synchnorousCookieStore.tabsData[123456]['_cbcnn.com/']
     ).toBeUndefined();
   });
 });

--- a/packages/extension/src/store/utils/updateCookieBadgeText.ts
+++ b/packages/extension/src/store/utils/updateCookieBadgeText.ts
@@ -35,7 +35,7 @@ export default function updateCookieBadgeText(
     const numCookies = Object.keys(storage).filter(
       (cookieKey) =>
         storage[cookieKey]?.parsedCookie &&
-        storage[cookieKey].frameIdList?.length >= 1
+        storage[cookieKey].frameIdList?.length >= 0
     ).length;
     if (numCookies >= 0) {
       chrome.action.setBadgeText(

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/tests/useHighlighting.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/tests/useHighlighting.tsx
@@ -55,7 +55,7 @@ describe('useHighlighting', () => {
       )
     );
 
-    expect(nextState['KRTBCOOKIE_290.pubmatic.com/']).toEqual(
+    expect(nextState['KRTBCOOKIE_290pubmatic.com/']).toEqual(
       expect.objectContaining(mock.default.tabCookies['KRTBCOOKIE_290'])
     );
   });


### PR DESCRIPTION
## Description
This PR aims to normalise the cookie key by removing the `.` at the start of the domain.

## Relevant Technical Choices
- `getCookieKey` will check if the domain has a leading `.` then it will remove it else it will use it as is.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
