### PR TITLE
Fix paths for cli to work on global as well as local installation.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21766,6 +21766,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/analysis-utils": "*",
+				"@google-psat/cli-dashboard": "*",
 				"@google-psat/common": "*",
 				"@google-psat/i18n": "*",
 				"@google-psat/library-detection": "*",
@@ -21787,9 +21788,6 @@
 				"tsc-watch": "^6.0.4",
 				"typescript": "^5.0.4",
 				"webpack": "^5.86.0"
-			},
-			"peerDependencies": {
-				"@google-psat/cli-dashboard": "*"
 			}
 		},
 		"packages/cli-dashboard": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
   "homepage": "https://github.com/GoogleChromeLabs/ps-analysis-tool",
   "dependencies": {
     "@google-psat/analysis-utils": "*",
+    "@google-psat/cli-dashboard": "*",
     "@google-psat/common": "*",
     "@google-psat/i18n": "*",
     "@google-psat/library-detection": "*",
@@ -58,8 +59,5 @@
     "tsc-watch": "^6.0.4",
     "typescript": "^5.0.4",
     "webpack": "^5.86.0"
-  },
-  "peerDependencies": {
-    "@google-psat/cli-dashboard": "*"
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,7 +19,7 @@
  */
 import { Command } from 'commander';
 import events from 'events';
-import { ensureFile, writeFile } from 'fs-extra';
+import { existsSync, ensureFile, writeFile } from 'fs-extra';
 // @ts-ignore Package does not support typescript.
 import Spinnies from 'spinnies';
 import fs from 'fs';
@@ -103,15 +103,56 @@ const saveResultsAsHTML = async (
   result: CompleteJson | CompleteJson[],
   isSiteMap: boolean
 ) => {
-  const htmlText = fs.readFileSync(
-    path.resolve(__dirname + '../../../cli-dashboard/dist/index.html'),
-    'utf-8'
-  );
+  let htmlText = '';
+  let reportHTML = '';
 
-  const reportHTML = fs.readFileSync(
-    path.resolve(__dirname + '../../../cli-dashboard/dist/report/index.html'),
-    'base64'
-  );
+  if (
+    existsSync(
+      path.resolve(
+        __dirname +
+          '../../node_modules/@google-psat/cli-dashboard/dist/index.html'
+      )
+    )
+  ) {
+    htmlText = fs.readFileSync(
+      path.resolve(
+        __dirname +
+          '../../node_modules/@google-psat/cli-dashboard/dist/index.html'
+      ),
+      'utf-8'
+    );
+
+    reportHTML = fs.readFileSync(
+      path.resolve(
+        __dirname +
+          '../../node_modules/@google-psat/cli-dashboard/dist/report/index.html'
+      ),
+      'base64'
+    );
+
+    fs.copyFileSync(
+      path.resolve(
+        __dirname +
+          '../../node_modules/@google-psat/cli-dashboard/dist/index.js'
+      ),
+      outDir + '/index.js'
+    );
+  } else {
+    htmlText = fs.readFileSync(
+      path.resolve(__dirname + '../../../cli-dashboard/dist/index.html'),
+      'utf-8'
+    );
+
+    reportHTML = fs.readFileSync(
+      path.resolve(__dirname + '../../../cli-dashboard/dist/report/index.html'),
+      'base64'
+    );
+
+    fs.copyFileSync(
+      path.resolve(__dirname + '../../../cli-dashboard/dist/index.js'),
+      outDir + '/index.js'
+    );
+  }
 
   const messages = I18n.getMessages();
 
@@ -126,11 +167,6 @@ const saveResultsAsHTML = async (
       translations: messages,
     })}</script>` +
     htmlText.substring(htmlText.indexOf('</head>'));
-
-  fs.copyFileSync(
-    path.resolve(__dirname + '../../../cli-dashboard/dist/index.js'),
-    outDir + '/index.js'
-  );
 
   const outFileFullDir = path.resolve(outDir + '/index.html');
   const htmlBlob = new Blob([html]);

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -139,24 +139,30 @@ class I18n {
     const localeArray = this.createLocaleArray(locale);
 
     for (const _locale of localeArray) {
+      let localePath = '';
       if (
         existsSync(
           path.resolve(
             __dirname +
-              `../../../i18n/_locales/messages/${_locale}/messages.json`
+              `../../node_modules/@google-psat/i18n/_locales/messages/${_locale}/messages.json`
           )
         )
       ) {
+        localePath = path.resolve(
+          __dirname +
+            `../../node_modules/@google-psat/i18n/_locales/messages/${_locale}/messages.json`
+        );
+      } else {
+        localePath = path.resolve(
+          __dirname + `../../../i18n/_locales/messages/${_locale}/messages.json`
+        );
+      }
+
+      if (existsSync(localePath)) {
         const messages = JSON.parse(
-          readFileSync(
-            path.resolve(
-              __dirname +
-                `../../../i18n/_locales/messages/${_locale}/messages.json`
-            ),
-            {
-              encoding: 'utf-8',
-            }
-          )
+          readFileSync(localePath, {
+            encoding: 'utf-8',
+          })
         );
 
         this.initMessages(messages);

--- a/packages/i18n/src/tests/i18n.ts
+++ b/packages/i18n/src/tests/i18n.ts
@@ -65,7 +65,6 @@ describe('I18n', () => {
 
     expect(result).toEqual(messages);
   });
-
   it('should load CLI messages data', async () => {
     const existsSyncMock = jest.spyOn(fs, 'existsSync');
     const readFileSyncMock = jest.spyOn(fs, 'readFileSync');
@@ -86,17 +85,14 @@ describe('I18n', () => {
     readFileSyncMock.mockReturnValueOnce(JSON.stringify(messages));
     await I18n.loadCLIMessagesData(locale);
 
-    expect(existsSyncMock).toHaveBeenCalledWith(
-      path.resolve(
-        __dirname + `../../../../i18n/_locales/messages/hi/messages.json`
-      )
+    expect(existsSyncMock).toHaveBeenNthCalledWith(
+      2,
+      path.resolve(__dirname + `../../../_locales/messages/hi/messages.json`)
     );
-    expect(existsSyncMock).toHaveBeenCalledTimes(1);
+    expect(existsSyncMock).toHaveBeenCalledTimes(2);
 
     expect(readFileSyncMock).toHaveBeenCalledWith(
-      path.resolve(
-        __dirname + `../../../../i18n/_locales/messages/hi/messages.json`
-      ),
+      path.resolve(__dirname + `../../../_locales/messages/hi/messages.json`),
       {
         encoding: 'utf-8',
       }


### PR DESCRIPTION
## Description
This PR aims to make CLI work when its published on NPM as well as when the repository is cloned.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices
- Use different paths to get the CLI dependencies.

## Testing Instructions
For local installation:
- Clone this branch.
- Go to terminal and run `npm run build-cli`.
- Now run `npm run cli https://natgeo.com`
- You should be able to see the report.

For global installation:
- Go to terminal and run `npm run local-registry:start && npm run publish:all:local`.
- Then open new terminal instance ther run `npm i -g @google-psat/cli && psat https://bbc.com`.
- You should be able to see the report.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).
