### PR TITLE
Feat: Add option to pass a port for development server

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -55,10 +55,7 @@ program
     '-p, --sitemap-path <value>',
     'Path to a sitemap saved in the file system'
   )
-  .option(
-    '-po, --dashboard-port <value>',
-    'A port for the CLI dashboard server.'
-  )
+  .option('-po, --port <value>', 'A port for the CLI dashboard server.')
   .option('-ul, --url-limit <value>', 'No of URLs to analyze')
   .option(
     '-nh, --no-headless ',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -101,7 +101,7 @@ const startDashboardServer = async (dir: string, port: number) => {
   const sitemapUrl = program.opts().sitemapUrl;
   const csvPath = program.opts().csvPath;
   const sitemapPath = program.opts().sitemapPath;
-  const dashboardPort = parseInt(program.opts().dashboardPort || '9000');
+  const port = parseInt(program.opts().port || '9000');
   const numberOfUrlsInput = program.opts().urlLimit;
   const isHeadless = Boolean(program.opts().headless);
   const shouldSkipPrompts = !program.opts().prompts;
@@ -109,27 +109,28 @@ const startDashboardServer = async (dir: string, port: number) => {
   const outDir = program.opts().outDir;
   const shouldSkipAcceptBanner = program.opts().acceptBanner;
 
-  //check if devserver port in already in use only if the dashboard is goint to be used
-
-  if (!outDir) {
-    const isPortInUse = await checkPortInUse(dashboardPort);
-
-    if (isPortInUse) {
-      console.error(
-        `Error: Report server port ${dashboardPort} already in use. You might be already running CLI`
-      );
-      process.exit(1);
-    }
-  }
-
   validateArgs(
     url,
     sitemapUrl,
     csvPath,
     sitemapPath,
     numberOfUrlsInput,
-    outDir
+    outDir,
+    port
   );
+
+  //check if devserver port in already in use only if the dashboard is goint to be used
+
+  if (!outDir) {
+    const isPortInUse = await checkPortInUse(port);
+
+    if (isPortInUse) {
+      console.error(
+        `Error: Report server port ${port} already in use. You might be already running CLI`
+      );
+      process.exit(1);
+    }
+  }
 
   const prefix =
     url || sitemapUrl
@@ -236,6 +237,6 @@ const startDashboardServer = async (dir: string, port: number) => {
   startDashboardServer(
     encodeURIComponent(prefix) +
       (sitemapUrl || csvPath || sitemapPath ? '&type=sitemap' : ''),
-    dashboardPort
+    port
   );
 })();

--- a/packages/cli/src/utils/tests/validateArgs.ts
+++ b/packages/cli/src/utils/tests/validateArgs.ts
@@ -44,7 +44,7 @@ describe('validateArgs', () => {
       return;
     });
 
-    validateArgs('https://example.com', '', '', '', '', '');
+    validateArgs('https://example.com', '', '', '', '', '', 9000);
 
     expect(mockExit).toHaveBeenCalledTimes(0);
   });
@@ -59,7 +59,7 @@ describe('validateArgs', () => {
     jest.spyOn(fse, 'mkdir').mockImplementation(() => {
       return;
     });
-    validateArgs('', '', '', '', '', '');
+    validateArgs('', '', '', '', '', '', 9000);
 
     expect(mockExit).toHaveBeenCalled();
   });
@@ -80,7 +80,8 @@ describe('validateArgs', () => {
       '',
       '',
       '',
-      ''
+      '',
+      9000
     );
 
     expect(mockExit).toHaveBeenCalled();
@@ -92,7 +93,7 @@ describe('validateArgs', () => {
       return false;
     });
 
-    validateArgs('', '', '', './path/list.xml', '', '');
+    validateArgs('', '', '', './path/list.xml', '', '', 9000);
 
     expect(mockExit).toHaveBeenCalled();
   });
@@ -103,7 +104,7 @@ describe('validateArgs', () => {
       return true;
     });
 
-    validateArgs('', '', '', './path/list.xml', 'a', '');
+    validateArgs('', '', '', './path/list.xml', 'a', '', 9000);
 
     expect(mockExit).toHaveBeenCalled();
   });

--- a/packages/cli/src/utils/validateArgs.ts
+++ b/packages/cli/src/utils/validateArgs.ts
@@ -26,6 +26,7 @@ import path from 'path';
  * @param {string} sitemapPath File system path to a sitemap xml file.
  * @param {string} numberOfUrls Url limit argument.
  * @param {string} outDir File system path to the output directory.
+ * @param port
  */
 // eslint-disable-next-line complexity
 const validateArgs = async (
@@ -34,8 +35,14 @@ const validateArgs = async (
   csvPath: string,
   sitemapPath: string,
   numberOfUrls: string,
-  outDir: string
+  outDir: string,
+  port: number
 ) => {
+  if (isNaN(port) || (!isNaN(port) && (port < 0 || port > 65536))) {
+    console.log(`Invalid port argument. Please porvide a port >=0 and <=65536`);
+    process.exit(1);
+  }
+
   const numArgs: number = [
     Boolean(url),
     Boolean(sitemapUrl),


### PR DESCRIPTION
## Description
Adds a new argument to the CLI interface '--dashboard-port' or '-po' which can be used to launch the CLI server on a chosen port.

## Relevant Technical Choices
- Naming the new argument CLI interface '--dashboard-port' or '-po'.
- Add a check that the user has chosen options for the dashboard to be launched before checking for any port conflicts.

## Testing Instructions

- Use the cli command `npm run cli -- -u https://edition.cnn.com -po 9009`
- CLI dashboard should be launched on the chosen port.
- A service running on chosen port should not effect the CLI's functioning if its run in headless mode. `npm run cli -- -u https://edition.cnn.com -d ./out`

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #573 
