### PR TITLE
Fix: CLI dashboard blocking reason

### DIFF
--- a/packages/cli-dashboard/src/components/cookiesWithIssues/index.tsx
+++ b/packages/cli-dashboard/src/components/cookiesWithIssues/index.tsx
@@ -79,7 +79,7 @@ const CookiesWithIssues = ({
       </Resizable>
       <CookieDetails
         selectedFrameCookie={selectedFrameCookie}
-        isUsingCDP={false}
+        isUsingCDP={true}
       />
     </div>
   );

--- a/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesListing/index.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesListing/index.tsx
@@ -97,7 +97,7 @@ const CookiesListing = ({
         />
       </Resizable>
       <CookieDetails
-        isUsingCDP={false}
+        isUsingCDP={true}
         selectedFrameCookie={selectedFrameCookie}
       />
     </div>


### PR DESCRIPTION
## Description

Details panel was missing blocked reason section. Changing `isUsingCDP` prop value to true in CLI dashboard fixes it.

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

