### PR TITLE
Fix: Broken download button icon

### DIFF
--- a/packages/design-system/src/components/exportButton/index.tsx
+++ b/packages/design-system/src/components/exportButton/index.tsx
@@ -41,14 +41,14 @@ const ExportButton = ({
       onClick={onClick}
       title={title}
       className={classNames({
-        'flex items-center text-center dark:text-mischka text-comet-black':
+        'flex items-center justify-center h-full text-center dark:text-mischka text-comet-black':
           true,
         'hover:text-comet-grey hover:dark:text-bright-gray active:dark:text-mischka active:text-comet-black':
           !disabled,
         'opacity-50': disabled,
       })}
     >
-      <Export className="h-[13px] w-[13px]" />
+      <Export />
     </button>
   );
 };

--- a/packages/design-system/src/components/menuBar/index.tsx
+++ b/packages/design-system/src/components/menuBar/index.tsx
@@ -113,7 +113,7 @@ const MenuBar = ({
           <button
             disabled={disableReportDownload}
             className={classnames(
-              'flex items-center relative justify-center w-5 h-5 p-1 rounded-full cursor-pointer transition-all ease-in-out group',
+              'flex items-center relative justify-center w-6 h-6 rounded-full cursor-pointer transition-all ease-in-out group',
               {
                 'bg-baby-blue-eyes': disableReportDownload,
                 'bg-ultramarine-blue': !disableReportDownload,
@@ -129,7 +129,7 @@ const MenuBar = ({
                 : 'Download Report'}
               <div className="absolute w-2 h-2 bg-ultramarine-blue top-1/3 -right-1 transform rotate-45" />
             </div>
-            <Export className="text-white scale-75" />
+            <Export className="text-white" />
           </button>
           <div className="absolute top-7 -left-2 border-b border-bright-gray dark:border-quartz w-9" />
         </div>

--- a/packages/design-system/src/components/refreshButton/index.tsx
+++ b/packages/design-system/src/components/refreshButton/index.tsx
@@ -29,7 +29,7 @@ const RefreshButton = ({ onClick, title = 'Refresh' }: RefreshButtonProps) => {
       onClick={onClick ? onClick : undefined}
       title={title}
       className={
-        'flex items-center text-center dark:text-mischka text-comet-black hover:text-comet-grey hover:dark:text-bright-gray active:dark:text-mischka active:text-comet-black pt-[1px]'
+        'flex items-center justify-center h-full text-center dark:text-mischka text-comet-black hover:text-comet-grey hover:dark:text-bright-gray active:dark:text-mischka active:text-comet-black pt-[1px]'
       }
     >
       <RefreshIcon className="h-[13px] w-[13px]" />

--- a/packages/design-system/src/components/table/components/tableTopBar/index.tsx
+++ b/packages/design-system/src/components/table/components/tableTopBar/index.tsx
@@ -86,7 +86,7 @@ const TableTopBar = ({
       />
       <div className="h-full w-px bg-american-silver dark:bg-quartz mx-3" />
 
-      <div className="flex gap-3">
+      <div className="flex gap-3 justify-center items-center h-full">
         {extraInterface?.()}
         {exportTableData && (
           <ExportButton

--- a/packages/design-system/src/icons/export.svg
+++ b/packages/design-system/src/icons/export.svg
@@ -1,13 +1,1 @@
-<svg width="15" height="15" viewBox="0 0 15 15" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_4_21)">
-<path d="M0.75 14.25H14.25" stroke="currentColor" stroke-width="2" stroke-linecap="square"/>
-<path d="M6.96966 10.7803C7.26256 11.0732 7.73745 11.0732 8.03035 10.7803L11.5607 6.81065C11.8536 6.51775 11.8536 6.0429 11.5607 5.75C11.2678 5.4571 10.7929 5.4571 10.5 5.75L7.5 9.18934L4.5 5.75C4.2071 5.4571 3.73225 5.4571 3.43935 5.75C3.14645 6.0429 3.14645 6.51775 3.43935 6.81065L6.96966 10.7803ZM6.75 0.25L6.75 10.25H8.25L8.25 0.25H6.75Z" fill="currentColor"/>
-<path d="M0.75 12.75V13.125" stroke="currentColor" stroke-width="3" stroke-linecap="square"/>
-<path d="M14.25 12.75V13.25" stroke="currentColor" stroke-width="3" stroke-linecap="square"/>
-</g>
-<defs>
-<clipPath id="clip0_4_21">
-<rect width="15" height="15" fill="white"/>
-</clipPath>
-</defs>
-</svg>
+<svg width="20" height="20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5.5 16c-.417 0-.77-.146-1.062-.438A1.444 1.444 0 0 1 4 14.5V13h1.5v1.5h9V13H16v1.5c0 .417-.146.77-.438 1.062A1.444 1.444 0 0 1 14.5 16h-9Zm4.5-3L6 9l1.062-1.062 2.188 2.187V3h1.5v7.125l2.188-2.187L14 9l-4 4Z" fill="currentColor"/></svg>


### PR DESCRIPTION
## Description
This PR fixes the distorted icon of download button when visiting back from subpages on landing pages.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices
- Changed the svg used as download button, as it had some issue of misalignment causing distortion.
- Used icon from performance tab's download button.
<!-- Please describe your changes. -->

## Testing Instructions
- Open cookie table, and then visit multiple subpages.
- Come back to the landing page and icon should be consistent and no issue should be there.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/2973a5fd-cc3f-410c-8d9e-231b1ba58113


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #624 
