### PR TITLE
Fix: Normalise blocking reason.

### DIFF
--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -472,9 +472,18 @@ chrome.debugger.onEvent.addListener((source, method, params) => {
       return;
     }
     try {
+      const modifiedCookieExclusionReasons = cookieExclusionReasons.map(
+        (reason) => {
+          if (reason.toLowerCase().startsWith('exclude')) {
+            return reason.substring(7) as Protocol.Network.CookieBlockedReason;
+          }
+          return reason as Protocol.Network.CookieBlockedReason;
+        }
+      );
+
       syncCookieStore?.addCookieExclusionWarningReason(
         cookie?.name + domainToUse + cookie?.path,
-        cookieExclusionReasons,
+        modifiedCookieExclusionReasons,
         cookieWarningReasons,
         source.tabId
       );


### PR DESCRIPTION
## Description
This PR aims to normalise blocking reasons that are being added from different APIs.

## Relevant Technical Choices
- Essentially `ExcludeThirdPartyPhaseout` and `ThirdPartyPhaseout` are actually the same, the only difference is they come from different APIs.

## Testing Instructions
- Open a Chrome instance with a 3PCD-enabled flag.
-  Go to any website with 3rd party cookies.
- You should see only ThirdPartyPhaseout as a blocking reason, not ExcludeThirdPartyPhaseout

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~~[ ] This code is covered by unit tests to verify that it works as intended.~~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
