### PR TITLE
Add "ok" for gdpr consent button lookup.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24769,7 +24769,7 @@
 		},
 		"packages/analysis-utils": {
 			"name": "@google-psat/analysis-utils",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",
@@ -24796,7 +24796,7 @@
 		},
 		"packages/cli": {
 			"name": "@google-psat/cli",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/analysis-utils": "*",
@@ -24828,7 +24828,7 @@
 		},
 		"packages/cli-dashboard": {
 			"name": "@google-psat/cli-dashboard",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",
@@ -24889,7 +24889,7 @@
 		},
 		"packages/common": {
 			"name": "@google-psat/common",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/i18n": "*",
@@ -24906,7 +24906,7 @@
 		},
 		"packages/design-system": {
 			"name": "@google-psat/design-system",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",
@@ -24924,7 +24924,7 @@
 		},
 		"packages/eslint-import-resolver": {
 			"name": "@google-psat/eslint-import-resolver",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eslint-import-resolver-node": "^0.3.7"
@@ -24972,7 +24972,7 @@
 		},
 		"packages/i18n": {
 			"name": "@google-psat/i18n",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"intl-messageformat": "^10.5.11"
@@ -24980,7 +24980,7 @@
 		},
 		"packages/library-detection": {
 			"name": "@google-psat/library-detection",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",
@@ -25005,7 +25005,7 @@
 		},
 		"packages/report": {
 			"name": "@google-psat/report",
-			"version": "0.10.1",
+			"version": "0.10.1-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",

--- a/packages/analysis-utils/src/browserManagement/index.ts
+++ b/packages/analysis-utils/src/browserManagement/index.ts
@@ -138,6 +138,7 @@ export class BrowserManagement {
               cnode.textContent &&
               (cnode.textContent.toLowerCase().includes('accept') ||
                 cnode.textContent.toLowerCase().includes('allow') ||
+                cnode.textContent.toLowerCase().includes('ok') ||
                 cnode.textContent.toLowerCase().includes('agree'))
           );
 


### PR DESCRIPTION
## Description

Imrprove the consent acceptance quality.

## Relevant Technical Choices

Added the as additional consent acceptance the term "ok" .

## Testing Instructions

Test with [otto.de](http://otto.de/) and [manufactum.com](https://www.manufactum.com/) website where it requires to click "ok" to accept the cookie consent.


## Additional Information:

The test with local environment ```npm run cli -- --display https://www.manufactum.com``` displayed that the button "ok" being successfully clicked. 

## Screenshot/Screencast



---

## Checklist

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

We have tried to run the test locally with command  npm run test:cli:e2e
but we got following errors and could not complete.

CLI E2E Test
    ✕ Should run site analysis (8537 ms)

  ● CLI E2E Test › Should run site analysis

    assert.strictEqual(received, expected)

    Expected value to strictly be equal to:
      true
    Received:
      false
   
    Message:
      should match stdout expected includes /out/bbc-com/report_(String) but actual (String)

Fixes #

