### PR TITLE
Enhancement: Move download report button in cli-dashboard to the sticky menu bar

### DIFF
--- a/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/index.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/index.tsx
@@ -19,7 +19,6 @@
  */
 import React, { useMemo } from 'react';
 import {
-  Button,
   CookiesLanding,
   MenuBar,
   type CookiesLandingSection,
@@ -78,17 +77,10 @@ const CookiesLandingContainer = ({
 
   return (
     <>
-      {downloadReport && (
-        <div className="absolute right-0 py-5 px-5">
-          <Button
-            extraClasses="w-fit text-sm flex justify-center items-center"
-            text="Download Report"
-            onClick={downloadReport}
-          />
-        </div>
-      )}
       <CookiesLanding>
         <MenuBar
+          disableReportDownload={false}
+          downloadReport={downloadReport}
           menuData={menuData}
           extraClasses="top-20"
           scrollContainerId="dashboard-layout-container"

--- a/packages/design-system/src/components/menuBar/index.tsx
+++ b/packages/design-system/src/components/menuBar/index.tsx
@@ -32,7 +32,7 @@ export type MenuData = Array<{
 }>;
 
 interface MenuBarProps {
-  disableReportDownload: boolean;
+  disableReportDownload?: boolean;
   downloadReport?: () => void;
   menuData: MenuData;
   extraClasses?: string;


### PR DESCRIPTION
## Description

This PR moves download report button in cli-dashboard to the sticky menu bar


## Screenshot/Screencast
<img width="1439" alt="Screenshot 2024-04-10 at 1 32 28 PM" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/53055971/c7f38011-292a-4279-92fe-620d59de1a7f">

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
