### PR TITLE
Add more blocked reasons content.

### DIFF
--- a/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/blockedCookiesSection.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/blockedCookiesSection.tsx
@@ -87,7 +87,9 @@ const BlockedCookiesSection = ({
         ...component,
         description:
           typeof legendDescription === 'string'
-            ? I18n.getMessage(legendDescription)
+            ? legendDescription.includes(' ')
+              ? legendDescription
+              : I18n.getMessage(legendDescription)
             : I18n.getFormattedMessages(legendDescription),
         title: component.label,
         containerClasses: '',

--- a/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/blockedCookiesSection.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/blockedCookiesSection.tsx
@@ -67,7 +67,9 @@ const BlockedCookiesSection = ({
         ...component,
         description:
           typeof legendDescription === 'string'
-            ? I18n.getMessage(legendDescription)
+            ? legendDescription.includes(' ')
+              ? legendDescription
+              : I18n.getMessage(legendDescription)
             : I18n.getFormattedMessages(legendDescription),
         title: component.label,
         containerClasses: '',

--- a/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/blockedCookiesSection.tsx
+++ b/packages/cli-dashboard/src/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/blockedCookiesSection.tsx
@@ -26,7 +26,12 @@ import {
   LEGEND_DESCRIPTION,
   useFiltersMapping,
 } from '@google-psat/design-system';
-import type { TabCookies, TabFrames, DataMapping } from '@google-psat/common';
+import {
+  type TabCookies,
+  type TabFrames,
+  type DataMapping,
+  getLegendDescription,
+} from '@google-psat/common';
 import { I18n } from '@google-psat/i18n';
 
 interface BlockedCookiesSectionProps {
@@ -65,12 +70,7 @@ const BlockedCookiesSection = ({
       const legendDescription = LEGEND_DESCRIPTION[component.label] || '';
       return {
         ...component,
-        description:
-          typeof legendDescription === 'string'
-            ? legendDescription.includes(' ')
-              ? legendDescription
-              : I18n.getMessage(legendDescription)
-            : I18n.getFormattedMessages(legendDescription),
+        description: getLegendDescription(legendDescription),
         title: component.label,
         containerClasses: '',
         onClick: (title: string) =>
@@ -87,12 +87,7 @@ const BlockedCookiesSection = ({
         LEGEND_DESCRIPTION[component.descriptionKey || ''];
       return {
         ...component,
-        description:
-          typeof legendDescription === 'string'
-            ? legendDescription.includes(' ')
-              ? legendDescription
-              : I18n.getMessage(legendDescription)
-            : I18n.getFormattedMessages(legendDescription),
+        description: getLegendDescription(legendDescription),
         title: component.label,
         containerClasses: '',
         onClick: (title: string) => {

--- a/packages/common/src/cookies.types.ts
+++ b/packages/common/src/cookies.types.ts
@@ -251,7 +251,7 @@ export interface DataMapping {
     count: number;
     color: string;
   }[];
-  onClick?: () => void | null;
+  onClick?: (() => void) | null;
 }
 
 export type FrameStateCreator = {

--- a/packages/common/src/data/cookieExclusionAndWarningReasons/cookieBlockedReason.ts
+++ b/packages/common/src/data/cookieExclusionAndWarningReasons/cookieBlockedReason.ts
@@ -47,7 +47,7 @@ const CookieBlockedReason = {
   DisallowedCharacter:
     "This 'Set-Cookie' header contained a disallowed character (a forbidden ASCII control character, or the tab character if it appears in the middle of the cookie name, value, an attribute name, or an attribute value).",
   NoCookieContent:
-    "This attempt to set a cookie via a 'Set-Cookie' header was blocked beacuse this cookie had no content",
+    "This attempt to set a cookie via a 'Set-Cookie' header was blocked beacuse the header did not contain any value.",
 };
 
 export default CookieBlockedReason;

--- a/packages/common/src/data/cookieExclusionAndWarningReasons/cookieBlockedReason.ts
+++ b/packages/common/src/data/cookieExclusionAndWarningReasons/cookieBlockedReason.ts
@@ -47,7 +47,7 @@ const CookieBlockedReason = {
   DisallowedCharacter:
     "This 'Set-Cookie' header contained a disallowed character (a forbidden ASCII control character, or the tab character if it appears in the middle of the cookie name, value, an attribute name, or an attribute value).",
   NoCookieContent:
-    "This attempt to set a cookie via a 'Set-Cookie' header was blocked beacuse the header did not contain any value.",
+    "This attempt to set a cookie via a 'Set-Cookie' header was blocked because the header did not contain any value.",
 };
 
 export default CookieBlockedReason;

--- a/packages/common/src/data/cookieExclusionAndWarningReasons/cookieBlockedReason.ts
+++ b/packages/common/src/data/cookieExclusionAndWarningReasons/cookieBlockedReason.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+//out/win-Debug/gen/third_party/devtools-frontend/src/front_end/core/sdk/NetworkRequest.js
 const CookieBlockedReason = {
   SecureOnly: ['body_SecureOnly'],
   NotOnPath: ['body_NotOnPath'],
@@ -32,6 +33,21 @@ const CookieBlockedReason = {
   SamePartyFromCrossPartyContext: ['body_SamePartyFromCrossPartyContext'],
   NameValuePairExceedsMaxSize: ['body_NameValuePairExceedsMaxSize'],
   InvalidDomain: ['body_InvalidDomain'],
+  SameSiteLax:
+    "This cookie was blocked because it had the 'SameSite=Lax' attribute and the request was made from a different site and was not initiated by a top-level navigation.",
+  SyntaxError: "This 'Set-Cookie' header had invalid syntax.",
+  SchemeNotSupported:
+    'The scheme of this connection is not allowed to store cookies.',
+  OverwriteSecure:
+    "This attempt to set a cookie via a 'Set-Cookie' header was blocked because it was not sent over a secure connection and would have overwritten a cookie with the Secure attribute.",
+  InvalidPrefix:
+    "This attempt to set a cookie via a 'Set-Cookie' header was blocked because it used the '__Secure-' or '__Host-' prefix in its name and broke the additional rules applied to cookies with these prefixes.",
+  SamePartyConflictsWithOtherAttributes:
+    "This attempt to set a cookie via a 'Set-Cookie' header was blocked because it had the 'SameParty' attribute but also had other conflicting attributes. Chrome requires cookies that use the 'SameParty' attribute to also have the 'Secure' attribute, and to not be restricted to 'SameSite=Strict'.",
+  DisallowedCharacter:
+    "This 'Set-Cookie' header contained a disallowed character (a forbidden ASCII control character, or the tab character if it appears in the middle of the cookie name, value, an attribute name, or an attribute value).",
+  NoCookieContent:
+    "This attempt to set a cookie via a 'Set-Cookie' header was blocked beacuse this cookie had no content",
 };
 
 export default CookieBlockedReason;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -41,6 +41,7 @@ export { default as delay } from './utils/delay';
 export { default as mergeDeep } from './utils/mergeDeep';
 export { default as resolveWithTimeout } from './utils/resolveWithTimeout';
 export { default as deriveBlockingStatus } from './utils/deriveBlockingStatus';
+export { default as getLegendDescription } from './utils/getLegendDescription';
 export * from './worker/enums';
 export * from './utils/generateReports';
 export * from './cookies.types';

--- a/packages/common/src/utils/getLegendDescription.ts
+++ b/packages/common/src/utils/getLegendDescription.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies.
+ */
+import { I18n } from '@google-psat/i18n';
+
+const getLegendDescription = (legendDescription: string | string[]) => {
+  return typeof legendDescription === 'string'
+    ? legendDescription.includes(' ')
+      ? legendDescription
+      : I18n.getMessage(legendDescription)
+    : I18n.getFormattedMessages(legendDescription);
+};
+
+export default getLegendDescription;

--- a/packages/design-system/src/components/cookieDetails/details.tsx
+++ b/packages/design-system/src/components/cookieDetails/details.tsx
@@ -63,10 +63,15 @@ const Details = ({ selectedCookie, isUsingCDP }: DetailsProps) => {
     const cookieExclusionReason =
       // @ts-ignore
       cookieIssueDetails.CookieExclusionReason[reason];
-    const cookieBlockedReason = I18n.getFormattedMessages(
-      // @ts-ignore
-      cookieIssueDetails.CookieBlockedReason[reason]
-    );
+    const cookieBlockedReason =
+      //@ts-ignore
+      typeof cookieIssueDetails.CookieBlockedReason[reason] === 'string'
+        ? //@ts-ignore
+          cookieIssueDetails.CookieBlockedReason[reason]
+        : I18n.getFormattedMessages(
+            // @ts-ignore
+            cookieIssueDetails.CookieBlockedReason[reason]
+          );
 
     if (cookieBlockedReason) {
       blockedReasons = blockedReasons + cookieBlockedReason;

--- a/packages/design-system/src/components/cookiesLanding/cookiesMatrix/index.tsx
+++ b/packages/design-system/src/components/cookiesLanding/cookiesMatrix/index.tsx
@@ -74,7 +74,9 @@ const CookiesMatrix = ({
       ...component,
       description:
         typeof legendDescription === 'string'
-          ? I18n.getMessage(legendDescription)
+          ? legendDescription.includes(' ')
+            ? legendDescription
+            : I18n.getMessage(legendDescription)
           : I18n.getFormattedMessages(legendDescription),
       title: component.label,
     });

--- a/packages/design-system/src/components/cookiesLanding/cookiesMatrix/index.tsx
+++ b/packages/design-system/src/components/cookiesLanding/cookiesMatrix/index.tsx
@@ -22,6 +22,7 @@ import {
   type TabFrames,
   Legend,
   filterFramesWithCookies,
+  getLegendDescription,
 } from '@google-psat/common';
 import { I18n } from '@google-psat/i18n';
 /**
@@ -72,12 +73,7 @@ const CookiesMatrix = ({
       LEGEND_DESCRIPTION[component.descriptionKey || component.label] || '';
     dataComponents.push({
       ...component,
-      description:
-        typeof legendDescription === 'string'
-          ? legendDescription.includes(' ')
-            ? legendDescription
-            : I18n.getMessage(legendDescription)
-          : I18n.getFormattedMessages(legendDescription),
+      description: getLegendDescription(legendDescription),
       title: component.label,
     });
   });

--- a/packages/design-system/src/constants.ts
+++ b/packages/design-system/src/constants.ts
@@ -83,6 +83,21 @@ export const LEGEND_DESCRIPTION: LegendData = {
   StorageAccessAPI: 'exemptionReasonStorageAccessAPI',
   TopLevelStorageAccessAPI: 'exemptionReasonTopLevelStorageAccessAPI',
   CorsOptIn: 'exemptionReasonCorsOptIn',
+  SameSiteLax:
+    "This cookie was blocked because it had the 'SameSite=Lax' attribute and the request was made from a different site and was not initiated by a top-level navigation.",
+  SyntaxError: "This 'Set-Cookie' header had invalid syntax.",
+  SchemeNotSupported:
+    'The scheme of this connection is not allowed to store cookies.',
+  OverwriteSecure:
+    "This attempt to set a cookie via a 'Set-Cookie' header was blocked because it was not sent over a secure connection and would have overwritten a cookie with the Secure attribute.",
+  InvalidPrefix:
+    "This attempt to set a cookie via a 'Set-Cookie' header was blocked because it used the '__Secure-' or '__Host-' prefix in its name and broke the additional rules applied to cookies with these prefixes.",
+  SamePartyConflictsWithOtherAttributes:
+    "This attempt to set a cookie via a 'Set-Cookie' header was blocked because it had the 'SameParty' attribute but also had other conflicting attributes. Chrome requires cookies that use the 'SameParty' attribute to also have the 'Secure' attribute, and to not be restricted to 'SameSite=Strict'.",
+  DisallowedCharacter:
+    "This 'Set-Cookie' header contained a disallowed character (a forbidden ASCII control character, or the tab character if it appears in the middle of the cookie name, value, an attribute name, or an attribute value).",
+  NoCookieContent:
+    "This attempt to set a cookie via a 'Set-Cookie' header was blocked beacuse the header did not contain any value.",
 };
 
 export const EMPTY_FRAME_COUNT = [

--- a/packages/design-system/src/theme/colors.ts
+++ b/packages/design-system/src/theme/colors.ts
@@ -187,4 +187,32 @@ export const COLOR_MAP: {
     color: '#D741A7',
     className: 'text-hollywood-cerise',
   },
+  SyntaxError: {
+    color: '#FF6F91',
+    className: 'text-baby-pink-gradient',
+  },
+  SchemeNotSupported: {
+    color: '#B39CD0',
+    className: 'text-spot-palette-mud-pink',
+  },
+  OverwriteSecure: {
+    color: '#E59500',
+    className: 'text-jamboo',
+  },
+  InvalidPrefix: {
+    color: '#EB4B98',
+    className: 'text-rose-bourbon',
+  },
+  SamePartyConflictsWithOtherAttributes: {
+    color: '#E0A890',
+    className: 'text-orange-buff',
+  },
+  DisallowedCharacter: {
+    color: '#0FFF95',
+    className: 'text-spring-green',
+  },
+  NoCookieContent: {
+    color: '#840032',
+    className: 'text-maroon-claret',
+  },
 };

--- a/packages/design-system/src/utils/prepareCookieStatsComponents.ts
+++ b/packages/design-system/src/utils/prepareCookieStatsComponents.ts
@@ -43,7 +43,7 @@ const prepareCookieStatsComponents = (
     if (isNaN(cookieStats.blockedCookies[key])) {
       return;
     }
-    console.log('key', key);
+
     blockedCookiesStats.push({
       count: cookieStats.blockedCookies[key],
       color: COLOR_MAP[key]?.color ?? '#E59500',

--- a/packages/design-system/src/utils/prepareCookieStatsComponents.ts
+++ b/packages/design-system/src/utils/prepareCookieStatsComponents.ts
@@ -43,7 +43,7 @@ const prepareCookieStatsComponents = (
     if (isNaN(cookieStats.blockedCookies[key])) {
       return;
     }
-
+    console.log('key', key);
     blockedCookiesStats.push({
       count: cookieStats.blockedCookies[key],
       color: COLOR_MAP[key]?.color ?? '#E59500',
@@ -52,8 +52,8 @@ const prepareCookieStatsComponents = (
     blockedCookiesLegend.push({
       label: key,
       count: cookieStats.blockedCookies[key],
-      color: COLOR_MAP[key].color ?? '#E59500',
-      countClassName: COLOR_MAP[key].className ?? 'text-jamboo',
+      color: COLOR_MAP[key]?.color ?? '#E59500',
+      countClassName: COLOR_MAP[key]?.className ?? 'text-jamboo',
     });
   });
 
@@ -67,14 +67,14 @@ const prepareCookieStatsComponents = (
 
     exemptedCookiesStats.push({
       count: cookieStats.exemptedCookies[key],
-      color: COLOR_MAP[key].color,
+      color: COLOR_MAP[key]?.color ?? '#E59500',
     });
 
     exemptedCookiesLegend.push({
       label: key,
       count: cookieStats.exemptedCookies[key],
-      color: COLOR_MAP[key].color,
-      countClassName: COLOR_MAP[key].className,
+      color: COLOR_MAP[key]?.color ?? '#E59500',
+      countClassName: COLOR_MAP[key]?.className ?? 'text-jamboo',
     });
   });
 

--- a/packages/design-system/src/utils/prepareCookieStatsComponents.ts
+++ b/packages/design-system/src/utils/prepareCookieStatsComponents.ts
@@ -46,14 +46,14 @@ const prepareCookieStatsComponents = (
 
     blockedCookiesStats.push({
       count: cookieStats.blockedCookies[key],
-      color: COLOR_MAP[key].color,
+      color: COLOR_MAP[key]?.color ?? '#E59500',
     });
 
     blockedCookiesLegend.push({
       label: key,
       count: cookieStats.blockedCookies[key],
-      color: COLOR_MAP[key].color,
-      countClassName: COLOR_MAP[key].className,
+      color: COLOR_MAP[key].color ?? '#E59500',
+      countClassName: COLOR_MAP[key].className ?? 'text-jamboo',
     });
   });
 

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -14,7 +14,12 @@
     "noImplicitAny": true,
     "strictNullChecks": true
   },
-  "exclude": ["**/tests/**/*.ts", "**/tests/**/*.tsx"],
+  "exclude": [
+    "**/tests/**/*.ts",
+    "**/tests/**/*.tsx",
+    "**/dist/**/*",
+    "**/dist-types/**/*"
+  ],
   "references": [
     {
       "path": "../common"

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/blockedCookiesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/blockedCookiesSection.tsx
@@ -28,7 +28,7 @@ import {
   SIDEBAR_ITEMS_KEYS,
   useSidebar,
 } from '@google-psat/design-system';
-import type { DataMapping } from '@google-psat/common';
+import { type DataMapping, getLegendDescription } from '@google-psat/common';
 import { I18n } from '@google-psat/i18n';
 /**
  * Internal dependencies
@@ -75,12 +75,7 @@ const BlockedCookiesSection = () => {
       const legendDescription = LEGEND_DESCRIPTION[component.label] || '';
       return {
         ...component,
-        description:
-          typeof legendDescription === 'string'
-            ? legendDescription.includes(' ')
-              ? legendDescription
-              : I18n.getMessage(legendDescription)
-            : I18n.getFormattedMessages(legendDescription),
+        description: getLegendDescription(legendDescription),
         title: component.label,
         containerClasses: '',
         onClick: (title: string) =>

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/blockedCookiesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/blockedCookiesSection.tsx
@@ -77,7 +77,9 @@ const BlockedCookiesSection = () => {
         ...component,
         description:
           typeof legendDescription === 'string'
-            ? I18n.getMessage(legendDescription)
+            ? legendDescription.includes(' ')
+              ? legendDescription
+              : I18n.getMessage(legendDescription)
             : I18n.getFormattedMessages(legendDescription),
         title: component.label,
         containerClasses: '',

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/exemptedCookiesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/exemptedCookiesSection.tsx
@@ -52,7 +52,9 @@ const ExemptedCookiesSection = () => {
         ...component,
         description:
           typeof legendDescription === 'string'
-            ? I18n.getMessage(legendDescription)
+            ? legendDescription.includes(' ')
+              ? legendDescription
+              : I18n.getMessage(legendDescription)
             : I18n.getFormattedMessages(legendDescription),
         title: component.label,
         containerClasses: '',

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/exemptedCookiesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/exemptedCookiesSection.tsx
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import React from 'react';
-import type { DataMapping } from '@google-psat/common';
+import { type DataMapping, getLegendDescription } from '@google-psat/common';
 import {
   prepareCookieStatsComponents,
   prepareCookiesCount,
@@ -50,12 +50,7 @@ const ExemptedCookiesSection = () => {
       const legendDescription = LEGEND_DESCRIPTION[component.label] || '';
       return {
         ...component,
-        description:
-          typeof legendDescription === 'string'
-            ? legendDescription.includes(' ')
-              ? legendDescription
-              : I18n.getMessage(legendDescription)
-            : I18n.getFormattedMessages(legendDescription),
+        description: getLegendDescription(legendDescription),
         title: component.label,
         containerClasses: '',
         onClick: (title: string) => {

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/framesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/framesSection.tsx
@@ -24,6 +24,7 @@ import {
   type MatrixComponentProps,
   LEGEND_DESCRIPTION,
 } from '@google-psat/design-system';
+import { getLegendDescription } from '@google-psat/common';
 import { I18n } from '@google-psat/i18n';
 /**
  * Internal dependencies
@@ -43,12 +44,7 @@ const FramesSection = () => {
         LEGEND_DESCRIPTION[component.descriptionKey] || '';
       return {
         ...component,
-        description:
-          typeof legendDescription === 'string'
-            ? legendDescription.includes(' ')
-              ? legendDescription
-              : I18n.getMessage(legendDescription)
-            : I18n.getFormattedMessages(legendDescription),
+        description: getLegendDescription(legendDescription),
         title: component.label,
         containerClasses: '',
       };

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/framesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/framesSection.tsx
@@ -45,7 +45,9 @@ const FramesSection = () => {
         ...component,
         description:
           typeof legendDescription === 'string'
-            ? I18n.getMessage(legendDescription)
+            ? legendDescription.includes(' ')
+              ? legendDescription
+              : I18n.getMessage(legendDescription)
             : I18n.getFormattedMessages(legendDescription),
         title: component.label,
         containerClasses: '',

--- a/packages/report/src/components/blockedCookiesSection.tsx
+++ b/packages/report/src/components/blockedCookiesSection.tsx
@@ -27,11 +27,11 @@ import {
   type MatrixComponentProps,
 } from '@google-psat/design-system';
 import { I18n } from '@google-psat/i18n';
+import { type DataMapping, getLegendDescription } from '@google-psat/common';
 /**
  * Internal dependencies
  */
 import { useData } from '../stateProviders/data';
-import type { DataMapping } from '@google-psat/common';
 
 const CookiesSection = () => {
   const data = useData(({ state }) => state.data);
@@ -54,12 +54,7 @@ const CookiesSection = () => {
       const legendDescription = LEGEND_DESCRIPTION[component.label] || '';
       return {
         ...component,
-        description:
-          typeof legendDescription === 'string'
-            ? legendDescription.includes(' ')
-              ? legendDescription
-              : I18n.getMessage(legendDescription)
-            : I18n.getFormattedMessages(legendDescription),
+        description: getLegendDescription(legendDescription),
         title: component.label,
         containerClasses: '',
       };

--- a/packages/report/src/components/blockedCookiesSection.tsx
+++ b/packages/report/src/components/blockedCookiesSection.tsx
@@ -56,7 +56,9 @@ const CookiesSection = () => {
         ...component,
         description:
           typeof legendDescription === 'string'
-            ? I18n.getMessage(legendDescription)
+            ? legendDescription.includes(' ')
+              ? legendDescription
+              : I18n.getMessage(legendDescription)
             : I18n.getFormattedMessages(legendDescription),
         title: component.label,
         containerClasses: '',

--- a/packages/report/src/components/framesSection.tsx
+++ b/packages/report/src/components/framesSection.tsx
@@ -24,6 +24,7 @@ import {
   MatrixContainer,
 } from '@google-psat/design-system';
 import { I18n } from '@google-psat/i18n';
+import { getLegendDescription } from '@google-psat/common';
 /**
  * Internal dependencies
  */
@@ -42,12 +43,7 @@ const CookiesSection = () => {
 
     return {
       ...component,
-      description:
-        typeof legendDescription === 'string'
-          ? legendDescription.includes(' ')
-            ? legendDescription
-            : I18n.getMessage(legendDescription)
-          : I18n.getFormattedMessages(legendDescription),
+      description: getLegendDescription(legendDescription),
       title: component.label,
       containerClasses: '',
     };

--- a/packages/report/src/components/framesSection.tsx
+++ b/packages/report/src/components/framesSection.tsx
@@ -44,7 +44,9 @@ const CookiesSection = () => {
       ...component,
       description:
         typeof legendDescription === 'string'
-          ? I18n.getMessage(legendDescription)
+          ? legendDescription.includes(' ')
+            ? legendDescription
+            : I18n.getMessage(legendDescription)
           : I18n.getFormattedMessages(legendDescription),
       title: component.label,
       containerClasses: '',

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -152,6 +152,13 @@ module.exports = {
       'cocoa-brown': '#D96C06',
       'persian-indigo': '#3A1772',
       'hollywood-cerise': '#D741A7',
+      'baby-pink-gradient': '#FF6F91',
+      'spot-palette-mud-pink': '#B39CD0',
+      jamboo: '#E59500',
+      'rose-bourbon': '#EB4B98',
+      'orange-buff': '#E0A890',
+      'spring-green': '#0FFF95',
+      'maroon-claret': '#840032',
     },
     backgroundColor: {
       ...colors,

--- a/test.csv
+++ b/test.csv
@@ -1,5 +1,0 @@
-https://domain-aaa.com/spotify
-https://www.math-only-math.com/
-https://amp-support.rt.gw/saint-josephs-day-see-how-to-make-a-wish-for-saint-joseph/
-https://mydramalist.com/article/netflix-confirms-the-main-leads-of-the-upcoming-k-drama-cashero
-https://zee5.com/

--- a/test.csv
+++ b/test.csv
@@ -1,0 +1,5 @@
+https://domain-aaa.com/spotify
+https://www.math-only-math.com/
+https://amp-support.rt.gw/saint-josephs-day-see-how-to-make-a-wish-for-saint-joseph/
+https://mydramalist.com/article/netflix-confirms-the-main-leads-of-the-upcoming-k-drama-cashero
+https://zee5.com/


### PR DESCRIPTION
## Description
This PR adds more blocked reason and handles message to be displayed where there is not translated content

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Clone this branch and in the terminal run `npm run build:all`.
- Run the PSAT CLI on following URL using the command. `npm run cli https://time.com -- -l hi`.
- You should see the dashboard without breakages and the new blocked reason in English.
- Similarly, the extension should also not break for the site time.com.


## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
