### PR TITLE
Fix: Add `Blocked` status in CSV report

### DIFF
--- a/packages/design-system/src/components/table/utils/generateCookieTableCSV.ts
+++ b/packages/design-system/src/components/table/utils/generateCookieTableCSV.ts
@@ -57,6 +57,8 @@ const generateCookieTableCSV = (cookies: CookieTableData[]): Blob => {
 
     if ((isInboundBlocked || isOutboundBlocked) && !hasValidBlockedReason) {
       status = 'Undetermined';
+    } else if (hasValidBlockedReason) {
+      status = 'Blocked';
     }
 
     //This should be in the same order as cookieDataHeader


### PR DESCRIPTION
## Description
This PR adds code to add Blocked status in the Blocking status column when the CSV file is downloaded. 
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open the PSAT panel and enable CDP.
- Open the cookie table on the first frame.
- Find the download icon beside the search bar and click it.
- Open the downloaded file and scroll to the last column.
- The Blocking status column should have the value Blocked for some cookies.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="929" alt="Screenshot 2024-05-06 at 14 55 19" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/296ff266-3ea9-4f98-aefd-4b204b34ae1e">

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
-  ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
