### PR TITLE
Fixing CLI output typo and improve text

### DIFF
--- a/packages/analysis-utils/src/browserManagement/index.ts
+++ b/packages/analysis-utils/src/browserManagement/index.ts
@@ -175,7 +175,7 @@ export class BrowserManagement {
     const page = this.pages[url];
 
     if (!page) {
-      throw new Error('no page with the provided id was found');
+      throw new Error('No page with the provided ID was found');
     }
 
     this.debugLog(`Starting navigation to URL: ${url}`);
@@ -195,7 +195,7 @@ export class BrowserManagement {
     const page = this.pages[url];
 
     if (!page) {
-      throw new Error('no page with the provided id was found');
+      throw new Error('No page with the provided ID was found');
     }
 
     try {
@@ -203,7 +203,7 @@ export class BrowserManagement {
         window.scrollBy(0, 10000);
       });
     } catch (error) {
-      this.debugLog('Scrolled to end of page');
+      this.debugLog('Scrolled to the end of page');
       //ignore
     }
 
@@ -611,7 +611,7 @@ export class BrowserManagement {
     const page = this.pages[url];
 
     if (!page) {
-      throw new Error('no page with the provided id was found');
+      throw new Error('No page with the provided ID was found');
     }
 
     const domQueryMatches: LibraryData = {};

--- a/packages/analysis-utils/src/browserManagement/index.ts
+++ b/packages/analysis-utils/src/browserManagement/index.ts
@@ -105,7 +105,7 @@ export class BrowserManagement {
       headless: this.isHeadless,
       args,
     });
-    this.debugLog('Browser intialized');
+    this.debugLog('Browser initialized');
   }
 
   async clickOnAcceptBanner(url: string) {
@@ -152,7 +152,7 @@ export class BrowserManagement {
 
   async openPage(): Promise<Page> {
     if (!this.browser) {
-      throw new Error('Browser not intialized');
+      throw new Error('Browser not initialized');
     }
     const sitePage = await this.browser.newPage();
 

--- a/packages/analysis-utils/src/browserManagement/index.ts
+++ b/packages/analysis-utils/src/browserManagement/index.ts
@@ -480,10 +480,10 @@ export class BrowserManagement {
     const page = this.pages[pageId];
 
     if (!page) {
-      throw new Error(`no page with the provided id was found:${pageId}`);
+      throw new Error(`No page with the provided ID was found:${pageId}`);
     }
 
-    this.debugLog('Attaching network event listeners to page');
+    this.debugLog('Attaching network event listeners to the page');
 
     const cdpSession = await page.createCDPSession();
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -227,7 +227,7 @@ program.parse();
   const cookieDictionary = await fetchDictionary();
 
   spinnies.add('cookie-spinner', {
-    text: 'Analyzing cookies on first site visit',
+    text: 'Analyzing cookies on the first site visit',
   });
 
   const cookieAnalysisAndFetchedResourceData =
@@ -322,12 +322,12 @@ program.parse();
 })().catch((error) => {
   const spinnies = new Spinnies();
   spinnies.add('error-line-1', {
-    text: 'Some error occured while analyzing the website.',
+    text: 'Some errors occurred while analyzing the website.',
     status: 'non-spinnable',
     color: 'red',
   });
   spinnies.add('error-line-2', {
-    text: 'For more information check the stack trace below:\n',
+    text: 'For more information, check the stack trace below:\n',
     status: 'non-spinnable',
     color: 'red',
   });

--- a/packages/cli/src/utils/validators.ts
+++ b/packages/cli/src/utils/validators.ts
@@ -58,11 +58,11 @@ export function numericValidator(value: string, flag: string) {
     switch (flag) {
       case '-n':
         throw new InvalidArgumentError(
-          "Correct value for option  '-n, --number-of-urls <num>' would be non negative number greater than 0 and less than equal to total number of urls"
+          "The correct value for option  '-n, --number-of-urls <num>' would be a nonnegative number greater than 0 and less than equal to the total number of URLs"
         );
       case '-c':
         throw new InvalidArgumentError(
-          "Correct value for option '-c, --concurrency <num>' would be non negative number greater than 0 and less than equal to total number of urls"
+          "The correct value for option '-c, --concurrency <num>' would be a nonnegative number greater than 0 and less than equal to the total number of URLs"
         );
       case '-w':
         throw new InvalidArgumentError(
@@ -75,7 +75,7 @@ export function numericValidator(value: string, flag: string) {
 
   const parsedValue = parseInt(value);
   if (isNaN(parsedValue)) {
-    redLogger(`Error: ${value} is not valid numeric value.`);
+    redLogger(`Error: ${value} is not a valid numeric value.`);
   }
   return parsedValue;
 }
@@ -148,15 +148,15 @@ export function urlValidator(url: string, flag: string) {
     switch (flag) {
       case '[website-url]':
         throw new InvalidArgumentError(
-          'Correct value for command-argument would be https://example.com'
+          'The correct value for the command-argument would be https://example.com'
         );
       case '-u':
         throw new InvalidArgumentError(
-          "Correct value for option '-u, --url <url>' would be https://example.com"
+          "The correct value for option '-u, --url <url>' would be https://example.com"
         );
       case '-s':
         throw new InvalidArgumentError(
-          "Correct value for option '-s, --source-url <url>' would be https://gagan.pro/sitemap/toypta.xml or https://sitemap.superintegratedapp.com/sitemaps/sitemap.csv"
+          "The correct value for option '-s, --source-url <url>' would be https://example.com/sitemap/sitemap.xml or https://example.com/sitemaps/sitemap.csv"
         );
       default:
         throw new InvalidArgumentError('');
@@ -182,7 +182,7 @@ export function outDirValidator(outDir: string, flag: string) {
     switch (flag) {
       case '-o':
         throw new InvalidArgumentError(
-          "Correct value for option '-o, --out-dir <path>' would be /users/path/to/save/output"
+          "The correct value for option '-o, --out-dir <path>' would be /users/path/to/save/output"
         );
       default:
         throw new InvalidArgumentError('');

--- a/packages/extension/src/view/devtools/test-utils/puppeteerManagement.ts
+++ b/packages/extension/src/view/devtools/test-utils/puppeteerManagement.ts
@@ -100,11 +100,11 @@ export class PuppeteerManagement {
       return t.type() === 'other' && t.url().startsWith('devtools://');
     });
     if (!devtoolsTargets) {
-      throw new Error('Devtools targets not found.');
+      throw new Error('DevTools targets not found.');
     }
     const devtools = await devtoolsTargets.page();
     if (!devtools) {
-      throw new Error('Devtools not found.');
+      throw new Error('DevTools not found.');
     }
 
     return devtools;

--- a/packages/extension/src/view/devtools/test-utils/puppeteerManagement.ts
+++ b/packages/extension/src/view/devtools/test-utils/puppeteerManagement.ts
@@ -73,7 +73,7 @@ export class PuppeteerManagement {
 
   async openPage(): Promise<Page> {
     if (!this.browser) {
-      throw new Error('Browser not intialized');
+      throw new Error('Browser not initialized');
     }
     const sitePage = await this.browser.newPage();
     const pages = await this.browser.pages();


### PR DESCRIPTION
## Description

This pull request corrects some sentences on the output messages from the CLI and improves some sentences to make them clear

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

1. Open the CLI on the terminal 
2. Run a audit with verbose mode `$ psat https://example.com -v`
3. Check the output messages

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [ ] I have thoroughly tested this code to the best of my abilities.
- [ ] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #807
