### PR TITLE
Add website hostname as prefix to cookie table CSV

### DIFF
--- a/packages/cli-dashboard/src/app.tsx
+++ b/packages/cli-dashboard/src/app.tsx
@@ -47,21 +47,22 @@ const App = () => {
     CompleteJson[] | null
   >(null);
 
-  const [type, path] = useMemo(() => {
+  const [type, dirPath, dir] = useMemo(() => {
     const urlParams = new URLSearchParams(window.location.search);
-    const dir = urlParams.get('dir');
+    const _dir = urlParams.get('dir') || '';
 
     return [
       urlParams.get('type') === 'sitemap'
         ? DisplayType.SITEMAP
         : DisplayType.SITE,
-      `/out/${dir}/out.json`,
+      `/out/${_dir}/out.json`,
+      _dir,
     ];
   }, []);
 
   useEffect(() => {
     (async () => {
-      const response = await fetch(path);
+      const response = await fetch(dirPath);
       const data: CompleteJson[] = await response.json();
       setCompleteJsonReport(data);
 
@@ -82,9 +83,9 @@ const App = () => {
       setCookies(_cookies);
       setTechnologies(_technologies);
     })();
-  }, [path, type]);
+  }, [dirPath, type]);
 
-  if (!path) {
+  if (!dirPath) {
     return (
       <div className="flex justify-center items-center">
         <div className="text-2xl">No path provided</div>
@@ -99,6 +100,7 @@ const App = () => {
         cookies={cookies}
         technologies={technologies}
         completeJson={completeJsonReport}
+        path={dir}
       />
     );
   }
@@ -109,7 +111,8 @@ const App = () => {
         completeJson={completeJsonReport}
         cookies={cookies}
         technologies={technologies}
-        selectedSite={path.slice(5, -9)}
+        selectedSite={dirPath.slice(5, -9)}
+        path={dir}
       />
     </div>
   );

--- a/packages/cli-dashboard/src/components/siteMapReport/index.tsx
+++ b/packages/cli-dashboard/src/components/siteMapReport/index.tsx
@@ -39,6 +39,7 @@ interface SiteMapReportProps {
   cookies: CookieFrameStorageType;
   technologies: TechnologyData[];
   completeJson: CompleteJson[] | null;
+  path: string;
 }
 
 const SiteMapReport = ({
@@ -46,6 +47,7 @@ const SiteMapReport = ({
   technologies,
   landingPageCookies,
   completeJson,
+  path,
 }: SiteMapReportProps) => {
   const [data, setData] = useState<SidebarItems>(sidebarData);
 
@@ -58,6 +60,7 @@ const SiteMapReport = ({
         completeJson={completeJson}
         sidebarData={data}
         setSidebarData={setData}
+        path={path}
       />
     </SidebarProvider>
   );

--- a/packages/cli-dashboard/src/components/siteMapReport/layout.tsx
+++ b/packages/cli-dashboard/src/components/siteMapReport/layout.tsx
@@ -50,6 +50,7 @@ interface LayoutProps {
   completeJson: CompleteJson[] | null;
   sidebarData: SidebarItems;
   setSidebarData: React.Dispatch<React.SetStateAction<SidebarItems>>;
+  path: string;
 }
 
 const Layout = ({
@@ -59,6 +60,7 @@ const Layout = ({
   completeJson,
   sidebarData,
   setSidebarData,
+  path,
 }: LayoutProps) => {
   const [sites, setSites] = useState<string[]>([]);
 
@@ -154,6 +156,7 @@ const Layout = ({
                 technologies: siteFilteredTechnologies,
                 completeJson,
                 selectedSite: site,
+                path,
               },
             },
             children: {},
@@ -185,6 +188,7 @@ const Layout = ({
     completeJson,
     cookiesWithIssues,
     isKeySelected,
+    path,
     reshapedCookies,
     setSidebarData,
     siteFilteredCookies,

--- a/packages/cli-dashboard/src/components/siteReport/index.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/index.tsx
@@ -44,6 +44,7 @@ interface SiteReportProps {
   technologies: TechnologyData[];
   completeJson: CompleteJson[] | null;
   selectedSite: string | null;
+  path: string;
 }
 
 const SiteReport = ({
@@ -51,6 +52,7 @@ const SiteReport = ({
   technologies,
   completeJson,
   selectedSite,
+  path,
 }: SiteReportProps) => {
   const [data, setData] = useState<SidebarItems>(Tabs);
 
@@ -59,6 +61,7 @@ const SiteReport = ({
       cookies={cookies}
       technologies={technologies}
       completeJson={completeJson}
+      path={path}
     >
       <SidebarProvider data={data}>
         <Layout selectedSite={selectedSite} setSidebarData={setData} />

--- a/packages/cli-dashboard/src/components/siteReport/stateProviders/contentStore/index.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/stateProviders/contentStore/index.tsx
@@ -36,6 +36,7 @@ export interface ContentStore {
     tabCookies: { [key: string]: CookieTableData };
     technologies: TechnologyData[] | undefined;
     completeJson: CompleteJson[] | null;
+    path: string;
   };
 }
 
@@ -44,6 +45,7 @@ const initialState: ContentStore = {
     tabCookies: {},
     technologies: [],
     completeJson: null,
+    path: '',
   },
 };
 
@@ -57,6 +59,7 @@ interface ContentStoreProviderProps {
   };
   technologies?: TechnologyData[];
   completeJson: CompleteJson[] | null;
+  path: string;
 }
 
 export const Provider = ({
@@ -64,6 +67,7 @@ export const Provider = ({
   technologies,
   completeJson,
   children,
+  path,
 }: PropsWithChildren<ContentStoreProviderProps>) => {
   const tabCookies = useMemo(() => reshapeCookies(cookies), [cookies]);
 
@@ -74,6 +78,7 @@ export const Provider = ({
           tabCookies,
           technologies,
           completeJson,
+          path,
         },
       }}
     >

--- a/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesListing/index.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesListing/index.tsx
@@ -45,8 +45,9 @@ const CookiesListing = ({
     [frame: string]: CookieTableData | null;
   } | null>(null);
 
-  const { tabCookies } = useContentStore(({ state }) => ({
+  const { tabCookies, path } = useContentStore(({ state }) => ({
     tabCookies: state.tabCookies,
+    path: state.path,
   }));
 
   const cookies = useMemo(
@@ -94,6 +95,7 @@ const CookiesListing = ({
           selectedFrameCookie={selectedFrameCookie}
           setSelectedFrameCookie={setSelectedFrameCookie}
           isFiltersSidebarOpen={isSidebarOpen}
+          hostname={path}
         />
       </Resizable>
       <CookieDetails

--- a/packages/design-system/src/components/cookieTable/index.tsx
+++ b/packages/design-system/src/components/cookieTable/index.tsx
@@ -193,7 +193,9 @@ const CookieTable = forwardRef<
         conditionalTableRowClassesHandler={_conditionalTableRowClassesHandler}
         exportTableData={
           !hideExport
-            ? (rows: TableRow[]) => exportCookies(rows, hostname)
+            ? (rows: TableRow[]) => {
+                exportCookies(rows, hostname);
+              }
             : undefined
         }
         hasVerticalBar={hasVerticalBar}

--- a/packages/design-system/src/components/cookieTable/index.tsx
+++ b/packages/design-system/src/components/cookieTable/index.tsx
@@ -56,6 +56,7 @@ interface CookieTableProps {
     row: TableRow
   ) => void;
   hideExport?: boolean;
+  hostname: string;
 }
 
 const CookieTable = forwardRef<
@@ -78,6 +79,7 @@ const CookieTable = forwardRef<
     extraInterfaceToTopBar,
     onRowContextMenu,
     hideExport,
+    hostname,
   }: CookieTableProps,
   ref
 ) {
@@ -189,7 +191,11 @@ const CookieTable = forwardRef<
         onRowContextMenu={onRowContextMenuHandler}
         getRowObjectKey={getRowObjectKey}
         conditionalTableRowClassesHandler={_conditionalTableRowClassesHandler}
-        exportTableData={!hideExport ? exportCookies : undefined}
+        exportTableData={
+          !hideExport
+            ? (rows: TableRow[]) => exportCookies(rows, hostname)
+            : undefined
+        }
         hasVerticalBar={hasVerticalBar}
         isRowSelected={isRowSelected}
       >

--- a/packages/design-system/src/components/cookieTable/utils/exportCookies.ts
+++ b/packages/design-system/src/components/cookieTable/utils/exportCookies.ts
@@ -30,7 +30,8 @@ const exportCookies = (rows: TableRow[], hostname: string) => {
   const _cookies = rows.map(({ originalData }) => originalData);
   if (_cookies.length > 0 && 'parsedCookie' in _cookies[0]) {
     const csvTextBlob = generateCookieTableCSV(_cookies as CookieTableData[]);
-    saveAs(csvTextBlob, `${hostname.replace('.', '-')}-report.csv`);
+    const fileName = hostname.split('.').join('-');
+    saveAs(csvTextBlob, `${fileName}-report.csv`);
   }
 };
 

--- a/packages/design-system/src/components/cookieTable/utils/exportCookies.ts
+++ b/packages/design-system/src/components/cookieTable/utils/exportCookies.ts
@@ -26,11 +26,11 @@ import { saveAs } from 'file-saver';
 import { TableRow } from '../../table';
 import { generateCookieTableCSV } from '../../table/utils';
 
-const exportCookies = (rows: TableRow[]) => {
+const exportCookies = (rows: TableRow[], hostname: string) => {
   const _cookies = rows.map(({ originalData }) => originalData);
   if (_cookies.length > 0 && 'parsedCookie' in _cookies[0]) {
     const csvTextBlob = generateCookieTableCSV(_cookies as CookieTableData[]);
-    saveAs(csvTextBlob, 'Cookies Report.csv');
+    saveAs(csvTextBlob, `${hostname.replace('.', '-')}-report.csv`);
   }
 };
 

--- a/packages/extension/src/view/devtools/components/cookies/cookiesListing/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookiesListing/index.tsx
@@ -113,6 +113,7 @@ const CookiesListing = ({ setFilteredCookies }: CookiesListingProps) => {
           extraInterfaceToTopBar={extraInterfaceToTopBar}
           onRowContextMenu={rowContextMenuRef.current?.onRowContextMenu}
           ref={cookieTableRef}
+          hostname={tabUrl ? new URL(tabUrl).hostname : ''}
         />
       </Resizable>
       <CookieDetails


### PR DESCRIPTION
## Description
This PR adds code to add hostname as a prefix to the cookie table CSV.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open the PSAT panel and open the cookie table.
- Click on the download icon beside the search bar.
- A file should be downloaded and the file name should include hostname as a prefix.
- For eg. website is https://livemint.com, the file should be `www-livemint-com-report.csv`
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="309" alt="Screenshot 2024-05-31 at 16 51 30" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/cfc00755-7e19-4306-b78a-7cb4d6ef9f20">

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #688 
