### PR TITLE
Fix: Persist filters after web page reload

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -37,6 +37,7 @@ export { default as executeTaskInDevToolWorker } from './worker/executeTaskInDev
 export { default as getValueByKey } from './utils/getValueByKey';
 export * from './utils/contextSelector';
 export { default as addUTMParams } from './utils/addUTMParams';
+export { default as mergeDeep } from './utils/mergeDeep';
 export * from './worker/enums';
 export * from './utils/generateReports';
 export * from './cookies.types';

--- a/packages/common/src/utils/mergeDeep.ts
+++ b/packages/common/src/utils/mergeDeep.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const isObject = (item: any) => {
+  return item && typeof item === 'object' && !Array.isArray(item);
+};
+
+const mergeDeep = (target: any, source: any) => {
+  if (isObject(target) && isObject(source)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) {
+          Object.assign(target, { [key]: {} });
+        }
+        mergeDeep(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    }
+  }
+  return target;
+};
+
+export default mergeDeep;

--- a/packages/common/src/utils/tests/mergeDeep.ts
+++ b/packages/common/src/utils/tests/mergeDeep.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import mergeDeep from '../mergeDeep';
+
+describe('mergeDeep', () => {
+  it('merges two objects deeply', () => {
+    const target = {
+      a: 1,
+      b: 2,
+      c: {
+        d: 3,
+        e: 4,
+      },
+    };
+    const source = {
+      a: 2,
+      c: {
+        e: 5,
+        f: 6,
+      },
+    };
+    const result = {
+      a: 2,
+      b: 2,
+      c: {
+        d: 3,
+        e: 5,
+        f: 6,
+      },
+    };
+
+    expect(mergeDeep(target, source)).toEqual(result);
+  });
+
+  it('merges two objects deeply with nested arrays', () => {
+    const target = {
+      a: 1,
+      b: 2,
+      c: {
+        d: 3,
+        e: 4,
+        f: [1, 2, 3],
+      },
+    };
+    const source = {
+      a: 2,
+      c: {
+        e: 5,
+        f: [4, 5, 6],
+      },
+    };
+    const result = {
+      a: 2,
+      b: 2,
+      c: {
+        d: 3,
+        e: 5,
+        f: [4, 5, 6],
+      },
+    };
+
+    expect(mergeDeep(target, source)).toEqual(result);
+  });
+});

--- a/packages/design-system/src/components/table/persistentSettingsStore/utils/updateStorage.ts
+++ b/packages/design-system/src/components/table/persistentSettingsStore/utils/updateStorage.ts
@@ -22,6 +22,7 @@ import {
   TABLE_PERSISTENT_SETTINGS_STORE_KEY,
   TablePersistentSettingsStoreContext,
 } from '..';
+import { mergeDeep } from '@ps-analysis-tool/common';
 
 const updateStorage = async (
   persistenceKey: string,
@@ -100,10 +101,7 @@ const updateChromeStorage = async (
   let requiredData = tableData?.[persistenceKey];
 
   if (requiredData) {
-    requiredData = {
-      ...requiredData,
-      ...storageData,
-    };
+    requiredData = mergeDeep(requiredData, storageData);
   } else {
     requiredData = storageData;
   }

--- a/packages/design-system/src/components/table/useTable/types.ts
+++ b/packages/design-system/src/components/table/useTable/types.ts
@@ -57,7 +57,7 @@ export type TableFilter = {
     isSelectAllOptionSelected?: boolean;
     filterValues?: {
       [filterValue: string]: {
-        selected: boolean;
+        selected: boolean | null;
         description?: string;
       };
     };

--- a/packages/design-system/src/components/table/useTable/useFiltering/hooks/index.ts
+++ b/packages/design-system/src/components/table/useTable/useFiltering/hooks/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as useFiltersPersistence } from './useFiltersPersistence';
+export { default as useFiltersOptions } from './useFiltersOptions';
+export { default as useFiltersExtraction } from './useFiltersExtraction';

--- a/packages/design-system/src/components/table/useTable/useFiltering/hooks/tests/useFiltersExtraction.tsx
+++ b/packages/design-system/src/components/table/useTable/useFiltering/hooks/tests/useFiltersExtraction.tsx
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+import useFiltersExtraction from '../useFiltersExtraction';
+import React from 'react';
+
+describe('useFiltersExtraction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  const data = [
+    {
+      parsedCookie: {
+        name: 'cookie1',
+        value: 'value1',
+        sameSite: 'Lax',
+      },
+    },
+    {
+      parsedCookie: {
+        name: 'cookie2',
+        value: 'value2',
+        sameSite: 'None',
+      },
+    },
+  ];
+
+  const tableFilterData = {
+    'parsedCookie.name': {
+      title: 'Cookie Name',
+      description: 'Name of the cookie',
+      enableSelectAllOption: true,
+    },
+    'parsedCookie.value': {
+      title: 'Cookie Value',
+      description: 'Value of the cookie',
+      hasStaticFilterValues: true,
+      filterValues: {
+        value1: {
+          selected: false,
+        },
+        value2: {
+          selected: false,
+        },
+      },
+    },
+    'parsedCookie.sameSite': {
+      title: 'Same Site',
+      description: 'Same site of the cookie',
+      hasStaticFilterValues: true,
+      hasPrecalculatedFilterValues: true,
+      filterValues: {
+        Lax: {
+          selected: false,
+        },
+        None: {
+          selected: false,
+        },
+      },
+    },
+  };
+
+  const options = {
+    current: {
+      'parsedCookie.value': {
+        value1: {
+          selected: true,
+        },
+        value2: {
+          selected: true,
+        },
+      },
+      'parsedCookie.sameSite': {
+        None: {
+          selected: true,
+        },
+      },
+    },
+  };
+
+  const selectAllFilterSelection = {
+    'parsedCookie.name': {
+      selected: true,
+    },
+  };
+
+  const expectedFilters = {
+    'parsedCookie.name': {
+      title: 'Cookie Name',
+      description: 'Name of the cookie',
+      enableSelectAllOption: true,
+      filterValues: {
+        cookie1: {
+          selected: true,
+        },
+        cookie2: {
+          selected: true,
+        },
+      },
+    },
+    'parsedCookie.value': {
+      title: 'Cookie Value',
+      description: 'Value of the cookie',
+      hasStaticFilterValues: true,
+      filterValues: {
+        value1: {
+          selected: true,
+        },
+        value2: {
+          selected: true,
+        },
+      },
+    },
+    'parsedCookie.sameSite': {
+      title: 'Same Site',
+      description: 'Same site of the cookie',
+      hasStaticFilterValues: true,
+      hasPrecalculatedFilterValues: true,
+      filterValues: {
+        Lax: {
+          selected: null,
+        },
+        None: {
+          selected: true,
+        },
+      },
+    },
+  };
+
+  const expectedSelectAllFilterSelection = {
+    'parsedCookie.name': {
+      selected: true,
+    },
+  };
+
+  it('should extract filters from data with options', () => {
+    const setFilters = jest.fn();
+    const useFiltersSpy = jest.spyOn(React, 'useState');
+    useFiltersSpy.mockImplementation(() => [{}, setFilters]);
+
+    const setSelectAllFilterSelection = jest.fn();
+    const useSelectAllFilterSelectionSpy = jest.spyOn(React, 'useState');
+    useSelectAllFilterSelectionSpy.mockImplementation(() => [
+      {},
+      setSelectAllFilterSelection,
+    ]);
+
+    renderHook(() =>
+      useFiltersExtraction(
+        // @ts-ignore
+        data,
+        tableFilterData,
+        options,
+        selectAllFilterSelection,
+        setFilters,
+        setSelectAllFilterSelection
+      )
+    );
+
+    expect(setFilters).toHaveBeenCalledWith(expect.any(Function));
+
+    const setFiltersFn = setFilters.mock.calls[0][0];
+    const setSelectAllFilterSelectionFn =
+      setSelectAllFilterSelection.mock.calls[0][0];
+
+    expect(setFiltersFn(tableFilterData)).toEqual(expectedFilters);
+    expect(setSelectAllFilterSelectionFn(selectAllFilterSelection)).toEqual(
+      expectedSelectAllFilterSelection
+    );
+  });
+});

--- a/packages/design-system/src/components/table/useTable/useFiltering/hooks/tests/useFiltersOptions.tsx
+++ b/packages/design-system/src/components/table/useTable/useFiltering/hooks/tests/useFiltersOptions.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+import useFiltersOptions from '../useFiltersOptions';
+import React from 'react';
+
+describe('useFiltersOptions', () => {
+  const tableFilterData = {
+    'parsedCookie.name': {
+      title: 'Cookie Name',
+      description: 'Name of the cookie',
+      enableSelectAllOption: true,
+      filterValues: {
+        cookie1: {
+          selected: false,
+        },
+        cookie2: {
+          selected: false,
+        },
+      },
+    },
+    'parsedCookie.value': {
+      title: 'Cookie Value',
+      description: 'Value of the cookie',
+      hasStaticFilterValues: true,
+      filterValues: {
+        value1: {
+          selected: false,
+        },
+        value2: {
+          selected: false,
+        },
+      },
+    },
+    'parsedCookie.sameSite': {
+      title: 'Same Site',
+      description: 'Same site of the cookie',
+      hasStaticFilterValues: true,
+      hasPrecalculatedFilterValues: true,
+      filterValues: {
+        Lax: {
+          selected: false,
+        },
+        None: {
+          selected: false,
+        },
+      },
+    },
+  };
+
+  const options = {
+    current: {
+      'parsedCookie.name': {
+        All: {
+          selected: true,
+        },
+      },
+      'parsedCookie.value': {
+        value1: {
+          selected: true,
+        },
+        value2: {
+          selected: true,
+        },
+      },
+      'parsedCookie.sameSite': {
+        None: {
+          selected: true,
+        },
+      },
+    },
+  };
+
+  const expectedFilters = {
+    'parsedCookie.name': {
+      title: 'Cookie Name',
+      description: 'Name of the cookie',
+      enableSelectAllOption: true,
+      filterValues: {
+        cookie1: {
+          selected: false,
+        },
+        cookie2: {
+          selected: false,
+        },
+      },
+    },
+    'parsedCookie.value': {
+      title: 'Cookie Value',
+      description: 'Value of the cookie',
+      hasStaticFilterValues: true,
+      filterValues: {
+        value1: {
+          selected: true,
+        },
+        value2: {
+          selected: true,
+        },
+      },
+    },
+    'parsedCookie.sameSite': {
+      title: 'Same Site',
+      description: 'Same site of the cookie',
+      hasStaticFilterValues: true,
+      hasPrecalculatedFilterValues: true,
+      filterValues: {
+        Lax: {
+          selected: false,
+        },
+        None: {
+          selected: true,
+        },
+      },
+    },
+  };
+
+  const expectedSelectAllFilterSelection = {
+    'parsedCookie.name': {
+      selected: true,
+    },
+  };
+
+  it('should run options on select filters', () => {
+    const setSelectAllFilterSelection = jest.fn();
+    const useSelectAllFilterSelectionSpy = jest.spyOn(React, 'useState');
+    useSelectAllFilterSelectionSpy.mockImplementation(() => [
+      {},
+      setSelectAllFilterSelection,
+    ]);
+
+    const setFilters = jest.fn();
+    const useFiltersSpy = jest.spyOn(React, 'useState');
+    useFiltersSpy.mockImplementation(() => [{}, setFilters]);
+
+    renderHook(() =>
+      useFiltersOptions(setSelectAllFilterSelection, setFilters, options, false)
+    );
+
+    const setFiltersFn = setFilters.mock.calls[0][0];
+    const setSelectAllFilterSelectionFn =
+      setSelectAllFilterSelection.mock.calls[0][0];
+
+    expect(setFiltersFn(tableFilterData)).toEqual(expectedFilters);
+    expect(
+      setSelectAllFilterSelectionFn({
+        'parsedCookie.name': {
+          selected: false,
+        },
+      })
+    ).toEqual(expectedSelectAllFilterSelection);
+  });
+});

--- a/packages/design-system/src/components/table/useTable/useFiltering/hooks/useFiltersExtraction.tsx
+++ b/packages/design-system/src/components/table/useTable/useFiltering/hooks/useFiltersExtraction.tsx
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useEffect } from 'react';
+import { PersistentStorageData, TableData, TableFilter } from '../../types';
+import { getValueByKey } from '@ps-analysis-tool/common';
+
+/**
+ * External dependencies.
+ */
+
+const useFiltersExtraction = (
+  data: TableData[],
+  tableFilterData: TableFilter | undefined,
+  options: React.MutableRefObject<PersistentStorageData['selectedFilters']>,
+  selectAllFilterSelection: {
+    [filterKey: string]: { selected: boolean | null };
+  },
+  setFilters: React.Dispatch<React.SetStateAction<TableFilter>>,
+  setSelectAllFilterSelection: React.Dispatch<
+    React.SetStateAction<{ [filterKey: string]: { selected: boolean | null } }>
+  >
+) => {
+  const handleStaticFilters = useCallback(
+    (filter: TableFilter[keyof TableFilter], filterKey: string) => {
+      const filterValues = { ...(filter.filterValues || {}) };
+
+      const updatedFilterValues = Object.fromEntries(
+        Object.keys(filterValues).map((filterValue) => {
+          const _filterValue = filterValue.trim();
+          return [
+            _filterValue,
+            {
+              ...filterValues[_filterValue],
+              selected:
+                options.current?.[filterKey]?.[_filterValue]?.selected || null,
+            },
+          ];
+        })
+      );
+
+      return [filterKey, { ...filter, filterValues: updatedFilterValues }];
+    },
+    [options]
+  );
+
+  const calculateDynamicFilterValues = useCallback(
+    (filterKey: string, filter: TableFilter[keyof TableFilter]) => {
+      const filterValues = { ...(filter.filterValues || {}) };
+
+      const mappedValues = data
+        .map((row) => {
+          let value = getValueByKey(filterKey, row);
+
+          if (filter.calculateFilterValues) {
+            value = filter.calculateFilterValues(value);
+          }
+
+          return value;
+        })
+        .filter((value) => value && value.toString().trim());
+
+      const newFilterValues = mappedValues.reduce((acc, value) => {
+        const val = value.toString().trim();
+
+        // if selectAll is selected, then select all filter values
+        if (val && !acc[val]) {
+          const isSelectAllFilterSelected =
+            selectAllFilterSelection?.[filterKey]?.selected;
+
+          if (filterValues[val]) {
+            acc[val] = {
+              ...filterValues[val],
+              selected:
+                isSelectAllFilterSelected ||
+                filterValues[val].selected ||
+                options.current?.[filterKey]?.[val]?.selected ||
+                null,
+            };
+          } else {
+            acc[val] = {
+              selected:
+                isSelectAllFilterSelected ||
+                options.current?.[filterKey]?.[val]?.selected ||
+                null,
+            };
+          }
+        }
+
+        return acc;
+      }, {});
+
+      return newFilterValues;
+    },
+    [data, options, selectAllFilterSelection]
+  );
+
+  // extract filters from data
+  useEffect(() => {
+    setFilters((prevFilters) =>
+      Object.fromEntries(
+        Object.entries(prevFilters).map(([filterKey, filter]) => {
+          if (filter.hasStaticFilterValues) {
+            return handleStaticFilters(filter, filterKey);
+          }
+
+          const filterValues = calculateDynamicFilterValues(
+            filterKey,
+            filter as TableFilter[keyof TableFilter]
+          );
+
+          return [filterKey, { ...filter, filterValues }];
+        })
+      )
+    );
+  }, [calculateDynamicFilterValues, handleStaticFilters, setFilters]);
+
+  const extractPrecalculatedFilterKeys = useCallback(() => {
+    return Object.fromEntries(
+      Object.entries(tableFilterData || {})
+        .filter(([, filter]) => filter.hasPrecalculatedFilterValues)
+        .map(([key, filter]) => {
+          return [key, filter.filterValues];
+        })
+    );
+  }, [tableFilterData]);
+
+  // extract filters from precalculated filter values
+  useEffect(() => {
+    const filtersByKey = extractPrecalculatedFilterKeys();
+
+    setFilters((prevFilters) => {
+      const newFilters = { ...prevFilters };
+
+      Object.entries(newFilters).forEach(([key, filter]) => {
+        if (!filtersByKey[key]) {
+          return;
+        }
+
+        const filterValues: TableFilter[keyof TableFilter]['filterValues'] = {};
+
+        Object.entries(filtersByKey[key] || {}).forEach(
+          ([filterValue, filterValueData]) => {
+            const _filterValue = filterValue.trim();
+            const isSelectAllFilterSelected =
+              selectAllFilterSelection?.[key]?.selected;
+
+            if (!filter.filterValues) {
+              filter.filterValues = {};
+            }
+
+            if (!filter.filterValues?.[_filterValue]) {
+              filterValues[_filterValue] = {
+                ...filterValueData,
+                selected:
+                  isSelectAllFilterSelected ||
+                  filterValueData.selected ||
+                  options.current?.[key]?.[_filterValue]?.selected ||
+                  null,
+              };
+            } else {
+              filterValues[_filterValue] = {
+                ...filterValueData,
+                selected:
+                  isSelectAllFilterSelected ||
+                  filter.filterValues[_filterValue].selected ||
+                  filterValueData.selected ||
+                  options.current?.[key]?.[_filterValue]?.selected ||
+                  null,
+              };
+            }
+          }
+        );
+
+        filter.filterValues = filterValues;
+      });
+
+      return newFilters;
+    });
+  }, [
+    extractPrecalculatedFilterKeys,
+    options,
+    selectAllFilterSelection,
+    setFilters,
+  ]);
+
+  // extract filterKeys with selectAllFilter enabled
+  useEffect(() => {
+    const filtersWithSelectAllFilterEnabled = Object.entries(
+      tableFilterData || {}
+    )
+      .filter(([, filter]) => filter.enableSelectAllOption)
+      .reduce<Record<string, { selected: boolean | null }>>(
+        (acc, [filterKey, filterValueData]) => {
+          acc[filterKey] = {
+            selected:
+              filterValueData.isSelectAllOptionSelected ||
+              options.current?.[filterKey]?.All?.selected ||
+              null,
+          };
+
+          return acc;
+        },
+        {}
+      );
+
+    setSelectAllFilterSelection((prev) => {
+      const newSelectAllFilterSelection = { ...prev };
+
+      Object.entries(filtersWithSelectAllFilterEnabled).forEach(
+        ([filterKey, filterValueData]) => {
+          if (!newSelectAllFilterSelection[filterKey]) {
+            newSelectAllFilterSelection[filterKey] = {
+              selected:
+                newSelectAllFilterSelection[filterKey]?.selected ||
+                filterValueData.selected ||
+                null,
+            };
+          }
+        }
+      );
+
+      return newSelectAllFilterSelection;
+    });
+  }, [options, setSelectAllFilterSelection, tableFilterData]);
+};
+
+export default useFiltersExtraction;

--- a/packages/design-system/src/components/table/useTable/useFiltering/hooks/useFiltersOptions.tsx
+++ b/packages/design-system/src/components/table/useTable/useFiltering/hooks/useFiltersOptions.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies.
+ */
+import { useCallback, useEffect } from 'react';
+
+/**
+ * Internal dependencies.
+ */
+import { PersistentStorageData, TableFilter } from '../../types';
+
+const useFiltersOptions = (
+  setSelectAllFilterSelection: React.Dispatch<
+    React.SetStateAction<{ [filterKey: string]: { selected: boolean | null } }>
+  >,
+  setFilters: React.Dispatch<React.SetStateAction<TableFilter>>,
+  options: React.MutableRefObject<PersistentStorageData['selectedFilters']>,
+  isDataLoading: boolean
+) => {
+  const runOptionsOnSelectAllFilters = useCallback(() => {
+    setSelectAllFilterSelection((prev) => {
+      const newSelectAllFilterSelection = { ...prev };
+
+      Object.keys(newSelectAllFilterSelection).forEach((filterKey) => {
+        const savedFilters = options.current?.[filterKey];
+        const isSelectAllSelected = savedFilters?.All?.selected;
+
+        if (!isSelectAllSelected) {
+          return;
+        }
+
+        newSelectAllFilterSelection[filterKey].selected = true;
+      });
+
+      return newSelectAllFilterSelection;
+    });
+  }, [options, setSelectAllFilterSelection]);
+
+  const runOptionsOnFilters = useCallback(() => {
+    setFilters((prevFilters) =>
+      Object.fromEntries(
+        Object.entries(prevFilters).map(([filterKey, filter]) => {
+          const savedFilterValues = options.current?.[filterKey];
+          const filterValues = filter.filterValues || {};
+
+          if (!Object.keys(savedFilterValues || {}).length) {
+            return [filterKey, { ...filter, filterValues }];
+          }
+
+          Object.entries(savedFilterValues || {}).forEach(
+            ([filterValue, filterValueData]) => {
+              if (filterValue === 'All') {
+                return;
+              }
+
+              filterValues[filterValue] = {
+                ...filterValueData,
+              };
+            }
+          );
+
+          return [filterKey, { ...filter, filterValues }];
+        })
+      )
+    );
+  }, [options, setFilters]);
+
+  // use stored filters to set selected state
+  useEffect(() => {
+    if (isDataLoading) {
+      return;
+    }
+
+    runOptionsOnSelectAllFilters();
+    runOptionsOnFilters();
+  }, [isDataLoading, runOptionsOnFilters, runOptionsOnSelectAllFilters]);
+};
+
+export default useFiltersOptions;

--- a/packages/design-system/src/components/table/useTable/useFiltering/index.tsx
+++ b/packages/design-system/src/components/table/useTable/useFiltering/index.tsx
@@ -63,6 +63,7 @@ const useFiltering = (
   }>({});
   const [isDataLoading, setIsDataLoading] = useState(true);
 
+  // extract saved filters from persistent storage
   useFiltersPersistence(
     filters,
     options,
@@ -72,6 +73,7 @@ const useFiltering = (
     genericTablePersistentSettingsKey
   );
 
+  // run options on filters to update filter values
   useFiltersOptions(
     setSelectAllFilterSelection,
     setFilters,
@@ -79,6 +81,7 @@ const useFiltering = (
     isDataLoading
   );
 
+  // extract filters from data
   useFiltersExtraction(
     data,
     tableFilterData,


### PR DESCRIPTION
## Description
This PR adds code to persist filters when the user refreshes the web page.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices
- When the table is opened, saved filters are extracted and applied.
- As time moves, the user keeps selecting filters, and we keep updating the storage.
- When the user navigates to another table, we extract and apply filters.
- So the flow continues to open the PSAT panel, open the table, apply filters, navigate to other tables, and close the PSAT.
- But if we count the reloading of the page as a step to fulfill, the data gets lost, how?
- During the debugging process, when the table is opened the first time we extract saved filters, let's say this time as T1.
- As the user starts selecting different filters and reaches time T4.
- During this time frame, storage has been updated but the local state storing extracted saved filters on T1 is still not updated, why? Because it was supposed to be updated when the user navigates to another table.
- But if the user reloads the web page, we lose filters between T1 and T4, why?
- Because the extraction cue hasn't been triggered(which is navigating into the table), and due to this we still operate on data stored on T1.
- The old data from T1 will not be able to apply changes between T1 and T4.

To solve this issue:
- The data flow has to be changed, for this, we'll use a variable that'll keep a reference of extracted saved filters and the latest updates on filters. So that we don't lose data during any time frame.
- With this, we'll always have the latest filters saved and can be applied for any data change, be it reloading also.
<!-- Please describe your changes. -->

## Testing Instructions
- Open the PSAT panel and navigate to the cookie table.
- Open the filters sidebar and select some filters.
- Now reload the webpage being analyzed.
- The filters should remain consistent and present as per cookies data available at a certain time frame.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/b21721a3-ad66-452e-a944-df3229f133a6


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #690
