### PR TITLE
Fix: Conditionally use `I18n.getMessage` function inside `InfoCard`

### DIFF
--- a/data/PSInfo.json
+++ b/data/PSInfo.json
@@ -18,6 +18,7 @@
   "protected-audience": {
     "name": "Protected Audience",
     "description": "The Protected Audience API is a Privacy Sandbox technology to serve remarketing and custom audience use cases, designed so third parties cannot track user browsing behavior across sites.",
+		"useI18n": false,
     "proposal": "https://github.com/WICG/turtledove",
     "publicDiscussion": "https://github.com/WICG/turtledove/issues",
 		"publicExplainer": "https://github.com/WICG/turtledove/blob/main/FLEDGE.md",

--- a/packages/design-system/src/components/landingPage/infoCard/fetchPSInfo.ts
+++ b/packages/design-system/src/components/landingPage/infoCard/fetchPSInfo.ts
@@ -33,6 +33,7 @@ export type PSInfoKeyType = (typeof PSInfoKey)[keyof typeof PSInfoKey];
 export type PSInfo = {
   name: string;
   description: string;
+  useI18n: boolean;
   proposal: string;
   publicExplainer: string;
   publicDiscussion: string;

--- a/packages/design-system/src/components/landingPage/infoCard/index.tsx
+++ b/packages/design-system/src/components/landingPage/infoCard/index.tsx
@@ -53,7 +53,10 @@ const InfoCard = ({ infoKey, className }: InfoCardProps) => {
           <p
             className="mb-3 text-raisin-black dark:text-bright-gray text-sm"
             dangerouslySetInnerHTML={{
-              __html: I18n.getMessage(PSInfo.description),
+              __html:
+                PSInfo.useI18n === false
+                  ? PSInfo.description
+                  : I18n.getMessage(PSInfo.description),
             }}
           />
           <LearnMoreDropdown PSInfo={PSInfo} />

--- a/packages/design-system/src/components/landingPage/infoCard/learnMoreDropdown.tsx
+++ b/packages/design-system/src/components/landingPage/infoCard/learnMoreDropdown.tsx
@@ -36,22 +36,27 @@ const LABELS = [
   {
     label: 'proposal',
     linkLabel: 'proposalNote',
+    useI18n: true,
   },
   {
     label: 'Public Explainer',
     linkLabel: 'Implementation explainer',
+    useI18n: false,
   },
   {
     label: 'publicDiscussion',
     linkLabel: 'publicDiscussionNote',
+    useI18n: true,
   },
   {
     label: 'videoOverview',
     linkLabel: 'videoOverviewNote',
+    useI18n: true,
   },
   {
     label: 'devDocumentation',
     linkLabel: 'devDocumentationNote',
+    useI18n: true,
   },
 ];
 
@@ -87,6 +92,14 @@ const LearnMoreDropdown = ({
               return null;
             }
 
+            const label = LABELS[index].useI18n
+              ? I18n.getMessage(LABELS[index].label)
+              : LABELS[index].label;
+
+            const linkLabel = LABELS[index].useI18n
+              ? I18n.getMessage(LABELS[index].linkLabel)
+              : LABELS[index].linkLabel;
+
             return (
               <RenderLink
                 key={index}
@@ -97,8 +110,8 @@ const LearnMoreDropdown = ({
                     ? addUTMParams(value)
                     : value
                 }
-                label={I18n.getMessage(LABELS[index].label)}
-                linkLabel={I18n.getMessage(LABELS[index].linkLabel)}
+                label={label}
+                linkLabel={linkLabel}
               />
             );
           })}


### PR DESCRIPTION
## Description
This PR adds the useI18n key value inside InfoCard so as not to use getMessage for non-translated strings.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Configure the system for a locale other than English and open PSAT.
- Navigate to the Protected Audience landing page, the text should be visible in English without any breakage.
- Now compare the same with the `develop` branch.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="1319" alt="Screenshot 2024-06-24 at 11 25 03" src="https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/58820001/dbc3e805-04ef-4fa0-9974-bf2c8b8b8d8c">

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
