### PR TITLE
Fix: Update UX functionality of components

### DIFF
--- a/packages/cli-dashboard/src/hooks/useCookieListing/index.tsx
+++ b/packages/cli-dashboard/src/hooks/useCookieListing/index.tsx
@@ -193,7 +193,7 @@ const useCookieListing = (
           return val === (filterValue === 'True');
         },
       },
-      'parsedCookie.samesite': {
+      'parsedCookie.sameSite': {
         title: 'SameSite',
         hasStaticFilterValues: true,
         filterValues: {

--- a/packages/design-system/src/components/table/components/tableBody/bodyCell.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/bodyCell.tsx
@@ -87,12 +87,12 @@ const BodyCell = ({
           )}
         </div>
       )}
-      <p
+      <div
         className="truncate"
         title={typeof cellValue === 'string' ? cellValue : ''}
       >
         {cellValue}
-      </p>
+      </div>
     </div>
   );
 };

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/rowContextMenu.tsx
@@ -116,6 +116,7 @@ const RowContextMenu = forwardRef<
     if (chrome.devtools.panels?.network?.show) {
       // @ts-ignore
       chrome.devtools.panels.network.show({ filter });
+      setContextMenuOpen(false);
       return;
     }
 

--- a/packages/extension/src/view/devtools/components/layout.tsx
+++ b/packages/extension/src/view/devtools/components/layout.tsx
@@ -187,7 +187,10 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
   const lastUrl = useRef(tabUrl);
 
   useEffect(() => {
-    if (lastUrl.current === tabUrl || lastUrl.current === null) {
+    if (
+      lastUrl.current === null ||
+      new URL(lastUrl.current).hostname === new URL(tabUrl || '').hostname
+    ) {
       lastUrl.current = tabUrl;
       return;
     }


### PR DESCRIPTION
## Description
This PR 
- Updates the filter key used in CLI for the same site, which will now show correct data.
- Remain on the same frame if the hostname is the same as the previous URL, inside the extension.
- Close the context menu on the table row once the user has navigated to the network panel.
- Correct the dom elements nesting to not get errors inside the console.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Run analysis of site on CLI.
- Let the dashboard open, and open the cookie table.
- Select the SameSite filter and rows should be filtered correctly.
- Now open the PSAT panel in dev tools and analyze livemint.com
- Open the first frame and now click a link inside the web page.
- Navigation to a new page of the same hostname should keep the first frame selected.
- Now right click on any row and context menu should open.
- Click on Show requests in network panel button, you should navigate to network panel.
- Go back to PSAT panel, the context menu should be closed.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
