### PR TITLE
Feature: Provide an optional argument to CLI.

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,6 +50,7 @@ const program = new Command();
 program
   .version('0.8.0')
   .description('CLI to test a URL for 3p cookies')
+  .argument('[website-url]', 'The URL of website you want to analyse')
   .option('-u, --url <value>', 'URL of a site')
   .option('-s, --sitemap-url <value>', 'URL of a sitemap')
   .option('-c, --csv-path <value>', 'Path to a CSV file with a set of URLs.')
@@ -125,7 +126,7 @@ const saveResultsAsHTML = async (
 
 // eslint-disable-next-line complexity
 (async () => {
-  const url = program.opts().url;
+  const url = program.args?.[0] ?? program.opts().url;
   const sitemapUrl = program.opts().sitemapUrl;
   const csvPath = program.opts().csvPath;
   const sitemapPath = program.opts().sitemapPath;

--- a/packages/cli/src/utils/validateArgs.ts
+++ b/packages/cli/src/utils/validateArgs.ts
@@ -49,7 +49,7 @@ const validateArgs = async (
   if (numArgs !== 1) {
     console.log(
       `Please provide one and only one of the following
-        a) URL of a site (-u or --url)
+        a) URL of a site (-u or --url or default argument)
         b) URL of a sitemap (-s or --sitemap-url)
         c) Path to a CSV file (-c or --csv-path)
         d) Path to an XML file (-p or --sitemap-path)`

--- a/packages/design-system/src/components/menuBar/tests/isElementInView.ts
+++ b/packages/design-system/src/components/menuBar/tests/isElementInView.ts
@@ -27,7 +27,7 @@ describe('isElementInView', () => {
       }),
     };
 
-    expect(isElementInView(element)).toBe(true);
+    expect(isElementInView(element as HTMLElement)).toBe(true);
   });
 
   it('should return false if the element is not in view', () => {
@@ -40,20 +40,20 @@ describe('isElementInView', () => {
       }),
     };
 
-    expect(isElementInView(element)).toBe(false);
+    expect(isElementInView(element as HTMLElement)).toBe(false);
 
     element.getBoundingClientRect = () => ({
       top: 0,
       bottom: -100,
     });
 
-    expect(isElementInView(element)).toBe(false);
+    expect(isElementInView(element as HTMLElement)).toBe(false);
 
     element.getBoundingClientRect = () => ({
       top: 0,
       bottom: 24,
     });
 
-    expect(isElementInView(element)).toBe(false);
+    expect(isElementInView(element as HTMLElement)).toBe(false);
   });
 });


### PR DESCRIPTION
## Description
This PR aims to add a default argument to the CLI which will be the website URL and will allow the user to analyse the website without requiring to use the `-u` option.
If the user wants to use the `-u` option, it will still be available.

## Relevant Technical Choices
- Add optional argument using `.argument` function from `commander.js`

## Testing Instructions
- Clone this branch.
- In the terminal run `npm run cli:build`.
- Now in the terminal run `npm run cli https://bbc.com`.
- This should analyse `bbc.com` website.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/59614577/89826e59-4d24-475a-9b28-f31ca4a6df70


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~~[ ] This code is covered by unit tests to verify that it works as intended.~~NA
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

