### PR TITLE
Enhancement: Add filtering feedback to the matrix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24769,7 +24769,7 @@
 		},
 		"packages/analysis-utils": {
 			"name": "@google-psat/analysis-utils",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",
@@ -24796,7 +24796,7 @@
 		},
 		"packages/cli": {
 			"name": "@google-psat/cli",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/analysis-utils": "*",
@@ -24828,7 +24828,7 @@
 		},
 		"packages/cli-dashboard": {
 			"name": "@google-psat/cli-dashboard",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",
@@ -24889,7 +24889,7 @@
 		},
 		"packages/common": {
 			"name": "@google-psat/common",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/i18n": "*",
@@ -24906,7 +24906,7 @@
 		},
 		"packages/design-system": {
 			"name": "@google-psat/design-system",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",
@@ -24924,7 +24924,7 @@
 		},
 		"packages/eslint-import-resolver": {
 			"name": "@google-psat/eslint-import-resolver",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eslint-import-resolver-node": "^0.3.7"
@@ -24972,7 +24972,7 @@
 		},
 		"packages/i18n": {
 			"name": "@google-psat/i18n",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"intl-messageformat": "^10.5.11"
@@ -24980,7 +24980,7 @@
 		},
 		"packages/library-detection": {
 			"name": "@google-psat/library-detection",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",
@@ -25005,7 +25005,7 @@
 		},
 		"packages/report": {
 			"name": "@google-psat/report",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",

--- a/packages/common/src/cookies.types.ts
+++ b/packages/common/src/cookies.types.ts
@@ -167,6 +167,7 @@ export interface Legend {
   color: string;
   countClassName: string;
   onClick?: (title: string) => void;
+  isSelected?: (title: string) => boolean;
 }
 
 export interface CookieStatsComponents {
@@ -256,6 +257,7 @@ export interface DataMapping {
     color: string;
   }[];
   onClick?: (() => void) | null;
+  isSelected?: () => boolean;
 }
 
 export type FrameStateCreator = {

--- a/packages/design-system/src/components/cookiesLanding/landingHeader/index.tsx
+++ b/packages/design-system/src/components/cookiesLanding/landingHeader/index.tsx
@@ -53,6 +53,8 @@ const LandingHeader = ({
                   'active:opacity-50 hover:scale-95 transition-all duration-300 ease-in-out cursor-pointer ':
                     circleData.onClick,
                   'cursor-default': !circleData.onClick,
+                  'bg-[#f5f5f5] dark:bg-[#1d1d1d] rounded-md':
+                    circleData?.isSelected?.(),
                 })}
                 onClick={() => {
                   circleData.onClick?.();

--- a/packages/design-system/src/components/matrix/index.tsx
+++ b/packages/design-system/src/components/matrix/index.tsx
@@ -57,6 +57,8 @@ const Matrix = ({ dataComponents, expand }: MatrixProps) => {
                   'hover:opacity-90 active:opacity-50 hover:scale-[0.98] hover:bg-[#f5f5f5] hover:dark:bg-[#1d1d1d] hover:shadow-[inset_0_0_10px_5px_rgba(238,238,238,0.5)] hover:dark:shadow-[inset_0_0_10px_5px_rgba(32,32,32,0.1)] rounded-md transition-all duration-75 ease-in-out cursor-pointer':
                     dataComponent.onClick,
                   'cursor-default': !dataComponent.onClick,
+                  'bg-[#f5f5f5] dark:bg-[#1d1d1d] rounded-md':
+                    dataComponent.isSelected?.(dataComponent.title),
                 })}
               >
                 <MatrixComponent

--- a/packages/design-system/src/components/matrix/matrixComponent/index.tsx
+++ b/packages/design-system/src/components/matrix/matrixComponent/index.tsx
@@ -33,6 +33,7 @@ export interface MatrixComponentProps {
   isExpanded?: boolean;
   countClassName: string;
   containerClasses?: string;
+  isSelected?: (title: string) => boolean;
 }
 
 const MatrixComponent = ({

--- a/packages/design-system/src/components/table/useTable/useFiltering/index.tsx
+++ b/packages/design-system/src/components/table/useTable/useFiltering/index.tsx
@@ -45,6 +45,7 @@ export type TableFilteringOutput = {
     isSingleFilterRemovalAction?: boolean
   ) => void;
   isSelectAllFilterSelected: (filterKey: string) => boolean;
+  isFilterValueSelected: (accessorKey: string, filterValue: string) => boolean;
   resetFilters: () => void;
 };
 
@@ -96,6 +97,15 @@ const useFiltering = (
       return Boolean(selectAllFilterSelection?.[filterKey]?.selected);
     },
     [selectAllFilterSelection]
+  );
+
+  const isFilterValueSelected = useCallback(
+    (accessorKey: string, filterValue: string) => {
+      return Boolean(
+        filters[accessorKey]?.filterValues?.[filterValue]?.selected
+      );
+    },
+    [filters]
   );
 
   const toggleSelectAllFilter = useCallback(
@@ -336,6 +346,7 @@ const useFiltering = (
     toggleSelectAllFilter,
     isSelectAllFilterSelected,
     resetFilters,
+    isFilterValueSelected,
   };
 };
 

--- a/packages/design-system/src/utils/prepareCookieDataMapping.ts
+++ b/packages/design-system/src/utils/prepareCookieDataMapping.ts
@@ -28,12 +28,14 @@ import { I18n } from '@google-psat/i18n';
  * @param {CookiesCount} cookieStats The calculated cookie count for each type.
  * @param {CookieStatsComponents} cookiesStatsComponents cookies statistics of curent tab with the legend data.
  * @param selectedItemUpdater The function to update the selected item.
+ * @param isFilterValueSelected The function to check if the filter value is selected.
  * @returns {DataMapping[]} Mapped data array for displaying the landing header.
  */
 export default function prepareCookieDataMapping(
   cookieStats: CookiesCount,
   cookiesStatsComponents: CookieStatsComponents,
-  selectedItemUpdater: (title: string, accessorKey?: string) => void
+  selectedItemUpdater: (title: string, accessorKey?: string) => void,
+  isFilterValueSelected: (accessorKey: string, filterValue: string) => boolean
 ): DataMapping[] {
   return [
     {
@@ -41,6 +43,7 @@ export default function prepareCookieDataMapping(
       count: cookieStats.total,
       data: cookiesStatsComponents.legend,
       onClick: () => selectedItemUpdater('', 'isFirstParty'), // title is empty as we don't want to select any filter.
+      isSelected: () => isFilterValueSelected('isFirstParty', ''),
     },
     {
       title: I18n.getMessage('firstPartyCookies'),
@@ -48,6 +51,8 @@ export default function prepareCookieDataMapping(
       data: cookiesStatsComponents.firstParty,
       onClick: () =>
         selectedItemUpdater(I18n.getMessage('firstParty'), 'isFirstParty'),
+      isSelected: () =>
+        isFilterValueSelected('isFirstParty', I18n.getMessage('firstParty')),
     },
     {
       title: I18n.getMessage('thirdPartyCookies'),
@@ -55,6 +60,8 @@ export default function prepareCookieDataMapping(
       data: cookiesStatsComponents.thirdParty,
       onClick: () =>
         selectedItemUpdater(I18n.getMessage('thirdParty'), 'isFirstParty'),
+      isSelected: () =>
+        isFilterValueSelected('isFirstParty', I18n.getMessage('thirdParty')),
     },
   ];
 }

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/blockedCookiesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/blockedCookiesSection.tsx
@@ -41,9 +41,13 @@ import { useCookie, useSettings } from '../../../stateProviders';
 
 interface BlockedCookiesSectionProps {
   tabCookies: TabCookies;
+  isFilterValueSelected: (accessorKey: string, filterValue: string) => boolean;
 }
 
-const BlockedCookiesSection = ({ tabCookies }: BlockedCookiesSectionProps) => {
+const BlockedCookiesSection = ({
+  tabCookies,
+  isFilterValueSelected,
+}: BlockedCookiesSectionProps) => {
   const { tabFrames } = useCookie(({ state }) => ({
     tabFrames: state.tabFrames,
   }));
@@ -87,6 +91,8 @@ const BlockedCookiesSection = ({ tabCookies }: BlockedCookiesSectionProps) => {
         containerClasses: '',
         onClick: (title: string) =>
           selectedItemUpdater(title, 'blockedReasons'),
+        isSelected: (title: string) =>
+          isFilterValueSelected('blockedReasons', title),
       };
     });
 

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/cookiesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/cookiesSection.tsx
@@ -27,17 +27,21 @@ import {
   useFiltersMapping,
 } from '@google-psat/design-system';
 import { I18n } from '@google-psat/i18n';
+import type { TabCookies } from '@google-psat/common';
 /**
  * Internal dependencies
  */
 import { useCookie } from '../../../stateProviders';
-import type { TabCookies } from '@google-psat/common';
 
 interface CookiesSectionProps {
   tabCookies: TabCookies;
+  isFilterValueSelected: (accessorKey: string, filterValue: string) => boolean;
 }
 
-const CookiesSection = ({ tabCookies }: CookiesSectionProps) => {
+const CookiesSection = ({
+  tabCookies,
+  isFilterValueSelected,
+}: CookiesSectionProps) => {
   const { tabFrames } = useCookie(({ state }) => ({
     tabFrames: state.tabFrames,
   }));
@@ -49,7 +53,8 @@ const CookiesSection = ({ tabCookies }: CookiesSectionProps) => {
   const cookieClassificationDataMapping = prepareCookieDataMapping(
     cookieStats,
     cookiesStatsComponents,
-    selectedItemUpdater
+    selectedItemUpdater,
+    isFilterValueSelected
   );
 
   const cookieComponentData = useMemo(() => {
@@ -57,8 +62,14 @@ const CookiesSection = ({ tabCookies }: CookiesSectionProps) => {
       ...component,
       onClick: (title: string) =>
         selectedItemUpdater(title, 'analytics.category'),
+      isSelected: (title: string) =>
+        isFilterValueSelected('analytics.category', title),
     }));
-  }, [cookiesStatsComponents.legend, selectedItemUpdater]);
+  }, [
+    cookiesStatsComponents.legend,
+    isFilterValueSelected,
+    selectedItemUpdater,
+  ]);
 
   const processedTabFrames = useMemo(
     () => Object.fromEntries(Object.entries(tabFrames || {})),

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/exemptedCookiesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/exemptedCookiesSection.tsx
@@ -40,10 +40,12 @@ import { useCookie } from '../../../stateProviders';
 
 interface ExemptedCookiesSectionProps {
   tabCookies: TabCookies;
+  isFilterValueSelected: (accessorKey: string, filterValue: string) => boolean;
 }
 
 const ExemptedCookiesSection = ({
   tabCookies,
+  isFilterValueSelected,
 }: ExemptedCookiesSectionProps) => {
   const { tabFrames } = useCookie(({ state }) => ({
     tabFrames: state.tabFrames,
@@ -65,6 +67,8 @@ const ExemptedCookiesSection = ({
         onClick: (title: string) => {
           selectedItemUpdater(title, 'exemptionReason');
         },
+        isSelected: (title: string) =>
+          isFilterValueSelected(title, 'exemptionReason'),
       };
     });
   const exemptedCookiesDataMapping: DataMapping[] = [

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/exemptedCookiesSection.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/exemptedCookiesSection.tsx
@@ -68,7 +68,7 @@ const ExemptedCookiesSection = ({
           selectedItemUpdater(title, 'exemptionReason');
         },
         isSelected: (title: string) =>
-          isFilterValueSelected(title, 'exemptionReason'),
+          isFilterValueSelected('exemptionReason', title),
       };
     });
   const exemptedCookiesDataMapping: DataMapping[] = [

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/index.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/index.tsx
@@ -107,6 +107,7 @@ const AssembledCookiesLanding = () => {
           <Landing
             tabCookies={cookiesByKey}
             appliedFilters={filter.selectedFilters}
+            isFilterValueSelected={filter.isFilterValueSelected}
           />
         </div>
       </div>

--- a/packages/extension/src/view/devtools/components/cookies/cookieLanding/landing.tsx
+++ b/packages/extension/src/view/devtools/components/cookies/cookieLanding/landing.tsx
@@ -42,9 +42,14 @@ import ExemptedCookiesSection from './exemptedCookiesSection';
 interface LandingProps {
   tabCookies: TabCookies;
   appliedFilters: TableFilter;
+  isFilterValueSelected: (accessorKey: string, filterValue: string) => boolean;
 }
 
-const Landing = ({ tabCookies, appliedFilters }: LandingProps) => {
+const Landing = ({
+  tabCookies,
+  appliedFilters,
+  isFilterValueSelected,
+}: LandingProps) => {
   const { unfilteredCookies, url, tabFrames } = useCookie(({ state }) => ({
     unfilteredCookies: state.tabCookies,
     tabFrames: state.tabFrames,
@@ -69,6 +74,7 @@ const Landing = ({ tabCookies, appliedFilters }: LandingProps) => {
           Element: CookiesSection,
           props: {
             tabCookies,
+            isFilterValueSelected,
           },
         },
       },
@@ -79,6 +85,7 @@ const Landing = ({ tabCookies, appliedFilters }: LandingProps) => {
           Element: BlockedCookiesSection,
           props: {
             tabCookies,
+            isFilterValueSelected,
           },
         },
       },
@@ -109,13 +116,14 @@ const Landing = ({ tabCookies, appliedFilters }: LandingProps) => {
           Element: ExemptedCookiesSection,
           props: {
             tabCookies,
+            isFilterValueSelected,
           },
         },
       });
     }
 
     return defaultSections;
-  }, [isUsingCDP, tabCookies]);
+  }, [isUsingCDP, tabCookies, isFilterValueSelected]);
 
   const menuData: MenuData = useMemo(
     () => sections.map(({ name, link }) => ({ name, link })),

--- a/packages/report/src/dashboard/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/blockedCookiesSection.tsx
+++ b/packages/report/src/dashboard/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/blockedCookiesSection.tsx
@@ -38,12 +38,14 @@ interface BlockedCookiesSectionProps {
   tabCookies: TabCookies | null;
   cookiesWithIssues: TabCookies | null;
   tabFrames: TabFrames | null;
+  isFilterValueSelected: (accessorKey: string, filterValue: string) => boolean;
 }
 
 const BlockedCookiesSection = ({
   tabCookies,
   cookiesWithIssues,
   tabFrames,
+  isFilterValueSelected,
 }: BlockedCookiesSectionProps) => {
   const { selectedItemUpdater, multiSelectItemUpdater } = useFiltersMapping(
     tabFrames || {}
@@ -92,6 +94,8 @@ const BlockedCookiesSection = ({
         containerClasses: '',
         onClick: (title: string) =>
           selectedItemUpdater(title, 'blockedReasons', selectTabFrame(title)),
+        isSelected: (title: string) =>
+          isFilterValueSelected('blockedReasons', title),
       };
     });
 
@@ -113,6 +117,8 @@ const BlockedCookiesSection = ({
             'analytics.category': [title],
           });
         },
+        isSelected: (title: string) =>
+          isFilterValueSelected('analytics.category', title),
       };
     });
 

--- a/packages/report/src/dashboard/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/cookiesSection.tsx
+++ b/packages/report/src/dashboard/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/cookiesSection.tsx
@@ -32,8 +32,13 @@ import {
 interface CookiesSectionProps {
   tabCookies: TabCookies | null;
   tabFrames: TabFrames | null;
+  isFilterValueSelected: (accessorKey: string, filterValue: string) => boolean;
 }
-const CookiesSection = ({ tabCookies, tabFrames }: CookiesSectionProps) => {
+const CookiesSection = ({
+  tabCookies,
+  tabFrames,
+  isFilterValueSelected,
+}: CookiesSectionProps) => {
   const { selectedItemUpdater } = useFiltersMapping(tabFrames || {});
 
   const cookieStats = prepareCookiesCount(tabCookies);
@@ -41,7 +46,8 @@ const CookiesSection = ({ tabCookies, tabFrames }: CookiesSectionProps) => {
   const cookieClassificationDataMapping = prepareCookieDataMapping(
     cookieStats,
     cookiesStatsComponents,
-    selectedItemUpdater
+    selectedItemUpdater,
+    isFilterValueSelected
   );
 
   const cookieComponentData = useMemo(() => {
@@ -49,8 +55,14 @@ const CookiesSection = ({ tabCookies, tabFrames }: CookiesSectionProps) => {
       ...component,
       onClick: (title: string) =>
         selectedItemUpdater(title, 'analytics.category'),
+      isSelected: (title: string) =>
+        isFilterValueSelected('analytics.category', title),
     }));
-  }, [cookiesStatsComponents.legend, selectedItemUpdater]);
+  }, [
+    cookiesStatsComponents.legend,
+    isFilterValueSelected,
+    selectedItemUpdater,
+  ]);
 
   return (
     <CookiesLandingWrapper

--- a/packages/report/src/dashboard/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/exemptedCookiesSection.tsx
+++ b/packages/report/src/dashboard/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/exemptedCookiesSection.tsx
@@ -38,11 +38,13 @@ import {
 interface ExemptedCookiesSectionProps {
   tabCookies: TabCookies | null;
   tabFrames: TabFrames | null;
+  isFilterValueSelected: (accessorKey: string, filterValue: string) => boolean;
 }
 
 const ExemptedCookiesSection = ({
   tabCookies,
   tabFrames,
+  isFilterValueSelected,
 }: ExemptedCookiesSectionProps) => {
   const { selectedItemUpdater } = useFiltersMapping(tabFrames || {});
   const cookieStats = useMemo(
@@ -79,6 +81,8 @@ const ExemptedCookiesSection = ({
         onClick: (title: string) => {
           selectedItemUpdater(title, 'exemptionReason', selectTabFrame(title));
         },
+        isSelected: (title: string) =>
+          isFilterValueSelected('exemptionReason', title),
       };
     });
 

--- a/packages/report/src/dashboard/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/landing.tsx
+++ b/packages/report/src/dashboard/components/siteReport/tabs/cookies/cookiesLandingContainer/cookieLanding/landing.tsx
@@ -45,6 +45,7 @@ interface LandingProps {
   libraryMatchesUrlCount?: {
     [url: string]: number;
   };
+  isFilterValueSelected: (accessorKey: string, filterValue: string) => boolean;
 }
 
 const Landing = ({
@@ -54,6 +55,7 @@ const Landing = ({
   downloadReport,
   libraryMatches,
   libraryMatchesUrlCount,
+  isFilterValueSelected,
   menuBarScrollContainerId = 'dashboard-layout-container',
 }: LandingProps) => {
   const sections: Array<CookiesLandingSection> = useMemo(() => {
@@ -66,6 +68,7 @@ const Landing = ({
           props: {
             tabCookies,
             tabFrames,
+            isFilterValueSelected,
           },
         },
       },
@@ -78,6 +81,7 @@ const Landing = ({
             tabCookies,
             cookiesWithIssues,
             tabFrames,
+            isFilterValueSelected,
           },
         },
       },
@@ -104,6 +108,7 @@ const Landing = ({
           props: {
             tabFrames,
             tabCookies,
+            isFilterValueSelected,
           },
         },
       });
@@ -127,6 +132,7 @@ const Landing = ({
     return baseSections;
   }, [
     cookiesWithIssues,
+    isFilterValueSelected,
     libraryMatches,
     libraryMatchesUrlCount,
     tabCookies,

--- a/packages/report/src/dashboard/components/siteReport/tabs/cookies/cookiesLandingContainer/index.tsx
+++ b/packages/report/src/dashboard/components/siteReport/tabs/cookies/cookiesLandingContainer/index.tsx
@@ -164,6 +164,7 @@ const AssembledCookiesLanding = ({
             libraryMatches={libraryMatches}
             libraryMatchesUrlCount={libraryMatchesUrlCount}
             menuBarScrollContainerId={menuBarScrollContainerId}
+            isFilterValueSelected={filterOutput.isFilterValueSelected}
           />
         </div>
       </div>


### PR DESCRIPTION
## Description
This PR adds code to apply styles conditionally to the matrix components when filters are selected.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices
- Expose a new method `isFilterValueSelected` to check whether the value is selected.
- The boolean return then shows the bg color to matrix components.
<!-- Please describe your changes. -->

## Testing Instructions
- Open PSAT's cookie landing page, and select filters.
- The selection should highlight the bg of the matrix component.
- Try the same with the CLI dashboard.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="1270" alt="Screenshot 2024-08-14 at 15 41 40" src="https://github.com/user-attachments/assets/b3575ce7-6094-4fd0-b917-25d4750951f4">
<img width="1271" alt="Screenshot 2024-08-14 at 15 42 12" src="https://github.com/user-attachments/assets/33cdd5be-b367-41d0-a233-a87b28af37ce">

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #800 
