### PR TITLE
Fix: CLI dashboard showing multiple cookie entries for same cookies

### DIFF
--- a/packages/cli/src/utils/browserManagement/index.ts
+++ b/packages/cli/src/utils/browserManagement/index.ts
@@ -365,7 +365,7 @@ export class BrowserManagement {
           requestMap,
           frameIdUrlMap,
           mainFrameId,
-          url
+          page.url()
         );
 
         const networkCookieKeySet = new Set();

--- a/packages/cli/src/utils/browserManagement/parseNetworkDataToCookieData.ts
+++ b/packages/cli/src/utils/browserManagement/parseNetworkDataToCookieData.ts
@@ -85,10 +85,14 @@ export const parseNetworkDataToCookieData = (
     data.responses?.forEach((response: ResponseData) => {
       response.cookies.forEach((cookie) => {
         // domain update required. Domain based on the server url
-        const parsedDomain =
+        let parsedDomain =
           cookie.parsedCookie.domain === ''
             ? getDomain(response.serverUrl)
             : cookie.parsedCookie.domain;
+
+        if (parsedDomain && parsedDomain[0] !== '.') {
+          parsedDomain = '.' + parsedDomain;
+        }
 
         const key =
           cookie.parsedCookie.name +
@@ -119,10 +123,14 @@ export const parseNetworkDataToCookieData = (
     data.requests?.forEach((request: RequestData) => {
       request.cookies.forEach((cookie) => {
         // domain update required. Domain based on the server url
-        const parsedDomain =
+        let parsedDomain =
           cookie.parsedCookie.domain === ''
             ? getDomain(request.serverUrl)
             : cookie.parsedCookie.domain;
+
+        if (parsedDomain && parsedDomain[0] !== '.') {
+          parsedDomain = '.' + parsedDomain;
+        }
 
         const key =
           cookie.parsedCookie.name +

--- a/packages/cli/src/utils/browserManagement/parseNetworkDataToCookieData.ts
+++ b/packages/cli/src/utils/browserManagement/parseNetworkDataToCookieData.ts
@@ -156,7 +156,7 @@ export const parseNetworkDataToCookieData = (
     });
 
     frameIdCookiesMap.set(frameId, {
-      frameUrl: frameIdUrlMap.get(frameId) || pageUrl,
+      frameUrl: frameIdUrlMap.get(frameId) || new URL(pageUrl).origin,
       frameCookies: Object.fromEntries(_frameCookies),
     });
   }
@@ -174,6 +174,7 @@ export const parseNetworkDataToCookieData = (
     if (!data.frameUrl.includes('http')) {
       continue;
     }
+
     const _url = new URL(data.frameUrl);
 
     const newFrameCookies = {


### PR DESCRIPTION
## Description

There were multiple copies of same copies with the only difference being a ".". This PR fixes that issue by adding a "." in front of all the cookie domains missing that. This approach is inspired by how the Chrome browser internally handles cookie domain.



## Testing Instructions
- Analyze the website - https://rtcamp.com.
- There should not be multiple entries of the same cookie 


## Screenshot/Screencast

### Before
<img width="1015" alt="Screenshot 2024-04-10 at 4 12 15 PM" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/53055971/c795b4ea-4466-4c18-a504-ee8d5a60a6e4">

### After

<img width="1439" alt="Screenshot 2024-04-10 at 4 11 29 PM" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/53055971/ca5526aa-6ae9-4ac4-b09d-01583590c371">


## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

