### PR TITLE
Navigate to `Settings` page from `Blocked Cookies` section

### DIFF
--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/blockedCookiesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/blockedCookiesSection.tsx
@@ -26,6 +26,8 @@ import {
   type MatrixComponentProps,
   LEGEND_DESCRIPTION,
   useFiltersMapping,
+  SIDEBAR_ITEMS_KEYS,
+  useSidebar,
 } from '@ps-analysis-tool/design-system';
 /**
  * Internal dependencies
@@ -42,6 +44,12 @@ const BlockedCookiesSection = () => {
     isUsingCDP: state.isUsingCDP,
   }));
 
+  // Callback handling updating selected item from the sidebar
+  const updateSelectedItemKey = useSidebar(
+    ({ actions }) => actions.updateSelectedItemKey
+  );
+
+  // For opening Cookies table with pre-filtered data, uses updateSelectedItemKey from useSidebar internally
   const { selectedItemUpdater } = useFiltersMapping(tabFrames || {});
 
   const cookieStats = prepareCookiesCount(tabCookies);
@@ -72,9 +80,17 @@ const BlockedCookiesSection = () => {
 
   const description = !isUsingCDP ? (
     <>
-      To gather data and insights regarding blocked cookies, please enable PSAT
-      to use the Chrome DevTools protocol. You can do this in the Settings page
-      or in the extension popup. For more information check the PSAT&nbsp;
+      Enable PSAT to use CDP for all cookie data, via the{' '}
+      <button
+        className="text-bright-navy-blue dark:text-jordy-blue"
+        onClick={() => {
+          updateSelectedItemKey(SIDEBAR_ITEMS_KEYS.SETTINGS);
+        }}
+      >
+        Settings page
+      </button>
+      . <br />
+      For more information, visit the PSAT&nbsp;
       <a
         target="_blank"
         rel="noreferrer"
@@ -83,6 +99,7 @@ const BlockedCookiesSection = () => {
       >
         Wiki
       </a>
+      .
     </>
   ) : (
     ''

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/blockedCookiesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/blockedCookiesSection.tsx
@@ -80,7 +80,7 @@ const BlockedCookiesSection = () => {
 
   const description = !isUsingCDP ? (
     <>
-      Enable PSAT to use CDP for all cookie data, via the{' '}
+      Enable PSAT to use CDP via the{' '}
       <button
         className="text-bright-navy-blue dark:text-jordy-blue"
         onClick={() => {

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/blockedCookiesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/blockedCookiesSection.tsx
@@ -44,7 +44,7 @@ const BlockedCookiesSection = () => {
     isUsingCDP: state.isUsingCDP,
   }));
 
-  // Callback handling updating selected item from the sidebar
+  // Callback selecting/updating the clicked item in the sidebar
   const updateSelectedItemKey = useSidebar(
     ({ actions }) => actions.updateSelectedItemKey
   );


### PR DESCRIPTION
## Description
This PR adds code to allow user move from Blocked Cookies section description text to Settings page for enabling CDP.
It also updates the text of the description.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open Cookies landing page with CDP disabled.
- Scroll to blocked cookies section.
- The text below piechart will be contain new text with Settings page as clickable element.
- Click on text and it should open settings page.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="470" alt="Screenshot 2024-04-11 at 16 37 06" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/6d989c2f-686b-41ae-90af-7e9a934a1544">


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
