### PR TITLE
Fix: Use onCommittedNavigation Listener instead of onTabUpdated

### DIFF
--- a/packages/extension/src/serviceWorker/chromeListeners/index.ts
+++ b/packages/extension/src/serviceWorker/chromeListeners/index.ts
@@ -27,7 +27,7 @@ import {
 } from './syncStorageOnChangedListener';
 import { onTabCreatedListener } from './tabOnCreatedListener';
 import { onTabRemovedListener } from './tabOnRemovedListener';
-import { onTabUpdatedListener } from './tabsOnUpdatedListener';
+import { onCommittedNavigationListener } from './onCommittedNavigationListener';
 import { windowsOnRemovedListener } from './windowsOnRemovedListener';
 import { windowsOnCreatedListener } from './windowsOnCreatedListener';
 
@@ -84,7 +84,7 @@ chrome.tabs.onRemoved.addListener(onTabRemovedListener);
  * Fires when a tab is updated.
  * @see https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onUpdated
  */
-chrome.tabs.onUpdated.addListener(onTabUpdatedListener);
+chrome.webNavigation.onCommitted.addListener(onCommittedNavigationListener);
 
 /**
  * Fires when a window is removed (closed).


### PR DESCRIPTION
## Description
On some sites it was noticed the tab doesnt reload but due to ads the tab was moved to loading state. This PR aims to use `onCommitted` listener from `chrome.webNavigation` which fixes the resetting of cookie stats issue.

## Relevant Technical Choices

- Use `onCommitted` listener from `chrome.webNavigation` instead of `chrome.tabs.onUpdated`.

## Testing Instructions
- Clone this branch.
- In the terminal run `npm run ext:build`
- Now in the browser open `beebom.com`
- Go to any article and keep on scrolling you should see that the cookie stats do not reset now.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
