### PR TITLE
Fix: Add custom sorting comparator for categories

### DIFF
--- a/packages/design-system/src/components/dashboard/components/siteReport/tabs/technologies/index.tsx
+++ b/packages/design-system/src/components/dashboard/components/siteReport/tabs/technologies/index.tsx
@@ -75,6 +75,18 @@ const Technologies = ({ selectedSite }: TechnologiesProps) => {
         accessorKey: 'categories',
         cell: (info: InfoType) =>
           (info as TechnologyData['categories']).map((i) => i.name).join(' | '),
+        sortingComparator: (a: InfoType, b: InfoType) => {
+          const aCategories =
+            (a as TechnologyData['categories'])
+              ?.map((i) => i.name)
+              .join(' | ') || '';
+          const bCategories =
+            (b as TechnologyData['categories'])
+              ?.map((i) => i.name)
+              .join(' | ') || '';
+
+          return aCategories.localeCompare(bCategories);
+        },
       },
     ],
     []

--- a/packages/design-system/src/components/table/useTable/provider.tsx
+++ b/packages/design-system/src/components/table/useTable/provider.tsx
@@ -72,7 +72,7 @@ export const TableProvider = ({
     useColumnResizing(visibleColumns, allTableColumnsKeys, commonKey);
 
   const { sortedData, sortKey, sortOrder, setSortKey, setSortOrder } =
-    useColumnSorting(data, commonKey);
+    useColumnSorting(data, tableColumns, commonKey);
 
   const {
     filters,

--- a/packages/design-system/src/components/table/useTable/types.ts
+++ b/packages/design-system/src/components/table/useTable/types.ts
@@ -37,6 +37,7 @@ export type TableColumn = {
   showBodyCellPrefixIcon?: (row: TableRow) => boolean;
   widthWeightagePercentage?: number;
   width?: number; // For internal use only
+  sortingComparator?: (a: InfoType, b: InfoType) => number;
 };
 
 export type TableRow = {

--- a/packages/design-system/src/components/table/useTable/useColumnSorting/index.tsx
+++ b/packages/design-system/src/components/table/useTable/useColumnSorting/index.tsx
@@ -23,7 +23,7 @@ import { getValueByKey } from '@google-psat/common';
 /**
  * Internal dependencies.
  */
-import type { TableData } from '../types';
+import type { TableColumn, TableData } from '../types';
 import { useTablePersistentSettingsStore } from '../../persistentSettingsStore';
 
 export type DefaultOptions = {
@@ -41,6 +41,7 @@ export type ColumnSortingOutput = {
 
 const useColumnSorting = (
   data: TableData[],
+  tableColumns: TableColumn[],
   tablePersistentSettingsKey?: string
 ): ColumnSortingOutput => {
   const [sortKey, _setSortKey] = useState<string>('');
@@ -68,9 +69,17 @@ const useColumnSorting = (
       return [];
     }
 
+    const sortingComparator = tableColumns.find(
+      (column) => column.accessorKey === sortKey
+    )?.sortingComparator;
+
     const _sortedData = [...data].sort((a, b) => {
       const candidateA = getValueByKey(sortKey, a);
       const candidateB = getValueByKey(sortKey, b);
+
+      if (sortingComparator) {
+        return sortingComparator(candidateA, candidateB) * (ascending ? 1 : -1);
+      }
 
       return (
         (candidateA === candidateB ? 0 : candidateA > candidateB ? 1 : -1) *
@@ -79,7 +88,7 @@ const useColumnSorting = (
     });
 
     return _sortedData;
-  }, [ascending, data, isDataLoading, sortKey]);
+  }, [ascending, data, isDataLoading, sortKey, tableColumns]);
 
   const { getPreferences, setPreferences } = useTablePersistentSettingsStore(
     ({ actions }) => ({


### PR DESCRIPTION
## Description
This PR adds a key to allow a column sorting comparator and fixes the technology table's categories column.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Run a CLI on a site or sitemap.
- Open the report and navigate to the technology table.
- Click on the category header, the rows should be sorted in ascending or descending order.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/user-attachments/assets/cf3cfc77-2211-465b-988e-b3078ba6fc5b


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
