### PR TITLE
Feature: Close support issues using stale actions.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Mark issues as stale.
+
+on:
+  schedule:
+    - cron: '44 20 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-issue-close: 14
+          exempt-all-milestones: true
+          only-labels: 'support'
+          stale-issue-message: 'This issue has been marked as stale because there has been no activity in the past 30 days.'
+          close-issue-message: 'This issue has been closed since there was no activity since it was marked as stale.'
+          stale-issue-label: 'stale'
+          remove-issue-stale-when-updated: true
+          labels-to-remove-when-unstale: 'stale'


### PR DESCRIPTION
## Description
This PR aims to close issues labelled as support and have had no activity for the last 30 days. After 30 days, the issue will be marked as `stale` 14 days after the issue is closed with a closing message.

## Relevant Technical Choices
- A GitHub Action cronJob is run which checks the support labelled issues.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [ ] I have thoroughly tested this code to the best of my abilities.
- [ ] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
