### PR TITLE
Fix: Context invalidated for sites which do not send request after site is loaded

### DIFF
--- a/packages/design-system/src/components/errorFallback/extensionReloadNotification.tsx
+++ b/packages/design-system/src/components/errorFallback/extensionReloadNotification.tsx
@@ -22,15 +22,34 @@ import React from 'react';
  * Internal dependencies.
  */
 import Button from '../button';
+interface ExtensionReloadNotificationProps {
+  tabId?: number;
+}
 
-const ExtensionReloadNotification = () => {
+const ExtensionReloadNotification = ({
+  tabId,
+}: ExtensionReloadNotificationProps) => {
   return (
     <div className="w-full h-full px-2 flex flex-col items-center justify-center border-b border-american-silver dark:border-quartz bg-white dark:bg-charleston-green dark:text-white">
       <p className="text-xl text-center px-4">
         Looks like extension has been updated since devtool was open.
       </p>
       <div className="ml-2 mt-4">
-        <Button onClick={() => window.location.reload()} text="Refresh panel" />
+        <Button
+          onClick={() => {
+            window.location.reload();
+            localStorage.removeItem('psatOpenedAfterPageLoad');
+            if (localStorage.getItem('psatOpenedAfterPageLoad') && tabId) {
+              try {
+                chrome.tabs.reload(tabId);
+                localStorage.removeItem('psatOpenedAfterPageLoad');
+              } catch (error) {
+                //Fail silenlty
+              }
+            }
+          }}
+          text="Refresh panel"
+        />
       </div>
     </div>
   );

--- a/packages/design-system/src/components/errorFallback/extensionReloadNotification.tsx
+++ b/packages/design-system/src/components/errorFallback/extensionReloadNotification.tsx
@@ -38,7 +38,6 @@ const ExtensionReloadNotification = ({
         <Button
           onClick={() => {
             window.location.reload();
-            localStorage.removeItem('psatOpenedAfterPageLoad');
             if (localStorage.getItem('psatOpenedAfterPageLoad') && tabId) {
               try {
                 chrome.tabs.reload(tabId);

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -624,27 +624,27 @@ chrome.runtime.onMessage.addListener(async (request) => {
   const incomingMessageTabId = request.payload.tabId;
 
   if (DEVTOOLS_OPEN === incomingMessageType) {
-    const dataToSend: { [key: string]: string } = {};
+    const dataToSend: { [key: string]: string | boolean } = {};
     dataToSend['tabMode'] = tabMode;
 
     if (tabMode === 'single') {
       dataToSend['tabToRead'] = tabToRead;
     }
 
-    chrome.runtime.sendMessage({
-      type: INITIAL_SYNC,
-      payload: dataToSend,
-    });
-
     if (
       !syncCookieStore?.tabs[incomingMessageTabId] &&
       tabMode === 'unlimited'
     ) {
       const currentTab = await getTab(incomingMessageTabId);
-
+      dataToSend['psatOpenedAfterPageLoad'] = true;
       syncCookieStore?.addTabData(incomingMessageTabId);
       syncCookieStore?.updateUrl(incomingMessageTabId, currentTab?.url || '');
     }
+
+    chrome.runtime.sendMessage({
+      type: INITIAL_SYNC,
+      payload: dataToSend,
+    });
 
     syncCookieStore?.updateDevToolsState(incomingMessageTabId, true);
 

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -636,7 +636,9 @@ chrome.runtime.onMessage.addListener(async (request) => {
       tabMode === 'unlimited'
     ) {
       const currentTab = await getTab(incomingMessageTabId);
-      dataToSend['psatOpenedAfterPageLoad'] = true;
+      dataToSend['psatOpenedAfterPageLoad'] = request.payload.doNotReReload
+        ? false
+        : true;
       syncCookieStore?.addTabData(incomingMessageTabId);
       syncCookieStore?.updateUrl(incomingMessageTabId, currentTab?.url || '');
     }

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -35,6 +35,8 @@ const App: React.FC = () => {
   const [sidebarData, setSidebarData] = useState(TABS);
   const contextInvalidatedRef = useRef(null);
 
+  const tabIdRef = useRef(chrome.devtools.inspectedWindow.tabId);
+
   const contextInvalidated = useContextInvalidated(contextInvalidatedRef);
 
   const [defaultSelectedItemKey, setDefaultSelectedItemKey] = useState(
@@ -70,7 +72,7 @@ const App: React.FC = () => {
           <Layout setSidebarData={setSidebarData} />
         ) : (
           <div className="flex flex-col items-center justify-center w-full h-full">
-            <ExtensionReloadNotification />
+            <ExtensionReloadNotification tabId={tabIdRef.current} />
           </div>
         )}
       </div>

--- a/packages/extension/src/view/devtools/hooks/useContextInvalidated.ts
+++ b/packages/extension/src/view/devtools/hooks/useContextInvalidated.ts
@@ -87,7 +87,6 @@ const useContextInvalidated = (
               //Fail silently
             }
           }
-          localStorage.removeItem('contextInvalidated');
         }
       }
     })();

--- a/packages/extension/src/view/devtools/hooks/useContextInvalidated.ts
+++ b/packages/extension/src/view/devtools/hooks/useContextInvalidated.ts
@@ -88,6 +88,7 @@ const useContextInvalidated = (
             }
           }
         }
+        localStorage.removeItem('contextInvalidated');
       }
     })();
   }, [allowedNumberOfTabs, isUsingCDP]);

--- a/packages/extension/src/view/devtools/stateProviders/cookie/cookieProvider.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/cookie/cookieProvider.tsx
@@ -224,6 +224,7 @@ const Provider = ({ children }: PropsWithChildren) => {
         cookieData?: TabCookies;
         tabToRead?: string;
         tabMode?: string;
+        psatOpenedAfterPageLoad?: boolean;
       };
     }) => {
       if (!message.type) {
@@ -246,6 +247,12 @@ const Provider = ({ children }: PropsWithChildren) => {
       if (INITIAL_SYNC === incomingMessageType && message?.payload?.tabMode) {
         if (message.payload.tabMode === 'unlimited') {
           isCurrentTabBeingListenedToRef.current = true;
+          if (
+            Object.keys(message.payload).includes('psatOpenedAfterPageLoad') &&
+            message.payload.psatOpenedAfterPageLoad
+          ) {
+            setContextInvalidated(true);
+          }
           setTabToRead(null);
         } else {
           if (tabId.toString() !== message?.payload?.tabToRead) {

--- a/packages/extension/src/view/devtools/stateProviders/cookie/cookieProvider.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/cookie/cookieProvider.tsx
@@ -252,6 +252,7 @@ const Provider = ({ children }: PropsWithChildren) => {
             message.payload.psatOpenedAfterPageLoad
           ) {
             setContextInvalidated(true);
+            localStorage.setItem('psatOpenedAfterPageLoad', 'true');
           }
           setTabToRead(null);
         } else {
@@ -375,12 +376,13 @@ const Provider = ({ children }: PropsWithChildren) => {
       type: DEVTOOLS_OPEN,
       payload: {
         tabId: chrome.devtools.inspectedWindow.tabId,
-        doNotReReload: localStorage.getItem('contextInvalidated')
-          ? true
-          : false,
+        doNotReReload:
+          localStorage.getItem('contextInvalidated') &&
+          !localStorage.getItem('psatOpenedAfterPageLoad')
+            ? true
+            : false,
       },
     });
-    localStorage.removeItem('contextInvalidated');
 
     return () => {
       chrome.runtime.sendMessage({

--- a/packages/extension/src/view/devtools/stateProviders/cookie/cookieProvider.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/cookie/cookieProvider.tsx
@@ -375,8 +375,12 @@ const Provider = ({ children }: PropsWithChildren) => {
       type: DEVTOOLS_OPEN,
       payload: {
         tabId: chrome.devtools.inspectedWindow.tabId,
+        doNotReReload: localStorage.getItem('contextInvalidated')
+          ? true
+          : false,
       },
     });
+    localStorage.removeItem('contextInvalidated');
 
     return () => {
       chrome.runtime.sendMessage({

--- a/packages/extension/src/view/devtools/stateProviders/cookie/cookieProvider.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/cookie/cookieProvider.tsx
@@ -372,15 +372,14 @@ const Provider = ({ children }: PropsWithChildren) => {
   }, []);
 
   useEffect(() => {
+    const doNotReReload =
+      localStorage.getItem('contextInvalidated') &&
+      !localStorage.getItem('psatOpenedAfterPageLoad');
     chrome.runtime.sendMessage({
       type: DEVTOOLS_OPEN,
       payload: {
         tabId: chrome.devtools.inspectedWindow.tabId,
-        doNotReReload:
-          localStorage.getItem('contextInvalidated') &&
-          !localStorage.getItem('psatOpenedAfterPageLoad')
-            ? true
-            : false,
+        doNotReReload,
       },
     });
 


### PR DESCRIPTION
## Description
- This PR aims to fix the context-invalidated message shown on static sites. These are the sites which once loaded do not send requests to the server which hinders in reading of the cookies.

## Relevant Technical Choices
- This problem only occurs in the multitab environment.
- When the user opens PSAT in a multitab environment after the extension was updated they will be shown a context-invalidated message.

## Testing Instructions
- Keep a website like https://www.clarin.com/ open in a tab with DevTool closed
- Go to chrome://extensions/
- Reload/Update the extension
- Go to https://www.clarin.com/ again and open DevTools

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~ NA
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
