### PR TITLE
Fix: Left over references and make some more space in the cookie table.

### DIFF
--- a/packages/common/src/constants/index.ts
+++ b/packages/common/src/constants/index.ts
@@ -14,5 +14,3 @@
  * limitations under the License.
  */
 export const UNKNOWN_FRAME_KEY = 'Unknown Frames';
-export const ORPHANED_COOKIE_KEY = 'Orphaned Cookies';
-export const UNMAPPED_COOKIE_KEY = 'Unmapped Cookies';

--- a/packages/extension/src/utils/getFramesForCurrentTab.ts
+++ b/packages/extension/src/utils/getFramesForCurrentTab.ts
@@ -16,11 +16,7 @@
 /**
  * External dependencies
  */
-import {
-  type TabFrames,
-  ORPHANED_COOKIE_KEY,
-  UNMAPPED_COOKIE_KEY,
-} from '@ps-analysis-tool/common';
+import { type TabFrames } from '@ps-analysis-tool/common';
 
 /**
  * Internal dependencies
@@ -66,7 +62,6 @@ export default async function getFramesForCurrentTab() {
       return tabFrame;
     })
   );
-  modifiedTabFrames[ORPHANED_COOKIE_KEY] = { frameIds: [] };
-  modifiedTabFrames[UNMAPPED_COOKIE_KEY] = { frameIds: [] };
+
   return modifiedTabFrames;
 }

--- a/packages/extension/src/utils/tests/getFramesForCurrentTab.ts
+++ b/packages/extension/src/utils/tests/getFramesForCurrentTab.ts
@@ -69,12 +69,6 @@ describe('getFramesForCurrentTab : ', () => {
         isOnRWS: false,
         frameType: 'sub_frame',
       },
-      'Orphaned Cookies': {
-        frameIds: [],
-      },
-      'Unmapped Cookies': {
-        frameIds: [],
-      },
     });
   });
 });

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/framesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/framesSection.tsx
@@ -22,38 +22,20 @@ import {
   CookiesMatrix,
   prepareFrameStatsComponent,
 } from '@ps-analysis-tool/design-system';
-import {
-  ORPHANED_COOKIE_KEY,
-  UNMAPPED_COOKIE_KEY,
-} from '@ps-analysis-tool/common';
 /**
  * Internal dependencies
  */
 import { useCookie } from '../../../stateProviders';
 
 const FramesSection = () => {
-  const { tabCookies, tabFrames, frameHasCookies } = useCookie(({ state }) => ({
+  const { tabCookies, tabFrames } = useCookie(({ state }) => ({
     tabCookies: state.tabCookies,
     tabFrames: state.tabFrames,
-    frameHasCookies: state.frameHasCookies,
   }));
 
   const processedTabFrames = useMemo(
-    () =>
-      Object.fromEntries(
-        Object.entries(tabFrames || {}).filter(([url]) => {
-          if (url === ORPHANED_COOKIE_KEY) {
-            return frameHasCookies[url];
-          }
-
-          if (url === UNMAPPED_COOKIE_KEY) {
-            return frameHasCookies[url];
-          }
-
-          return true;
-        })
-      ),
-    [tabFrames, frameHasCookies]
+    () => Object.fromEntries(Object.entries(tabFrames || {})),
+    [tabFrames]
   );
 
   const framesStats = prepareFrameStatsComponent(

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/useCookieListing/index.tsx
@@ -164,12 +164,14 @@ const useCookieListing = (domainsInAllowList: Set<string>) => {
       {
         header: 'Priority',
         accessorKey: 'parsedCookie.priority',
+        isHiddenByDefault: true,
         cell: (info: InfoType) => info,
         widthWeightagePercentage: 4,
       },
       {
         header: 'Size',
         accessorKey: 'parsedCookie.size',
+        isHiddenByDefault: true,
         cell: (info: InfoType) => info,
         widthWeightagePercentage: 3,
       },


### PR DESCRIPTION
## Description
This PR aims to hide the `priority` and `size` columns since they do not provide any useful information. This PR also aims to sweep some leftover references for `unmapped cookies` and `orphaned cookies` from the sidebar.

## Testing Instructions
- Clone this branch. In the terminal run `npm start`.
- Open a fresh browser instance and go to `https://bbc.com`.
- There should be no `Unmapped Cookies` or `Orphaned Cookies` in the frames list.
- Click on any of the frames having cookies you should see the table without `priority` and `size` columns.

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
