### PR TITLE
Add readiness content in `Facilitated Testing` section

### DIFF
--- a/packages/extension/src/view/devtools/components/facilitatedTesting/faciliatedTestingContent/infoCards.tsx
+++ b/packages/extension/src/view/devtools/components/facilitatedTesting/faciliatedTestingContent/infoCards.tsx
@@ -58,6 +58,11 @@ const INFO_CARDS_DATA = [
     href="https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support/issues/new/choose"
     target="_blank">here</a>  using the third-party cookie deprecation.`,
   },
+  {
+    heading: 'Readiness',
+    content:
+      'Discover how companies across the web are gearing up for third-party cookie deprecation. This <a class="text-bright-navy-blue dark:text-jordy-blue hover:opacity-80 underline" href="https://github.com/privacysandbox/privacy-sandbox-dev-support/blob/main/3pcd-readiness.md" target="_blank">comprehensive list</a> is compiled with insights from participants who have voluntarily shared their preparations.',
+  },
 ];
 
 const InfoCards = () => {


### PR DESCRIPTION
## Description
This PR adds code to add Readiness section inside `Facilitated Testing`  landing page's infocards.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open PSAT panel, navigate to Facilitated Testing landing page.
- Scroll vertically to find `Readiness` heading with content in infocards.
- The content should contain a link, click on it should open [this page](https://github.com/privacysandbox/privacy-sandbox-dev-support/blob/main/3pcd-readiness.md).
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="1319" alt="Screenshot 2024-05-07 at 10 31 16" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/6af238f1-afdb-4b34-aeb9-74ef4fe1aacc">

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #612 
