### PR TITLE
Refactor: Update `Clear All` button render condition 

### DIFF
--- a/packages/design-system/src/components/table/components/filtersSidebar/chips/index.tsx
+++ b/packages/design-system/src/components/table/components/filtersSidebar/chips/index.tsx
@@ -45,7 +45,7 @@ const ChipsBar = () => {
         'w-full h-6 px-2 py-1 flex items-center overflow-x-scroll no-scrollbar bg-anti-flash-white dark:bg-raisin-black border-b border-gray-300 dark:border-quartz'
       }
     >
-      {appliedFiltersCount > 1 && (
+      {appliedFiltersCount > 0 && (
         <button
           className="h-full flex items-center text-link text-xs whitespace-nowrap"
           onClick={resetFilters}

--- a/packages/design-system/src/components/table/components/filtersSidebar/tests/filtersSidebar.tsx
+++ b/packages/design-system/src/components/table/components/filtersSidebar/tests/filtersSidebar.tsx
@@ -21,6 +21,7 @@ import '@testing-library/jest-dom';
 import { act } from 'react-dom/test-utils';
 import { TableFilter } from '../../../useTable/types';
 import * as table from '../../../useTable/useTable';
+import ChipsBar from '../chips';
 
 describe('FiltersSidebar', () => {
   const mockUseTable = jest.fn();
@@ -28,9 +29,11 @@ describe('FiltersSidebar', () => {
 
   const initialProps = {
     filters: {},
+    selectedFilters: {},
     toggleFilterSelection: () => undefined,
     toggleSelectAllFilter: () => undefined,
     isSelectAllFilterSelected: () => false,
+    resetFilters: () => undefined,
   };
 
   const props = {
@@ -65,6 +68,24 @@ describe('FiltersSidebar', () => {
       filters3: {
         filterValues: {} as TableFilter['filterValues'],
         title: 'Filter 3',
+      },
+    },
+    selectedFilters: {
+      filter1: {
+        filterValues: {
+          value1: {
+            selected: true,
+          },
+        },
+        title: 'Filter 1',
+      },
+      filter2: {
+        filterValues: {
+          value3: {
+            selected: true,
+          },
+        },
+        title: 'Filter 2',
       },
     },
   };
@@ -324,6 +345,37 @@ describe('FiltersSidebar', () => {
 
     await waitFor(() => {
       expect(toggleFilterSelection).toHaveBeenCalledWith('filter1', 'value1');
+    });
+  });
+
+  it('should show clear all button', async () => {
+    const resetFilters = jest.fn();
+
+    mockUseTable.mockReturnValue({
+      filters: props.filters,
+      selectedFilters: props.selectedFilters,
+      isSelectAllFilterSelected: props.isSelectAllFilterSelected,
+      toggleFilterSelection: props.toggleFilterSelection,
+      toggleSelectAllFilter: props.toggleSelectAllFilter,
+      resetFilters: resetFilters,
+    });
+
+    render(
+      <>
+        <ChipsBar />
+        <FiltersSidebar />
+      </>
+    );
+
+    const clearAll = await screen.findByText('Clear all');
+    expect(clearAll).toBeInTheDocument();
+
+    act(() => {
+      clearAll.click();
+    });
+
+    await waitFor(() => {
+      expect(resetFilters).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Description
This PR updates the condition for showing clear all button even when one filter is selected.
Earlier implementation included showing of clear all button only when more than one filter is selected.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open cookie table, and click on filter icon to open filter sidebar.
- Dropdown any filter and select one value.
- The chips will appear above table and clear all button will be visible for one filter also.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="629" alt="Screenshot 2024-04-22 at 12 59 39" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/ce20d150-cb21-471a-91b1-eacde61bf4d2">

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #621 
