### PR TITLE
Fix: Report throwing error when downloaded from CLI.

### DIFF
--- a/packages/report/src/index.tsx
+++ b/packages/report/src/index.tsx
@@ -35,6 +35,7 @@ chrome = {
       addListener: noop,
       removeListener: noop,
     },
+    get: noop,
   },
   devtools: {
     inspectedWindow: {


### PR DESCRIPTION
## Description
The function of `chrome.tabs.get` which was added to the library detection was not mocked and this caused the dowloaded report to break. This PR aims to fix this issue.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Clone this branch.
- In the terminal run `npm run cli:build && npm run cli -- -u https://bbc.com`
- Now download the report from cli-dashboard.
- Check the html report.
- The error for `chrome.tabs.get` should not be present anymore.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
