### PR TITLE
Refactor: Update cookies section on the landing page

### DIFF
--- a/packages/cli-dashboard/src/app.css
+++ b/packages/cli-dashboard/src/app.css
@@ -7,3 +7,12 @@
     display: none;
   }
 }
+@layer base {
+  body {
+    @apply font-sans;
+  }
+  :root {
+    --color-message-box-dark: 33deg 14% 18%;
+    --color-message-box-light: 30deg 100% 75%;
+  }
+}

--- a/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/blockedCookiesSection.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/blockedCookiesSection.tsx
@@ -88,7 +88,7 @@ const BlockedCookiesSection = ({
           <MatrixContainer
             title="Blocked Reasons"
             matrixData={dataComponents}
-            infoIconTitle="Cookies that have been blocked by the browser.(The total count might not be same as cumulative reason count because cookie might be blocked due to more than 1 reason)."
+            infoIconTitle="Cookies that have been blocked by the browser. (The total count might not be same as cumulative reason count because cookie might be blocked due to more than 1 reason)."
           />
           <div className="flex flex-col mt-8">
             <div className="pt-4">

--- a/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/cookiesSection.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/cookiesSection.tsx
@@ -57,6 +57,20 @@ const CookiesSection = ({ tabCookies, tabFrames }: CookiesSectionProps) => {
   return (
     <CookiesLandingWrapper
       dataMapping={cookieClassificationDataMapping}
+      infoIconTitle={
+        <>
+          Please setup the{' '}
+          <a
+            href="https://github.com/GoogleChromeLabs/ps-analysis-tool/wiki/Evaluation-Environment"
+            target="_blank"
+            rel="noreferrer"
+            className="text-bright-navy-blue dark:text-jordy-blue"
+          >
+            evaluation environment
+          </a>{' '}
+          before analyzing cookies.
+        </>
+      }
       testId="cookies-insights"
     >
       {!cookieStats ||

--- a/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/cookiesSection.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/cookiesSection.tsx
@@ -57,20 +57,6 @@ const CookiesSection = ({ tabCookies, tabFrames }: CookiesSectionProps) => {
   return (
     <CookiesLandingWrapper
       dataMapping={cookieClassificationDataMapping}
-      infoIconTitle={
-        <>
-          Please setup the{' '}
-          <a
-            href="https://github.com/GoogleChromeLabs/ps-analysis-tool/wiki/Evaluation-Environment"
-            target="_blank"
-            rel="noreferrer"
-            className="text-bright-navy-blue dark:text-jordy-blue"
-          >
-            evaluation environment
-          </a>{' '}
-          before analyzing cookies.
-        </>
-      }
       testId="cookies-insights"
     >
       {!cookieStats ||

--- a/packages/design-system/src/components/cookiesLanding/cookiesLandingWrapper.tsx
+++ b/packages/design-system/src/components/cookiesLanding/cookiesLandingWrapper.tsx
@@ -22,9 +22,11 @@ import React from 'react';
  * Internal dependencies.
  */
 import LandingHeader, { type DataMapping } from './landingHeader';
+import { InfoIcon } from '../../icons';
 
 export interface CookiesLandingWrapperProps {
   dataMapping?: DataMapping[];
+  infoIconTitle?: string | React.ReactNode;
   showLandingHeader?: boolean;
   testId?: string | null;
   children?: React.ReactNode;
@@ -33,6 +35,7 @@ export interface CookiesLandingWrapperProps {
 
 const CookiesLandingWrapper = ({
   dataMapping = [],
+  infoIconTitle = '',
   showLandingHeader = true,
   testId = 'cookie-landing-insights',
   description = '',
@@ -41,7 +44,22 @@ const CookiesLandingWrapper = ({
   return (
     <div className="w-full flex flex-col min-w-[40rem]">
       <div className="w-full min-w-[40rem]" data-testid={testId}>
-        {showLandingHeader && <LandingHeader dataMapping={dataMapping} />}
+        <div className="pb-5">
+          {showLandingHeader && <LandingHeader dataMapping={dataMapping} />}
+          {Boolean(infoIconTitle) && (
+            <div className="px-4 pt-2 mx-auto leading-5 flex gap-2 justify-center items-center max-w-2xl">
+              <div>
+                <InfoIcon className="w-3 h-3 fill-granite-gray" />
+              </div>
+              <p
+                className="text-xxxs font-medium text-center text-gray dark:text-bright-gray"
+                style={{ whiteSpace: 'pre-line' }}
+              >
+                {infoIconTitle}
+              </p>
+            </div>
+          )}
+        </div>
         {description && (
           <div className="text-center px-4 flex items-center justify-center -mt-2 mb-10">
             <p className="lg:max-w-[450px] text-gray dark:text-bright-gray">

--- a/packages/design-system/src/components/cookiesLanding/cookiesLandingWrapper.tsx
+++ b/packages/design-system/src/components/cookiesLanding/cookiesLandingWrapper.tsx
@@ -52,7 +52,7 @@ const CookiesLandingWrapper = ({
                 <InfoIcon className="w-3 h-3 fill-granite-gray" />
               </div>
               <p
-                className="text-xxxs font-medium text-center text-gray dark:text-bright-gray"
+                className="text-xxxs text-center text-gray dark:text-bright-gray"
                 style={{ whiteSpace: 'pre-line' }}
               >
                 {infoIconTitle}

--- a/packages/design-system/src/components/cookiesLanding/cookiesLandingWrapper.tsx
+++ b/packages/design-system/src/components/cookiesLanding/cookiesLandingWrapper.tsx
@@ -47,7 +47,7 @@ const CookiesLandingWrapper = ({
         <div className="pb-5">
           {showLandingHeader && <LandingHeader dataMapping={dataMapping} />}
           {Boolean(infoIconTitle) && (
-            <div className="px-4 pt-2 mx-auto leading-5 flex gap-2 justify-center items-center max-w-2xl">
+            <div className="px-4 pt-2 mx-auto leading-5 flex gap-1 justify-center items-center max-w-2xl">
               <div>
                 <InfoIcon className="w-3 h-3 fill-granite-gray" />
               </div>

--- a/packages/design-system/src/components/cookiesLanding/cookiesMatrix/index.tsx
+++ b/packages/design-system/src/components/cookiesLanding/cookiesMatrix/index.tsx
@@ -44,8 +44,8 @@ interface CookiesMatrixProps {
   allowExpand?: boolean;
   highlightTitle?: boolean;
   capitalizeTitle?: boolean;
-  infoIconTitle?: string;
   matrixHorizontalData?: MatrixComponentHorizontalProps[] | null;
+  infoIconTitle?: string;
 }
 
 const CookiesMatrix = ({
@@ -62,7 +62,7 @@ const CookiesMatrix = ({
   highlightTitle = false,
   capitalizeTitle = false,
   matrixHorizontalData = null,
-  infoIconTitle = 'Cookies must be analyzed on a new, clean Chrome profile for an accurate report.',
+  infoIconTitle,
 }: CookiesMatrixProps) => {
   const dataComponents: MatrixComponentProps[] = [];
 

--- a/packages/design-system/src/components/cookiesLanding/landingHeader/index.tsx
+++ b/packages/design-system/src/components/cookiesLanding/landingHeader/index.tsx
@@ -29,7 +29,7 @@ const LandingHeader = ({ dataMapping = [] }: LandingHeaderProps) => {
   return (
     <div
       className={
-        'flex justify-center border-hex-gray pt-5 pb-5 dark:border-quartz border-t'
+        'flex justify-center border-hex-gray pt-5 dark:border-quartz border-t'
       }
       data-testid="cookies-landing-header"
     >

--- a/packages/design-system/src/components/matrixContainer/index.tsx
+++ b/packages/design-system/src/components/matrixContainer/index.tsx
@@ -82,11 +82,6 @@ const MatrixContainer = ({
               } ${capitalizeTitle ? 'capitalize' : 'uppercase'}`}
             >
               <span>{title}</span>
-              {Boolean(infoIconTitle) && (
-                <span title={infoIconTitle}>
-                  <InfoIcon className="fill-granite-gray" />
-                </span>
-              )}
               {count !== null && <span>: {Number(count) || 0}</span>}
             </h4>
             <p className="text-xs text-darkest-gray dark:text-bright-gray">
@@ -94,6 +89,16 @@ const MatrixContainer = ({
             </p>
           </div>
         </div>
+        {Boolean(infoIconTitle) && Boolean(isExpanded) && (
+          <div className="bg-hsl-light dark:bg-hsl-dark px-4 py-2 mx-4 my-2 leading-5 flex gap-2 justify-center items-center">
+            <div>
+              <InfoIcon className="fill-granite-gray" />
+            </div>
+            <p className="text-sm font-medium text-center text-raisin-black dark:text-bright-gray">
+              {infoIconTitle}
+            </p>
+          </div>
+        )}
         {showMatrix && (
           <Matrix dataComponents={matrixData} expand={isExpanded} />
         )}

--- a/packages/design-system/src/components/matrixContainer/index.tsx
+++ b/packages/design-system/src/components/matrixContainer/index.tsx
@@ -52,7 +52,7 @@ const MatrixContainer = ({
   allowExpand = true,
   highlightTitle = false,
   capitalizeTitle = false,
-  infoIconTitle = '',
+  infoIconTitle,
 }: MatrixContainerProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -82,6 +82,11 @@ const MatrixContainer = ({
               } ${capitalizeTitle ? 'capitalize' : 'uppercase'}`}
             >
               <span>{title}</span>
+              {Boolean(infoIconTitle) && (
+                <span title={infoIconTitle}>
+                  <InfoIcon className="fill-granite-gray" />
+                </span>
+              )}
               {count !== null && <span>: {Number(count) || 0}</span>}
             </h4>
             <p className="text-xs text-darkest-gray dark:text-bright-gray">
@@ -89,16 +94,6 @@ const MatrixContainer = ({
             </p>
           </div>
         </div>
-        {Boolean(infoIconTitle) && Boolean(isExpanded) && (
-          <div className="bg-hsl-light dark:bg-hsl-dark px-4 py-2 mx-4 my-2 leading-5 flex gap-2 justify-center items-center">
-            <div>
-              <InfoIcon className="fill-granite-gray" />
-            </div>
-            <p className="text-sm font-medium text-center text-raisin-black dark:text-bright-gray">
-              {infoIconTitle}
-            </p>
-          </div>
-        )}
         {showMatrix && (
           <Matrix dataComponents={matrixData} expand={isExpanded} />
         )}

--- a/packages/design-system/src/components/matrixContainer/index.tsx
+++ b/packages/design-system/src/components/matrixContainer/index.tsx
@@ -69,7 +69,7 @@ const MatrixContainer = ({
               >
                 <ChevronDown
                   className={classname('fill-granite-gray', {
-                    '-rotate-90': !isExpanded,
+                    'rotate-180': isExpanded,
                   })}
                 />
               </button>

--- a/packages/design-system/src/components/matrixContainer/index.tsx
+++ b/packages/design-system/src/components/matrixContainer/index.tsx
@@ -59,7 +59,22 @@ const MatrixContainer = ({
   return (
     <div className="w-full" data-testid={`matrix-${title}`}>
       <div>
-        <div className="flex gap-x-5 justify-between border-b border-bright-gray dark:border-quartz">
+        <div className="flex gap-2 justify-start border-b border-bright-gray dark:border-quartz">
+          {allowExpand && (
+            <h4 className="pb-3 text-xs font-bold text-darkest-gray dark:text-bright-gray text-right">
+              <button
+                onClick={() => setIsExpanded((state) => !state)}
+                data-testid="expand-button"
+                title={isExpanded ? 'Collapse View' : 'Expand View'}
+              >
+                <ChevronDown
+                  className={classname('fill-granite-gray', {
+                    '-rotate-90': !isExpanded,
+                  })}
+                />
+              </button>
+            </h4>
+          )}
           <div className="pb-3 flex flex-col gap-1.5">
             <h4
               className={`flex items-center gap-1 flex-1 grow text-xs font-bold text-darkest-gray dark:text-bright-gray ${
@@ -78,21 +93,6 @@ const MatrixContainer = ({
               {description}
             </p>
           </div>
-          {allowExpand && (
-            <h4 className="pb-3 flex-1 grow text-xs font-bold text-darkest-gray dark:text-bright-gray text-right">
-              <button
-                onClick={() => setIsExpanded((state) => !state)}
-                data-testid="expand-button"
-                title={isExpanded ? 'Collapse View' : 'Expand View'}
-              >
-                <ChevronDown
-                  className={classname('fill-granite-gray', {
-                    'rotate-180': isExpanded,
-                  })}
-                />
-              </button>
-            </h4>
-          )}
         </div>
         {showMatrix && (
           <Matrix dataComponents={matrixData} expand={isExpanded} />

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/cookiesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/cookiesSection.tsx
@@ -63,6 +63,20 @@ const CookiesSection = () => {
   return (
     <CookiesLandingWrapper
       dataMapping={cookieClassificationDataMapping}
+      infoIconTitle={
+        <>
+          Please setup the{' '}
+          <a
+            href="https://github.com/GoogleChromeLabs/ps-analysis-tool/wiki/Evaluation-Environment"
+            target="_blank"
+            rel="noreferrer"
+            className="text-bright-navy-blue dark:text-jordy-blue"
+          >
+            evaluation environment
+          </a>{' '}
+          before analyzing cookies.
+        </>
+      }
       testId="cookies-insights"
     >
       {!cookieStats ||

--- a/packages/extension/src/view/report/components/cookiesSection.tsx
+++ b/packages/extension/src/view/report/components/cookiesSection.tsx
@@ -37,13 +37,26 @@ const CookiesSection = () => {
   return (
     <CookiesLandingWrapper
       dataMapping={data.cookieClassificationDataMapping}
+      infoIconTitle={
+        <>
+          Please setup the{' '}
+          <a
+            href="https://github.com/GoogleChromeLabs/ps-analysis-tool/wiki/Evaluation-Environment"
+            target="_blank"
+            rel="noreferrer"
+            className="text-bright-navy-blue dark:text-jordy-blue"
+          >
+            evaluation environment
+          </a>{' '}
+          before analyzing cookies.
+        </>
+      }
       testId="cookies-insights"
     >
       <CookiesMatrix
         tabCookies={data.tabCookies}
         componentData={data.cookiesStatsComponents.legend}
         tabFrames={data.tabFrames}
-        infoIconTitle=""
         showHorizontalMatrix={data.showHorizontalMatrix}
       />
     </CookiesLandingWrapper>

--- a/packages/extension/src/view/report/components/cookiesSection.tsx
+++ b/packages/extension/src/view/report/components/cookiesSection.tsx
@@ -37,20 +37,6 @@ const CookiesSection = () => {
   return (
     <CookiesLandingWrapper
       dataMapping={data.cookieClassificationDataMapping}
-      infoIconTitle={
-        <>
-          Please setup the{' '}
-          <a
-            href="https://github.com/GoogleChromeLabs/ps-analysis-tool/wiki/Evaluation-Environment"
-            target="_blank"
-            rel="noreferrer"
-            className="text-bright-navy-blue dark:text-jordy-blue"
-          >
-            evaluation environment
-          </a>{' '}
-          before analyzing cookies.
-        </>
-      }
       testId="cookies-insights"
     >
       <CookiesMatrix


### PR DESCRIPTION
## Description
- Move the dropdown icon from right to extreme left in the sections of cookie landing page.
- Add note under cookies piechart saying `Please setup the evaluation environment before analyzing cookies.`, where click on evaluation environment should open wiki page.
- Remove info icon from categories, across extension, dashboard, report.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open cookies landing page, on extension, report, and dashboard
- The info icon on cookies section, alongside title Categories must not be present.
- On extension, a not should be present under cookies count piechart.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="1116" alt="Screenshot 2024-04-15 at 15 10 15" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/6ebafffb-e156-47d6-a3c0-7561fa3712bc">


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
