### PR TITLE
Fix: Known breakages section throwing error when a link is quickly opened and closed

### DIFF
--- a/packages/library-detection/src/core/stateProvider/index.tsx
+++ b/packages/library-detection/src/core/stateProvider/index.tsx
@@ -99,8 +99,11 @@ export const LibraryDetectionProvider = ({ children }: PropsWithChildren) => {
   }, []);
 
   const onErrorOccuredListener = useCallback(
-    ({ frameId }: chrome.webNavigation.WebNavigationFramedCallbackDetails) => {
-      if (frameId === 0) {
+    ({
+      frameId,
+      tabId: _tabId,
+    }: chrome.webNavigation.WebNavigationFramedCallbackDetails) => {
+      if (frameId === 0 && _tabId === chrome.devtools.inspectedWindow.tabId) {
         setErrorOccured(true);
       }
     },


### PR DESCRIPTION
## Description
This issue fixes the messaging that is displayed in the known breakages section when a link is quickly opened and closed.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~~[ ] This code is covered by unit tests to verify that it works as intended.~~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #635 
