### PR TITLE
Update 3PCD readiness section

### DIFF
--- a/packages/extension/src/view/devtools/components/facilitatedTesting/faciliatedTestingContent/infoCards.tsx
+++ b/packages/extension/src/view/devtools/components/facilitatedTesting/faciliatedTestingContent/infoCards.tsx
@@ -24,6 +24,11 @@ const EXPERIMENT_GROUP = 'Membership in Experiment Group';
 
 const INFO_CARDS_DATA = [
   {
+    heading: 'Third-Party Cookie Depreciation Readiness',
+    content:
+      'Discover how companies across the web are gearing up for third-party cookie deprecation. This <a class="text-bright-navy-blue dark:text-jordy-blue hover:opacity-80 underline" href="https://github.com/privacysandbox/privacy-sandbox-dev-support/blob/main/3pcd-readiness.md" target="_blank">comprehensive list</a> is compiled with insights from participants who have voluntarily shared their preparations.',
+  },
+  {
     heading: EXPERIMENT_GROUP,
     content: `To prepare for third-party cookie deprecation, we will be providing Chrome-facilitated testing modes that allow sites to preview how site behavior and functionality work without third-party cookies. Check <a class="text-bright-navy-blue dark:text-jordy-blue hover:opacity-80 underline" 
     href="${addUTMParams(
@@ -57,11 +62,6 @@ const INFO_CARDS_DATA = [
     target="_blank">here</a>. And if you have questions or feedback about Privacy Sandbox, you can raise a new issue <a class="text-bright-navy-blue dark:text-jordy-blue hover:opacity-80 underline" 
     href="https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support/issues/new/choose"
     target="_blank">here</a>  using the third-party cookie deprecation.`,
-  },
-  {
-    heading: 'Readiness',
-    content:
-      'Discover how companies across the web are gearing up for third-party cookie deprecation. This <a class="text-bright-navy-blue dark:text-jordy-blue hover:opacity-80 underline" href="https://github.com/privacysandbox/privacy-sandbox-dev-support/blob/main/3pcd-readiness.md" target="_blank">comprehensive list</a> is compiled with insights from participants who have voluntarily shared their preparations.',
   },
 ];
 


### PR DESCRIPTION
## Description
This PR updates the content in facilitated testing page
- Moves Readiness section to the top of list.
- Renames the title to `Third-Party Cookie Depreciation Readiness`.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open PSAT panel and navigate to Facilitated testing section.
- Infocards section's first item must be `Third-Party Cookie Depreciation Readiness`.
- Click on url should open new page and open github repo [here](https://github.com/privacysandbox/privacy-sandbox-dev-support/blob/main/3pcd-readiness.md).
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="1470" alt="Screenshot 2024-05-08 at 10 16 33" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/3d1434d7-0a61-4c09-a4ac-95d2c48c1b4d">

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
