### PR TITLE
Vertically centre align menu bar

### DIFF
--- a/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/index.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/index.tsx
@@ -82,7 +82,6 @@ const CookiesLandingContainer = ({
           disableReportDownload={false}
           downloadReport={downloadReport}
           menuData={menuData}
-          extraClasses="top-20"
           scrollContainerId="dashboard-layout-container"
         />
         {sections.map(({ link, panel: { Element, props } }) => (

--- a/packages/design-system/src/components/menuBar/index.tsx
+++ b/packages/design-system/src/components/menuBar/index.tsx
@@ -43,7 +43,7 @@ const MenuBar = ({
   disableReportDownload = true,
   downloadReport,
   menuData,
-  extraClasses,
+  extraClasses = '',
   scrollContainerId,
 }: MenuBarProps) => {
   const [selectedItem, setSelectedItem] = useState<string>(menuData[0].link);
@@ -105,8 +105,9 @@ const MenuBar = ({
       data-testid="menu-bar"
       className={classnames(
         'fixed right-0 flex flex-col gap-4 justify-center items-center z-10 w-9 p-2 bg-dynamic-grey dark:bg-charleston-green rounded-l-lg border border-bright-gray dark:border-quartz',
-        extraClasses ? extraClasses : 'top-4'
+        extraClasses
       )}
+      style={{ top: '50%', transform: 'translateY(-50%)' }}
     >
       {downloadReport && (
         <div className="relative">


### PR DESCRIPTION
## Description
This PR adds styles to vertically center align menu bar item on cookies landing page, in extension and CLI-dashboard.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open cookie landing page on extension and dashboard
- The menu bar should be present in the middle of the page, vertically aligned.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->


## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="1121" alt="Screenshot 2024-04-11 at 17 09 29" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/1151cd44-bd73-4474-a9f1-17ae26965076">

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
