### PR TITLE
CLI: Fix missing frame key in the page frames Hashmap

### DIFF
--- a/packages/analysis-utils/src/browserManagement/index.ts
+++ b/packages/analysis-utils/src/browserManagement/index.ts
@@ -666,7 +666,13 @@ export class BrowserManagement {
     const mainFrameUrlIdMap = await this.getMainframeIds();
 
     Object.entries(mainFrameUrlIdMap).forEach(([_url, id]) => {
-      this.pageFrames[_url][id] = '0';
+      if (!this.pageFrames[_url]) {
+        this.pageFrames[_url] = {
+          [id]: '0',
+        };
+      } else {
+        this.pageFrames[_url][id] = '0';
+      }
     });
 
     const result = await Promise.all(


### PR DESCRIPTION
## Description

This PR fixes an intermittently occurring error bug when analyzing sites.
![Screenshot 2024-06-25 at 7 53 54 AM](https://github.com/GoogleChromeLabs/ps-analysis-tool/assets/53055971/941bdb85-e14c-4183-a159-2c66844ed588)


## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~[ ] This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->