### PR TITLE
Feature: Add breadcrumbs to landing pages

### DIFF
--- a/packages/design-system/src/components/breadcrumbs/index.tsx
+++ b/packages/design-system/src/components/breadcrumbs/index.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies.
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies.
+ */
+import { useSidebar } from '../sidebar';
+import { ChevronRight } from '../../icons';
+
+interface BreadcrumbsProps {
+  items: Array<{
+    title: string;
+    key: string;
+  }>;
+}
+
+const Breadcrumbs = ({ items }: BreadcrumbsProps) => {
+  const updateSelectedItemKey = useSidebar(
+    ({ actions }) => actions.updateSelectedItemKey
+  );
+
+  return (
+    <div className={classNames('w-full flex items-center h-fit')}>
+      <div className="flex items-center">
+        {items.map((item, index) => (
+          <div
+            key={item.key}
+            onClick={() => updateSelectedItemKey(item.key)}
+            className={classNames(
+              'cursor-pointer hover:text-blue-500 hover:dark:text-blue-400 active:opacity-70 text-xs flex items-center text-raisin-black dark:text-bright-gray',
+              {
+                'font-bold': index === items.length - 1,
+              }
+            )}
+          >
+            {item.title}
+            {index < items.length - 1 && (
+              <span className="mx-2">
+                <ChevronRight className="w-3 h-3" />
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Breadcrumbs;

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -54,3 +54,4 @@ export { default as useFiltersMapping } from './cookiesLanding/useFiltersMapping
 export { default as useGlobalFiltering } from './cookiesLanding/useGlobalFiltering';
 export { default as Tabs } from './tabs';
 export { default as QuickLinksList } from './landingPage/quickLinksList';
+export { default as Breadcrumbs } from './breadcrumbs';

--- a/packages/design-system/src/components/landingPage/index.tsx
+++ b/packages/design-system/src/components/landingPage/index.tsx
@@ -28,6 +28,8 @@ import ProgressBar from '../progressBar';
 import QuickLinksList from './quickLinksList';
 import { PSInfoKeyType } from './infoCard/fetchPSInfo';
 import InfoCard from './infoCard';
+import Breadcrumbs from '../breadcrumbs';
+import { useSidebar } from '../sidebar';
 
 interface LandingPageProps {
   title?: string;
@@ -50,6 +52,9 @@ const LandingPage = ({
 }: LandingPageProps) => {
   const [loading, setLoading] = useState(iframeSrc ? true : false);
   const [open, setOpen] = useState(true);
+  const { extractSelectedItemKeyTitles } = useSidebar(({ actions }) => ({
+    extractSelectedItemKeyTitles: actions.extractSelectedItemKeyTitles,
+  }));
 
   return (
     <div className="overflow-auto h-full">
@@ -60,7 +65,7 @@ const LandingPage = ({
           'divide-y divide-hex-gray dark:divide-quartz'
         )}
       >
-        <div className="p-4">
+        <div className="p-4 flex flex-col gap-1">
           <button
             className="flex gap-2 text-2xl font-bold items-baseline text-raisin-black dark:text-bright-gray cursor-pointer"
             onClick={() => setOpen((prevOpen) => !prevOpen)}
@@ -72,6 +77,7 @@ const LandingPage = ({
               />
             </div>
           </button>
+          <Breadcrumbs items={extractSelectedItemKeyTitles()} />
         </div>
         <div className={classNames({ hidden: !open && !children })}>
           <div

--- a/packages/design-system/src/components/sidebar/useSidebar/context.ts
+++ b/packages/design-system/src/components/sidebar/useSidebar/context.ts
@@ -50,7 +50,7 @@ export interface SidebarStoreContext {
     isKeyAncestor: (key: string) => boolean;
     isKeySelected: (key: string) => boolean;
     toggleSidebarCollapse: () => void;
-    extractSelectedItemKeyTitles: () => string[];
+    extractSelectedItemKeyTitles: () => Array<{ title: string; key: string }>;
   };
 }
 

--- a/packages/design-system/src/components/sidebar/useSidebar/context.ts
+++ b/packages/design-system/src/components/sidebar/useSidebar/context.ts
@@ -50,6 +50,7 @@ export interface SidebarStoreContext {
     isKeyAncestor: (key: string) => boolean;
     isKeySelected: (key: string) => boolean;
     toggleSidebarCollapse: () => void;
+    extractSelectedItemKeyTitles: () => string[];
   };
 }
 

--- a/packages/design-system/src/components/sidebar/useSidebar/provider.tsx
+++ b/packages/design-system/src/components/sidebar/useSidebar/provider.tsx
@@ -269,7 +269,7 @@ export const SidebarProvider = ({
    * Extract the titles of the selected item key chain.
    * Eg: selectedItemKey = 'Privacy-Sandbox#cookies#frameUrl'
    * extractSelectedItemKeyTitles() => ['Privacy Sandbox', 'Cookies', 'Frame URL']
-   * @returns string[]
+   * @returns Array<{title: string, key: string}>
    */
   const extractSelectedItemKeyTitles = useCallback(() => {
     if (!selectedItemKey) {
@@ -278,7 +278,7 @@ export const SidebarProvider = ({
 
     let _sidebarItems = sidebarItems;
     const keys = selectedItemKey.split('#');
-    const titles: string[] = [];
+    const titles: Array<{ title: string; key: string }> = [];
 
     for (const key of keys) {
       const sidebarItem = _sidebarItems?.[key];
@@ -287,11 +287,13 @@ export const SidebarProvider = ({
         break;
       }
 
-      titles.push(
-        typeof sidebarItem.title === 'function'
-          ? sidebarItem.title()
-          : sidebarItem.title
-      );
+      titles.push({
+        title:
+          typeof sidebarItem.title === 'function'
+            ? sidebarItem.title()
+            : sidebarItem.title,
+        key,
+      });
 
       _sidebarItems = sidebarItem.children;
     }

--- a/packages/design-system/src/components/sidebar/useSidebar/provider.tsx
+++ b/packages/design-system/src/components/sidebar/useSidebar/provider.tsx
@@ -265,6 +265,40 @@ export const SidebarProvider = ({
     setIsCollapsed((prev) => !prev);
   }, []);
 
+  /**
+   * Extract the titles of the selected item key chain.
+   * Eg: selectedItemKey = 'Privacy-Sandbox#cookies#frameUrl'
+   * extractSelectedItemKeyTitles() => ['Privacy Sandbox', 'Cookies', 'Frame URL']
+   * @returns string[]
+   */
+  const extractSelectedItemKeyTitles = useCallback(() => {
+    if (!selectedItemKey) {
+      return [];
+    }
+
+    let _sidebarItems = sidebarItems;
+    const keys = selectedItemKey.split('#');
+    const titles: string[] = [];
+
+    for (const key of keys) {
+      const sidebarItem = _sidebarItems?.[key];
+
+      if (!sidebarItem) {
+        break;
+      }
+
+      titles.push(
+        typeof sidebarItem.title === 'function'
+          ? sidebarItem.title()
+          : sidebarItem.title
+      );
+
+      _sidebarItems = sidebarItem.children;
+    }
+
+    return titles;
+  }, [selectedItemKey, sidebarItems]);
+
   return (
     <SidebarContext.Provider
       value={{
@@ -286,6 +320,7 @@ export const SidebarProvider = ({
           isKeyAncestor,
           isKeySelected,
           toggleSidebarCollapse,
+          extractSelectedItemKeyTitles,
         },
       }}
     >

--- a/packages/extension/src/view/devtools/components/layout.tsx
+++ b/packages/extension/src/view/devtools/components/layout.tsx
@@ -31,6 +31,7 @@ import {
 } from '@google-psat/design-system';
 import { Resizable } from 're-resizable';
 import { I18n } from '@google-psat/i18n';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies.
@@ -225,20 +226,28 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
     }
   }, [isCollapsed]);
 
+  const [allowTransition, setAllowTransition] = useState(true);
+
   return (
     <div className="w-full h-full flex flex-row z-1">
       <Resizable
         size={{ width: sidebarWidth, height: '100%' }}
         defaultSize={{ width: '200px', height: '100%' }}
+        onResizeStart={() => {
+          setAllowTransition(false);
+        }}
         onResizeStop={(_, __, ___, d) => {
           setSidebarWidth((prevState) => prevState + d.width);
+          setAllowTransition(true);
         }}
         minWidth={isCollapsed ? 40 : 160}
         maxWidth={'90%'}
         enable={{
           right: !isCollapsed,
         }}
-        className="h-full transition-all duration-300"
+        className={classNames('h-full', {
+          'transition-all duration-300': allowTransition,
+        })}
       >
         <Sidebar visibleWidth={sidebarWidth} />
       </Resizable>

--- a/packages/extension/src/view/devtools/components/siteBoundaries/relatedWebsiteSets/index.tsx
+++ b/packages/extension/src/view/devtools/components/siteBoundaries/relatedWebsiteSets/index.tsx
@@ -18,10 +18,12 @@
  */
 import React, { useMemo } from 'react';
 import {
+  Breadcrumbs,
   InfoCard,
   PSInfoKey,
   QuickLinksList,
   Tabs,
+  useSidebar,
 } from '@google-psat/design-system';
 import { I18n } from '@google-psat/i18n';
 
@@ -32,6 +34,10 @@ import RWSJsonGenerator from './jsonGenerator';
 import Insights from './insights';
 
 const RelatedWebsiteSets = () => {
+  const { extractSelectedItemKeyTitles } = useSidebar(({ actions }) => ({
+    extractSelectedItemKeyTitles: actions.extractSelectedItemKeyTitles,
+  }));
+
   const tabItems = useMemo(
     () => [
       {
@@ -61,10 +67,11 @@ const RelatedWebsiteSets = () => {
 
   return (
     <div data-testid="related-website-sets-content" className="h-full w-full">
-      <div className="p-4">
+      <div className="p-4 flex flex-col gap-1 mb-2">
         <div className="flex gap-2 text-2xl font-bold items-baseline text-raisin-black dark:text-bright-gray">
           <h1 className="text-left">{I18n.getMessage('rws')}</h1>
         </div>
+        <Breadcrumbs items={extractSelectedItemKeyTitles()} />
       </div>
       <Tabs items={tabItems} />
       <div className="mt-8 border-t border-gray-300 dark:border-quartz">


### PR DESCRIPTION
## Description
This PR adds a component for rendering breadcrumbs.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices
- `useSidebar` returns a new callback `extractSidebarItemKeyTitles` to output an array of an object containing the title and key.
- Array<{title: string, key: string}>
<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [ ] I have thoroughly tested this code to the best of my abilities.
- [ ] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
