### PR TITLE
Fix: inconsistent highlighting on livemint.com

### DIFF
--- a/packages/cli/src/utils/browserManagement/index.ts
+++ b/packages/cli/src/utils/browserManagement/index.ts
@@ -233,7 +233,7 @@ export class BrowserManagement {
                 secure: parsedCookie.secure || false,
                 partitionKey,
               },
-              isBlocked: Boolean(blockedEntry),
+              isBlocked: (blockedEntry?.blockedReasons || []).length > 0,
               blockedReasons: blockedEntry?.blockedReasons,
             };
           });

--- a/packages/cli/src/utils/browserManagement/index.ts
+++ b/packages/cli/src/utils/browserManagement/index.ts
@@ -233,7 +233,7 @@ export class BrowserManagement {
                 secure: parsedCookie.secure || false,
                 partitionKey,
               },
-              isBlocked: (blockedEntry?.blockedReasons || []).length > 0,
+              isBlocked: Boolean(blockedEntry),
               blockedReasons: blockedEntry?.blockedReasons,
             };
           });

--- a/packages/cli/src/utils/browserManagement/parseNetworkDataToCookieData.ts
+++ b/packages/cli/src/utils/browserManagement/parseNetworkDataToCookieData.ts
@@ -112,6 +112,7 @@ export const parseNetworkDataToCookieData = (
           ...cookie,
           url: response.serverUrl,
           blockedReasons: Array.from(blockedReasonsSet),
+          isBlocked: Array.from(blockedReasonsSet).length > 0,
           parsedCookie: {
             ...cookie.parsedCookie,
             domain: parsedDomain || '',
@@ -150,6 +151,7 @@ export const parseNetworkDataToCookieData = (
           ...cookie,
           url: request.serverUrl,
           blockedReasons: Array.from(blockedReasonsSet),
+          isBlocked: Array.from(blockedReasonsSet).length > 0,
           parsedCookie: { ...cookie.parsedCookie, domain: parsedDomain || '' },
         });
       });


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR fixes some cookies not being highlighted on livemint.com

## Relevant Technical Choices
1. `isBlocked` is recalculated in `parseNetworkDataToCookieData`

## Testing Instructions

1. Run `npm run cli -- -u https://livemint.com/`
2. Open CLI Dashboard and the `ppid` cookie should be highlighted


## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~[ ] This code is covered by unit tests to verify that it works as intended.~ NA
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #680
