### PR TITLE
Fix: Map exclusion reason to cookie blocked reason.

### DIFF
--- a/packages/common/src/data/index.ts
+++ b/packages/common/src/data/index.ts
@@ -15,3 +15,15 @@
  */
 export { default as cookieIssueDetails } from './cookieExclusionAndWarningReasons';
 export { cookieExemptionReason } from './cookieExemptionReason';
+export const auditsToNetworkMap = {
+  ExcludeSameSiteUnspecifiedTreatedAsLax: 'SameSiteUnspecifiedTreatedAsLax',
+  ExcludeSameSiteNoneInsecure: 'SameSiteNoneInsecure',
+  ExcludeSameSiteLax: 'SameSiteLax',
+  ExcludeSameSiteStrict: 'SameSiteStrict',
+  ExcludeInvalidSameParty: 'InvalidSameParty',
+  ExcludeSamePartyCrossPartyContext: 'SamePartyCrossPartyContext',
+  ExcludeDomainNonASCII: 'DomainNonASCII',
+  ExcludeThirdPartyCookieBlockedInFirstPartySet:
+    'ThirdPartyBlockedInFirstPartySet',
+  ExcludeThirdPartyPhaseout: 'ThirdPartyPhaseout',
+};

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -225,6 +225,10 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     return;
   }
 
+  if (!syncCookieStore) {
+    syncCookieStore = new SynchnorousCookieStore();
+  }
+
   const queryParams = getQueryParams(tab.url);
 
   if (queryParams.psat_cdp || queryParams.psat_multitab) {

--- a/packages/extension/src/serviceWorker/index.ts
+++ b/packages/extension/src/serviceWorker/index.ts
@@ -22,6 +22,7 @@ import {
   type CookieData,
   parseResponseReceivedExtraInfo,
   parseRequestWillBeSentExtraInfo,
+  auditsToNetworkMap,
 } from '@ps-analysis-tool/common';
 
 /**
@@ -439,7 +440,9 @@ chrome.debugger.onEvent.addListener((source, method, params) => {
       const modifiedCookieExclusionReasons = cookieExclusionReasons.map(
         (reason) => {
           if (reason.toLowerCase().startsWith('exclude')) {
-            return reason.substring(7) as Protocol.Network.CookieBlockedReason;
+            return auditsToNetworkMap[
+              reason
+            ] as Protocol.Network.CookieBlockedReason;
           }
           return reason as Protocol.Network.CookieBlockedReason;
         }


### PR DESCRIPTION
## Description
This PR aims to add create a map between cookie exclusion reason and cookie blocked reason to normalise the cookie blocked reason.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~~[ ] This code is covered by unit tests to verify that it works as intended.~~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
