### PR TITLE
Refactor: Update order of PAT Section components

### DIFF
--- a/packages/design-system/src/components/sidebar/useSidebar/constants.ts
+++ b/packages/design-system/src/components/sidebar/useSidebar/constants.ts
@@ -24,7 +24,7 @@ export enum SIDEBAR_ITEMS_KEYS {
   RELATED_WEBSITE_SETS = 'related-website-sets',
   PRIVATE_ADVERTISING = 'private-advertising',
   TOPICS = 'topics',
-  ATTRIBUTION = 'attribution-reporting',
+  ATTRIBUTION_REPORTING = 'attribution-reporting',
   PROTECTED_AUDIENCE = 'protected-audience',
   PRIVATE_AGGREGATION = 'private-aggregation',
   ANTI_COVERT_TRACKING = 'anti-covert-tracking',

--- a/packages/design-system/src/components/sidebar/useSidebar/constants.ts
+++ b/packages/design-system/src/components/sidebar/useSidebar/constants.ts
@@ -24,7 +24,7 @@ export enum SIDEBAR_ITEMS_KEYS {
   RELATED_WEBSITE_SETS = 'related-website-sets',
   PRIVATE_ADVERTISING = 'private-advertising',
   TOPICS = 'topics',
-  ATTRIBUTION = 'attribution',
+  ATTRIBUTION = 'attribution-reporting',
   PROTECTED_AUDIENCE = 'protected-audience',
   PRIVATE_AGGREGATION = 'private-aggregation',
   ANTI_COVERT_TRACKING = 'anti-covert-tracking',

--- a/packages/extension/src/view/devtools/components/privateAdvertising/privateAdvertising.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/privateAdvertising.tsx
@@ -23,6 +23,11 @@ import { I18n } from '@google-psat/i18n';
 
 const content = [
   {
+    title: () => I18n.getMessage('topics'),
+    description: () => I18n.getMessage('topicsDescription'),
+    url: 'https://developers.google.com/privacy-sandbox/relevance/topics',
+  },
+  {
     title: () => I18n.getMessage('protectedAudience'),
     description: () => I18n.getMessage('protectedAudienceDescription'),
     url: 'https://developers.google.com/privacy-sandbox/relevance/protected-audience',
@@ -36,11 +41,6 @@ const content = [
     title: () => I18n.getMessage('privateAggregation'),
     description: () => I18n.getMessage('privateAggregationDescription'),
     url: 'https://developers.google.com/privacy-sandbox/relevance/private-aggregation',
-  },
-  {
-    title: () => I18n.getMessage('topics'),
-    description: () => I18n.getMessage('topicsDescription'),
-    url: 'https://developers.google.com/privacy-sandbox/relevance/topics',
   },
 ];
 

--- a/packages/extension/src/view/devtools/tabs.ts
+++ b/packages/extension/src/view/devtools/tabs.ts
@@ -164,19 +164,6 @@ const TABS: SidebarItems = {
             },
             children: {},
           },
-          [SIDEBAR_ITEMS_KEYS.ATTRIBUTION]: {
-            title: () => I18n.getMessage('attribution'),
-            panel: {
-              Element: Attribution,
-            },
-            icon: {
-              Element: AttributionIcon,
-            },
-            selectedIcon: {
-              Element: AttributionIconWhite,
-            },
-            children: {},
-          },
           [SIDEBAR_ITEMS_KEYS.PROTECTED_AUDIENCE]: {
             title: 'Protected Audience',
             panel: {
@@ -193,6 +180,19 @@ const TABS: SidebarItems = {
               props: {
                 className: 'fill-white',
               },
+            },
+            children: {},
+          },
+          [SIDEBAR_ITEMS_KEYS.ATTRIBUTION]: {
+            title: () => I18n.getMessage('attribution'),
+            panel: {
+              Element: Attribution,
+            },
+            icon: {
+              Element: AttributionIcon,
+            },
+            selectedIcon: {
+              Element: AttributionIconWhite,
             },
             children: {},
           },

--- a/packages/extension/src/view/devtools/tabs.ts
+++ b/packages/extension/src/view/devtools/tabs.ts
@@ -184,7 +184,7 @@ const TABS: SidebarItems = {
             children: {},
           },
           [SIDEBAR_ITEMS_KEYS.ATTRIBUTION]: {
-            title: () => I18n.getMessage('attribution'),
+            title: () => I18n.getMessage('attributionReporting'),
             panel: {
               Element: Attribution,
             },

--- a/packages/extension/src/view/devtools/tabs.ts
+++ b/packages/extension/src/view/devtools/tabs.ts
@@ -183,7 +183,7 @@ const TABS: SidebarItems = {
             },
             children: {},
           },
-          [SIDEBAR_ITEMS_KEYS.ATTRIBUTION]: {
+          [SIDEBAR_ITEMS_KEYS.ATTRIBUTION_REPORTING]: {
             title: () => I18n.getMessage('attributionReporting'),
             panel: {
               Element: Attribution,


### PR DESCRIPTION
## Description
This PR aims to reorder the items in the sidebar.

## Relevant Technical Choices


## Testing Instructions
- Clone the branch.
- In the terminal run `npm i` and then run `npm run build:ext`.
- You should see the order in PAT section as follows:
1. Topics
2. Protected Audience
3. Attribution Reporting
4. Private Aggregation

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #824 
