### PR TITLE
Feature: Add banner to migrate to `Built by Google` extension

### DIFF
--- a/packages/extension/src/view/devtools/components/layout.tsx
+++ b/packages/extension/src/view/devtools/components/layout.tsx
@@ -48,12 +48,12 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
   const [sidebarWidth, setSidebarWidth] = useState(200);
   const mainRef = useRef<HTMLElement>(null);
 
-  const { settingsChanged, handleSettingsChange } = useSettings(
-    ({ state, actions }) => ({
+  const { settingsChanged, handleSettingsChange, currentExtensions } =
+    useSettings(({ state, actions }) => ({
       settingsChanged: state.settingsChanged,
       handleSettingsChange: actions.handleSettingsChange,
-    })
-  );
+      currentExtensions: state.currentExtensions,
+    }));
 
   const {
     tabFrames,
@@ -230,7 +230,11 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
         ref={mainRef}
         className="h-full flex-1 relative overflow-hidden flex flex-col"
       >
-        <TransitionBanner />
+        {currentExtensions?.some(
+          (extension) =>
+            extension.extensionName === 'Privacy Sandbox Analysis Tool' &&
+            extension.extensionId === 'ehbnpceebmgpanbbfckhoefhdibijkef'
+        ) && <TransitionBanner />}
         <div
           className="w-full h-full overflow-auto"
           id="cookies-landing-scroll-container"

--- a/packages/extension/src/view/devtools/components/layout.tsx
+++ b/packages/extension/src/view/devtools/components/layout.tsx
@@ -38,6 +38,7 @@ import Cookies from './cookies';
 import useFrameOverlay from '../hooks/useFrameOverlay';
 import { useCookie, useSettings } from '../stateProviders';
 import { getCurrentTabId } from '../../../utils/getCurrentTabId';
+import TransitionBanner from './transitionBanner';
 
 interface LayoutProps {
   setSidebarData: React.Dispatch<React.SetStateAction<SidebarItems>>;
@@ -229,6 +230,7 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
         ref={mainRef}
         className="h-full flex-1 relative overflow-hidden flex flex-col"
       >
+        <TransitionBanner />
         <div
           className="w-full h-full overflow-auto"
           id="cookies-landing-scroll-container"

--- a/packages/extension/src/view/devtools/components/layout.tsx
+++ b/packages/extension/src/view/devtools/components/layout.tsx
@@ -209,6 +209,20 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
 
   useFrameOverlay(filteredCookies, handleUpdate);
 
+  const [showBanner, setShowBanner] = useState(false);
+
+  useEffect(() => {
+    const _showBanner = Boolean(
+      currentExtensions?.some(
+        (extension) =>
+          extension.extensionName === 'Privacy Sandbox Analysis Tool' &&
+          extension.extensionId === 'ehbnpceebmgpanbbfckhoefhdibijkef'
+      )
+    );
+
+    setShowBanner(_showBanner);
+  }, [currentExtensions]);
+
   return (
     <div className="w-full h-full flex flex-row z-1">
       <Resizable
@@ -230,11 +244,13 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
         ref={mainRef}
         className="h-full flex-1 relative overflow-hidden flex flex-col"
       >
-        {currentExtensions?.some(
-          (extension) =>
-            extension.extensionName === 'Privacy Sandbox Analysis Tool' &&
-            extension.extensionId === 'ehbnpceebmgpanbbfckhoefhdibijkef'
-        ) && <TransitionBanner />}
+        {showBanner && (
+          <TransitionBanner
+            closeBanner={() => {
+              setShowBanner(false);
+            }}
+          />
+        )}
         <div
           className="w-full h-full overflow-auto"
           id="cookies-landing-scroll-container"

--- a/packages/extension/src/view/devtools/components/transitionBanner/index.tsx
+++ b/packages/extension/src/view/devtools/components/transitionBanner/index.tsx
@@ -40,10 +40,10 @@ const TransitionBanner = () => {
               PSAT Extension has a new home
             </h3>
             <p className="text-sm text-charcoal dark:text-manatee">
-              Please download the new version at the Chrome web store
+              Please download the new version from the Chrome web store
             </p>
           </div>
-          <Button text="Go to Chrome Web Store" extraClasses="py-2 min-w-fit" />
+          <Button text="Add to Chrome" extraClasses="py-2 min-w-fit" />
         </div>
       </div>
     </div>

--- a/packages/extension/src/view/devtools/components/transitionBanner/index.tsx
+++ b/packages/extension/src/view/devtools/components/transitionBanner/index.tsx
@@ -26,12 +26,19 @@ import { Button, ClearIcon } from '@ps-analysis-tool/design-system';
 // @ts-ignore
 import PSIcon from '../../../../../icons/icon.svg';
 
-const TransitionBanner = () => {
+interface TransitionBannerProps {
+  closeBanner: () => void;
+}
+
+const TransitionBanner = ({ closeBanner }: TransitionBannerProps) => {
   return (
     <div className="w-full border-b border-bright-gray dark:border-quartz">
       <div className="w-full p-6 pb-0 overflow-auto">
         <div className="min-w-[35rem] max-w-[50rem] h-[100px] mx-auto mb-6 px-8 py-6 relative flex items-center justify-between gap-6 bg-bright-gray dark:bg-charleston-green rounded-lg">
-          <button className="absolute top-3 right-3 text-dim-gray">
+          <button
+            className="absolute top-3 right-3 text-dim-gray"
+            onClick={closeBanner}
+          >
             <ClearIcon className="w-3 h-3" />
           </button>
           <PSIcon className="w-12 h-12" />

--- a/packages/extension/src/view/devtools/components/transitionBanner/index.tsx
+++ b/packages/extension/src/view/devtools/components/transitionBanner/index.tsx
@@ -29,7 +29,7 @@ import PSIcon from '../../../../../icons/icon.svg';
 const TransitionBanner = () => {
   return (
     <div className="w-full border-b border-bright-gray dark:border-quartz">
-      <div className="w-full m-6 mb-0 overflow-auto">
+      <div className="w-full p-6 pb-0 overflow-auto">
         <div className="min-w-[35rem] max-w-[50rem] h-[100px] mx-auto mb-6 px-8 py-6 relative flex items-center justify-between gap-6 bg-bright-gray dark:bg-charleston-green rounded-lg">
           <button className="absolute top-3 right-3 text-dim-gray">
             <ClearIcon className="w-3 h-3" />

--- a/packages/extension/src/view/devtools/components/transitionBanner/index.tsx
+++ b/packages/extension/src/view/devtools/components/transitionBanner/index.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Button, ClearIcon } from '@ps-analysis-tool/design-system';
+
+/**
+ * Internal dependencies
+ */
+// @ts-ignore
+import PSIcon from '../../../../../icons/icon.svg';
+
+const TransitionBanner = () => {
+  return (
+    <div className="w-full border-b border-bright-gray dark:border-quartz">
+      <div className="w-full m-6 mb-0 overflow-auto">
+        <div className="min-w-[35rem] max-w-[50rem] h-[100px] mx-auto mb-6 px-8 py-6 relative flex items-center justify-between gap-6 bg-bright-gray dark:bg-charleston-green rounded-lg">
+          <button className="absolute top-3 right-3 text-dim-gray">
+            <ClearIcon className="w-3 h-3" />
+          </button>
+          <PSIcon className="w-12 h-12" />
+          <div>
+            <h3 className="text-base font-bold text-gray-900 dark:text-bright-gray">
+              PSAT Extension has a new home
+            </h3>
+            <p className="text-sm text-charcoal dark:text-manatee">
+              Please download the new version at the Chrome web store
+            </p>
+          </div>
+          <Button text="Go to Chrome Web Store" extraClasses="py-2 min-w-fit" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TransitionBanner;

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -57,7 +57,7 @@ const App: React.FC = () => {
       handleSettingsChange: actions.handleSettingsChange,
     }));
 
-  const [showBanner, setShowBanner] = useState<boolean>(false);
+  const [showBanner, setShowBanner] = useState<boolean | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -75,9 +75,15 @@ const App: React.FC = () => {
   }, []);
 
   if (showBanner) {
-    <CookieLanding>
-      <TransitionBanner />
-    </CookieLanding>;
+    return (
+      <CookieLanding>
+        <TransitionBanner
+          closeBanner={() => {
+            setShowBanner(false);
+          }}
+        />
+      </CookieLanding>
+    );
   }
 
   if (onChromeUrl) {

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -17,7 +17,7 @@
 /**
  * External dependencies.
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Button,
   CirclePieChart,
@@ -30,7 +30,7 @@ import {
  * Internal dependencies.
  */
 import './app.css';
-import { Legend, CookieLanding } from './components';
+import { Legend, CookieLanding, TransitionBanner } from './components';
 import { useCookie, useSettings } from './stateProviders';
 import { ALLOWED_NUMBER_OF_TABS } from '../../constants';
 
@@ -56,6 +56,29 @@ const App: React.FC = () => {
       settingsChanged: state.settingsChanged,
       handleSettingsChange: actions.handleSettingsChange,
     }));
+
+  const [showBanner, setShowBanner] = useState<boolean>(false);
+
+  useEffect(() => {
+    (async () => {
+      const extensions = await chrome.management.getAll();
+
+      const _showBanner = extensions?.some((extension) => {
+        return (
+          extension.name === 'Privacy Sandbox Analysis Tool' &&
+          extension.id === 'ehbnpceebmgpanbbfckhoefhdibijkef'
+        );
+      });
+
+      setShowBanner(_showBanner);
+    })();
+  }, []);
+
+  if (showBanner) {
+    <CookieLanding>
+      <TransitionBanner />
+    </CookieLanding>;
+  }
 
   if (onChromeUrl) {
     return (

--- a/packages/extension/src/view/popup/app.tsx
+++ b/packages/extension/src/view/popup/app.tsx
@@ -23,7 +23,6 @@ import {
   CirclePieChart,
   ProgressBar,
   ToastMessage,
-  ToggleSwitch,
   prepareCookieStatsComponents,
 } from '@ps-analysis-tool/design-system';
 
@@ -31,7 +30,7 @@ import {
  * Internal dependencies.
  */
 import './app.css';
-import { Legend } from './components';
+import { Legend, CookieLanding } from './components';
 import { useCookie, useSettings } from './stateProviders';
 import { ALLOWED_NUMBER_OF_TABS } from '../../constants';
 
@@ -51,31 +50,16 @@ const App: React.FC = () => {
     changeListeningToThisTab: actions.changeListeningToThisTab,
   }));
 
-  const {
-    allowedNumberOfTabs,
-    isUsingCDP,
-    settingsChanged,
-    setUsingCDP,
-    handleSettingsChange,
-  } = useSettings(({ state, actions }) => ({
-    allowedNumberOfTabs: state.allowedNumberOfTabs,
-    isUsingCDP: state.isUsingCDPForSettingsDisplay,
-    settingsChanged: state.settingsChanged,
-    setUsingCDP: actions.setUsingCDP,
-    handleSettingsChange: actions.handleSettingsChange,
-  }));
-
-  const cdpLabel = isUsingCDP ? 'Disable CDP' : 'Enable CDP';
+  const { allowedNumberOfTabs, settingsChanged, handleSettingsChange } =
+    useSettings(({ state, actions }) => ({
+      allowedNumberOfTabs: state.allowedNumberOfTabs,
+      settingsChanged: state.settingsChanged,
+      handleSettingsChange: actions.handleSettingsChange,
+    }));
 
   if (onChromeUrl) {
     return (
-      <div className="w-full h-full flex justify-center items-center flex-col z-1">
-        <ToggleSwitch
-          onLabel={cdpLabel}
-          additionalStyles="top-2 left-2 absolute"
-          setEnabled={setUsingCDP}
-          enabled={isUsingCDP}
-        />
+      <CookieLanding>
         <p className="font-bold text-lg mb-2">Not much to analyze here</p>
         <p className="text-chart-label text-xs">
           Its emptier than a cookie jar after a midnight snack!
@@ -90,7 +74,7 @@ const App: React.FC = () => {
             />
           )}
         </div>
-      </div>
+      </CookieLanding>
     );
   }
 
@@ -111,13 +95,7 @@ const App: React.FC = () => {
     allowedNumberOfTabs !== 'unlimited'
   ) {
     return (
-      <div className="w-full h-full flex justify-center items-center flex-col z-1">
-        <ToggleSwitch
-          onLabel={cdpLabel}
-          additionalStyles="top-2 left-2 absolute"
-          setEnabled={setUsingCDP}
-          enabled={isUsingCDP}
-        />
+      <CookieLanding>
         <Button onClick={changeListeningToThisTab} text="Analyze this tab" />
         <div className="absolute right-0 bottom-0 w-full">
           {settingsChanged && (
@@ -129,7 +107,7 @@ const App: React.FC = () => {
             />
           )}
         </div>
-      </div>
+      </CookieLanding>
     );
   }
 
@@ -138,13 +116,7 @@ const App: React.FC = () => {
     (cookieStats?.firstParty.total === 0 && cookieStats?.thirdParty.total === 0)
   ) {
     return (
-      <div className="w-full h-full flex justify-center items-center flex-col z-1">
-        <ToggleSwitch
-          onLabel={cdpLabel}
-          additionalStyles="top-2 left-2 absolute"
-          setEnabled={setUsingCDP}
-          enabled={isUsingCDP}
-        />
+      <CookieLanding>
         <p className="font-bold text-lg">No cookies found on this page</p>
         <p className="text-chart-label text-xs">
           Please try reloading the page
@@ -159,19 +131,13 @@ const App: React.FC = () => {
             />
           )}
         </div>
-      </div>
+      </CookieLanding>
     );
   }
   const statsComponents = prepareCookieStatsComponents(cookieStats);
 
   return (
-    <div className="w-full h-full flex justify-center items-center flex-col z-1">
-      <ToggleSwitch
-        onLabel={cdpLabel}
-        additionalStyles="top-2 left-2 absolute"
-        setEnabled={setUsingCDP}
-        enabled={isUsingCDP}
-      />
+    <CookieLanding>
       <div className="w-full flex gap-x-6 justify-center border-b border-hex-gray pb-3.5">
         <div className="w-32 text-center">
           <CirclePieChart
@@ -206,7 +172,7 @@ const App: React.FC = () => {
           />
         )}
       </div>
-    </div>
+    </CookieLanding>
   );
 };
 

--- a/packages/extension/src/view/popup/components/cookieLanding/index.tsx
+++ b/packages/extension/src/view/popup/components/cookieLanding/index.tsx
@@ -30,7 +30,7 @@ const CookieLanding = ({ children }: PropsWithChildren) => {
   const cdpLabel = isUsingCDP ? 'Disable CDP' : 'Enable CDP';
 
   return (
-    <div className="w-full h-full flex justify-center items-center flex-col z-1">
+    <div className="w-full h-full flex justify-center items-center flex-col flex-1 z-1">
       <ToggleSwitch
         onLabel={cdpLabel}
         additionalStyles="top-2 left-2 absolute"

--- a/packages/extension/src/view/popup/components/cookieLanding/index.tsx
+++ b/packages/extension/src/view/popup/components/cookieLanding/index.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { ToggleSwitch } from '@ps-analysis-tool/design-system';
+import React, { type PropsWithChildren } from 'react';
+import { useSettings } from '../../stateProviders';
+
+const CookieLanding = ({ children }: PropsWithChildren) => {
+  const { isUsingCDP, setUsingCDP } = useSettings(({ state, actions }) => ({
+    isUsingCDP: state.isUsingCDP,
+    setUsingCDP: actions.setUsingCDP,
+  }));
+
+  const cdpLabel = isUsingCDP ? 'Disable CDP' : 'Enable CDP';
+
+  return (
+    <div className="w-full h-full flex justify-center items-center flex-col z-1">
+      <ToggleSwitch
+        onLabel={cdpLabel}
+        additionalStyles="top-2 left-2 absolute"
+        setEnabled={setUsingCDP}
+        enabled={isUsingCDP}
+      />
+      {children}
+    </div>
+  );
+};
+
+export default CookieLanding;

--- a/packages/extension/src/view/popup/components/index.tsx
+++ b/packages/extension/src/view/popup/components/index.tsx
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { default as Legend } from './legend';
+export { default as CookieLanding } from './cookieLanding';

--- a/packages/extension/src/view/popup/components/index.tsx
+++ b/packages/extension/src/view/popup/components/index.tsx
@@ -15,3 +15,4 @@
  */
 export { default as Legend } from './legend';
 export { default as CookieLanding } from './cookieLanding';
+export { default as TransitionBanner } from './transitionBanner';

--- a/packages/extension/src/view/popup/components/transitionBanner/index.tsx
+++ b/packages/extension/src/view/popup/components/transitionBanner/index.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies.
+ */
+import React from 'react';
+import { Button, ClearIcon } from '@ps-analysis-tool/design-system';
+
+/**
+ * Internal dependencies.
+ */
+// @ts-ignore
+import PSIcon from '../../../../../icons/icon.svg';
+
+const TransitionBanner = () => {
+  return (
+    <div className="flex-1 flex items-center flex-col h-full w-full bg-bright-gray rounded-lg p-3">
+      <button className="h-fit w-full text-dim-gray">
+        <ClearIcon className="w-3 h-3 float-right" />
+      </button>
+      <PSIcon className="w-12 h-12" />
+      <h3 className="text-base font-bold text-gray-900 mt-6">
+        PSAT Extension has a new home
+      </h3>
+      <p className="max-w-[226px] text-sm text-center text-charcoal mt-6">
+        Please download the new version at the Chrome web store
+      </p>
+      <Button text="Go to Chrome Web Store" extraClasses="mt-6 py-2" />
+    </div>
+  );
+};
+
+export default TransitionBanner;

--- a/packages/extension/src/view/popup/components/transitionBanner/index.tsx
+++ b/packages/extension/src/view/popup/components/transitionBanner/index.tsx
@@ -37,9 +37,9 @@ const TransitionBanner = () => {
         PSAT Extension has a new home
       </h3>
       <p className="max-w-[226px] text-sm text-center text-charcoal mt-6">
-        Please download the new version at the Chrome web store
+        Please download the new version from the Chrome web store
       </p>
-      <Button text="Go to Chrome Web Store" extraClasses="mt-6 py-2" />
+      <Button text="Add to Chrome" extraClasses="mt-6 py-2" />
     </div>
   );
 };

--- a/packages/extension/src/view/popup/components/transitionBanner/index.tsx
+++ b/packages/extension/src/view/popup/components/transitionBanner/index.tsx
@@ -26,10 +26,14 @@ import { Button, ClearIcon } from '@ps-analysis-tool/design-system';
 // @ts-ignore
 import PSIcon from '../../../../../icons/icon.svg';
 
-const TransitionBanner = () => {
+interface TransitionBannerProps {
+  closeBanner: () => void;
+}
+
+const TransitionBanner = ({ closeBanner }: TransitionBannerProps) => {
   return (
     <div className="flex-1 flex items-center flex-col h-full w-full bg-bright-gray rounded-lg p-3">
-      <button className="h-fit w-full text-dim-gray">
+      <button className="h-fit w-full text-dim-gray" onClick={closeBanner}>
         <ClearIcon className="w-3 h-3 float-right" />
       </button>
       <PSIcon className="w-12 h-12" />

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -79,6 +79,7 @@ module.exports = {
     textColor: {
       ...colors,
       'text-medium-gray': '#BDBDBD',
+      'dim-gray': '#6C6C6C',
       'chestnut-gold': '#A98307',
       'battle-dress': '#7D8471',
       brownstone: '#79553D',


### PR DESCRIPTION
## Description
This PR adds UI for the transition banner letting users know that the extension's location has been moved, please download the latest version.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="385" alt="Screenshot 2024-04-24 at 10 46 17" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/af4adf22-1358-4a3e-a237-e10590d75708">
<img width="1470" alt="Screenshot 2024-04-24 at 10 45 34" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/bb112925-a596-4ed6-8434-942eaf0b3081">
<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #587 
