### PR TITLE
Feature: Navigate from PSAT to network panel

### DIFF
--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
@@ -109,11 +109,20 @@ const RowContextMenu = forwardRef<
     domainsInAllowList
   );
 
-  const handleCopy = useCallback(() => {
+  const handleFilterClick = useCallback(() => {
+    const filter = `cookie-domain:${domain} cookie-name:${name}`;
+
+    // @ts-ignore
+    if (chrome.devtools.panels.network.show) {
+      // @ts-ignore
+      chrome.devtools.panels.network.show({ filter });
+      return;
+    }
+
     try {
       // Need to do this since chrome doesnt allow the clipboard access in extension.
       const copyFrom = document.createElement('textarea');
-      copyFrom.textContent = `cookie-domain:${domain} cookie-name:${name}`;
+      copyFrom.textContent = filter;
       document.body.appendChild(copyFrom);
       copyFrom.select();
       document.execCommand('copy');
@@ -193,10 +202,17 @@ const RowContextMenu = forwardRef<
               }}
             >
               <button
-                onClick={handleCopy}
+                onClick={handleFilterClick}
                 className="w-full text-xs rounded px-1 py-[3px] flex items-center hover:bg-royal-blue hover:text-white cursor-default"
               >
-                <span>Copy Network Filter String</span>
+                <span>
+                  {
+                    // @ts-ignore
+                    chrome.devtools.panels.network.show
+                      ? 'Filter in Network Panel'
+                      : 'Copy Network Filter String'
+                  }
+                </span>
               </button>
 
               {isDomainInAllowList && parentDomain ? (

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
@@ -113,7 +113,7 @@ const RowContextMenu = forwardRef<
     const filter = `cookie-domain:${domain} cookie-name:${name}`;
 
     // @ts-ignore
-    if (chrome.devtools.panels.network.show) {
+    if (chrome.devtools.panels?.network?.show) {
       // @ts-ignore
       chrome.devtools.panels.network.show({ filter });
       return;
@@ -208,7 +208,7 @@ const RowContextMenu = forwardRef<
                 <span>
                   {
                     // @ts-ignore
-                    chrome.devtools.panels.network.show
+                    chrome.devtools.panels?.network?.show
                       ? 'Filter in Network Panel'
                       : 'Copy Network Filter String'
                   }

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
@@ -209,7 +209,7 @@ const RowContextMenu = forwardRef<
                   {
                     // @ts-ignore
                     chrome.devtools.panels?.network?.show
-                      ? 'Filter in Network Panel'
+                      ? 'Show Requests With This Cookie'
                       : 'Copy Network Filter String'
                   }
                 </span>


### PR DESCRIPTION
## Description
This PR adds an API that will allow navigation to the network panel from PSAT.
This API is available in the Chrome version 125.
On old Chrome versions, the old functionality of copying network filter string from context menu will continue.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open Chrome v125, and install PSAT.
- Start analyzing a tab, and move to the cookie table.
- Right-click on any row and the dialog box should open.
- The first item should say 'Show Requests With This Cookie', click on it will open the network panel with filter inside the input bar.
- The rows in network will be filtered according to the cookie name and domain provided.
- Try the same Chrome v124 or below now, this should not open the network panel and continue the old functionality copying filter to the clipboard.

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/228dc2cb-1bb8-4b28-8bbb-deb413c9cdcf


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #293 
