### PR TITLE
Feature: Include individual site summaries in the aggregated report of a sitemap

### DIFF
--- a/packages/common/src/utils/generateReports/generateRootSummaryDataCSV.ts
+++ b/packages/common/src/utils/generateReports/generateRootSummaryDataCSV.ts
@@ -132,6 +132,7 @@ export const generateRootSummaryDataCSV = (
     'Functional Cookies',
     'Marketing Cookies',
     'Uncategorised Cookies',
+    'Total Cookies With Issues',
     'Analytics Cookies With Cookies',
     'Functional Cookies With Cookies',
     'Marketing Cookies With Cookies',

--- a/packages/common/src/utils/generateReports/generateRootSummaryDataCSV.ts
+++ b/packages/common/src/utils/generateReports/generateRootSummaryDataCSV.ts
@@ -133,17 +133,13 @@ export const generateRootSummaryDataCSV = (
     'Marketing Cookies',
     'Uncategorised Cookies',
     'Total Cookies With Issues',
-    'Analytics Cookies With Cookies',
-    'Functional Cookies With Cookies',
-    'Marketing Cookies With Cookies',
-    'Uncategorised Cookies With Cookies',
+    'Analytics Cookies With Issues',
+    'Functional Cookies With Issues',
+    'Marketing Cookies With Issues',
+    'Uncategorised Cookies With Issues',
   ];
 
   let csvData = headers.join(',').concat('\r\n');
-
-  csvData = csvData
-    .concat('Aggregated,')
-    .concat(calculateCSVData(extractedData));
 
   siteMapAnalysisData.forEach((singleSiteData) => {
     const urlCookies = reshapeCookies(
@@ -154,6 +150,10 @@ export const generateRootSummaryDataCSV = (
       .concat(`${singleSiteData.pageUrl},`)
       .concat(calculateCSVData(urlCookies));
   });
+
+  csvData = csvData
+    .concat('Aggregated,')
+    .concat(calculateCSVData(extractedData));
 
   return csvData;
 };

--- a/packages/common/src/utils/generateReports/generateRootSummaryDataCSV.ts
+++ b/packages/common/src/utils/generateReports/generateRootSummaryDataCSV.ts
@@ -124,7 +124,7 @@ export const generateRootSummaryDataCSV = (
     extractReportData(siteMapAnalysisData).landingPageCookies
   );
   const headers = [
-    'URL Heading',
+    'URL',
     'Total Cookies',
     'First Party Cookies',
     'Third Party Cookies',

--- a/packages/common/src/utils/generateReports/generateRootSummaryDataCSV.ts
+++ b/packages/common/src/utils/generateReports/generateRootSummaryDataCSV.ts
@@ -14,23 +14,16 @@
  * limitations under the License.
  */
 /**
- * External dependencies.
- */
-import { I18n } from '@google-psat/i18n';
-/**
  * Internal dependencies
  */
 import type { CompleteJson, CookieTableData } from '../../cookies.types';
 import extractReportData from '../extractReportData';
 import reshapeCookies from '../reshapeCookies';
+import extractCookies from '../extractCookies';
 
-const generateRootSummaryDataCSV = (
-  siteMapAnalysisData: CompleteJson[]
-): string => {
-  const extractedData: { [key: string]: CookieTableData } = reshapeCookies(
-    extractReportData(siteMapAnalysisData).landingPageCookies
-  );
-
+const calculateCSVData = (cookies: {
+  [key: string]: CookieTableData;
+}): string => {
   let totalFirstPartyCookies = 0;
   let totalThirdPartyCookies = 0;
   let analyticsCookies = 0;
@@ -45,8 +38,8 @@ const generateRootSummaryDataCSV = (
   let totalCookies = 0;
 
   // eslint-disable-next-line complexity
-  Object.keys(extractedData).forEach((cookieKey) => {
-    const cookie = extractedData[cookieKey];
+  Object.keys(cookies).forEach((cookieKey) => {
+    const cookie = cookies[cookieKey];
 
     if (!cookie.analytics) {
       return;
@@ -107,27 +100,61 @@ const generateRootSummaryDataCSV = (
     totalCookies += 1;
   });
 
-  const summary = {
-    [I18n.getMessage('totalCookies')]: totalCookies,
-    [I18n.getMessage('totalFirstPartyCookies')]: totalFirstPartyCookies,
-    [I18n.getMessage('totalThirdPartyCookies')]: totalThirdPartyCookies,
-    [I18n.getMessage('analyticsCookies')]: analyticsCookies,
-    [I18n.getMessage('functionalCookies')]: functionalCookies,
-    [I18n.getMessage('marketingCookies')]: marketingCookies,
-    [I18n.getMessage('uncategorizedCookies')]: uncategorisedCookies,
-    [I18n.getMessage('cookiesWithIssues')]: cookiesWithIssues,
-    [I18n.getMessage('analyticsCookiesWithIssues')]: analyticsCookiesWithIssues,
-    [I18n.getMessage('functionalCookiesWithIssues')]:
-      functionalCookiesWithIssues,
-    [I18n.getMessage('marketingCookiesWithIssues')]: marketingCookiesWithIssues,
-    [I18n.getMessage('uncategorizedCookiesWithIssues')]:
-      uncategorisedCookiesWithIssues,
-  };
+  const summary = [
+    totalCookies,
+    totalFirstPartyCookies,
+    totalThirdPartyCookies,
+    analyticsCookies,
+    functionalCookies,
+    marketingCookies,
+    uncategorisedCookies,
+    cookiesWithIssues,
+    analyticsCookiesWithIssues,
+    functionalCookiesWithIssues,
+    marketingCookiesWithIssues,
+    uncategorisedCookiesWithIssues,
+  ];
 
-  return Object.entries(summary)
-    .map(([key, value]) => `${key}, ${value}`)
-    .join('\r\n')
-    .concat('\r\n');
+  return summary.join(',').concat('\r\n');
+};
+export const generateRootSummaryDataCSV = (
+  siteMapAnalysisData: CompleteJson[]
+) => {
+  const extractedData: { [key: string]: CookieTableData } = reshapeCookies(
+    extractReportData(siteMapAnalysisData).landingPageCookies
+  );
+  const headers = [
+    'URL Heading',
+    'Total Cookies',
+    'First Party Cookies',
+    'Third Party Cookies',
+    'Analytics Cookies',
+    'Functional Cookies',
+    'Marketing Cookies',
+    'Uncategorised Cookies',
+    'Analytics Cookies With Cookies',
+    'Functional Cookies With Cookies',
+    'Marketing Cookies With Cookies',
+    'Uncategorised Cookies With Cookies',
+  ];
+
+  let csvData = headers.join(',').concat('\r\n');
+
+  csvData = csvData
+    .concat('Aggregated,')
+    .concat(calculateCSVData(extractedData));
+
+  siteMapAnalysisData.forEach((singleSiteData) => {
+    const urlCookies = reshapeCookies(
+      extractCookies(singleSiteData.cookieData, '', false)
+    );
+
+    csvData = csvData
+      .concat(`${singleSiteData.pageUrl},`)
+      .concat(calculateCSVData(urlCookies));
+  });
+
+  return csvData;
 };
 
 export default generateRootSummaryDataCSV;


### PR DESCRIPTION
## Description
The PR aims to modify the generated CSV for a sitemap, where the count for each URL is provided along with the aggregated counts.

## Testing Instructions
- Clone this PR.
- In the terminal run `npm i` && `npm run build:cli`.
- Now run analysis on a sitemap with `-o` or download the zip from the CLI-dashboard.

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #850 
