### PR TITLE
Feature: Bridge PA data to UI panels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18846,6 +18846,11 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/pretty-print-json": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/pretty-print-json/-/pretty-print-json-3.0.2.tgz",
+			"integrity": "sha512-5XMO9I6LgOJVCxQikNgf9yAkXd6VqVb6Xeus+qonJW7fQ7wbkap/TWWwz67iikQSnkMhgR++S36asRn+NN876A=="
+		},
 		"node_modules/pretty-time": {
 			"version": "1.1.0",
 			"dev": true,
@@ -24212,6 +24217,7 @@
 				"marked-alert": "^2.0.2",
 				"mermaid": "^11.2.0",
 				"p-queue": "^7.3.4",
+				"pretty-print-json": "^3.0.2",
 				"re-resizable": "^6.9.9",
 				"react": "^18.2.0",
 				"react-copy-to-clipboard": "^5.1.0",

--- a/packages/common/src/protectedAudience.types.ts
+++ b/packages/common/src/protectedAudience.types.ts
@@ -75,6 +75,9 @@ export type AdsAndBiddersType = {
     adUnitCode: string;
     bidders: string[];
     mediaContainerSize: number[][];
+    winningBid: number;
+    bidCurrency: string;
+    winningBidder: string;
   };
 };
 

--- a/packages/design-system/src/components/pill/index.tsx
+++ b/packages/design-system/src/components/pill/index.tsx
@@ -25,7 +25,7 @@ interface PillProps {
 
 const Pill = ({ title }: PillProps) => {
   return (
-    <div className="h-5 p-2 text-raisin-black dark:text-bright-gray border border-gray-300 dark:border-quartz rounded-full">
+    <div className="h-fit p-1 dark:text-bright-gray border border-gray-400 dark:border-dark-gray-x11 rounded-full">
       {title}
     </div>
   );

--- a/packages/design-system/src/components/table/components/index.tsx
+++ b/packages/design-system/src/components/table/components/index.tsx
@@ -38,6 +38,7 @@ interface TableProps {
   extraInterfaceToTopBar?: () => React.JSX.Element;
   minWidth?: string;
   hideSearch?: boolean;
+  rowHeightClass?: string;
 }
 
 const Table = ({
@@ -47,6 +48,7 @@ const Table = ({
   extraInterfaceToTopBar,
   minWidth,
   hideSearch,
+  rowHeightClass,
 }: TableProps) => {
   const {
     tableContainerRef,
@@ -122,7 +124,7 @@ const Table = ({
         extraInterface={extraInterfaceToTopBar}
         hideSearch={hideSearch}
       />
-      {!hideFiltering && (
+      {hideFiltering ? null : (
         <ChipsBar
           selectedFilters={selectedFilters}
           resetFilters={resetFilters}
@@ -137,6 +139,7 @@ const Table = ({
             enable={{
               right: true,
             }}
+            className="overflow-auto h-full"
           >
             <FiltersSidebar
               filters={filters}
@@ -171,6 +174,7 @@ const Table = ({
               isRowFocused={isRowFocused}
               setIsRowFocused={setIsRowFocused}
               selectedKey={selectedKey}
+              rowHeightClass={rowHeightClass}
             />
           </div>
         </div>

--- a/packages/design-system/src/components/table/components/tableBody/bodyCell.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/bodyCell.tsx
@@ -36,6 +36,7 @@ interface BodyCellProps {
     Element: (props: any) => React.JSX.Element;
   };
   onRowClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+  rowHeightClass?: string;
 }
 
 const BodyCell = ({
@@ -47,6 +48,7 @@ const BodyCell = ({
   showIcon = false,
   icon,
   isHighlighted = false,
+  rowHeightClass,
 }: BodyCellProps) => {
   const IconElement = icon?.Element;
   const cellValue = cell?.() ?? '';
@@ -68,13 +70,13 @@ const BodyCell = ({
           e.stopPropagation();
         }
       }}
-      className={`flex box-border outline-0 px-1 py-px h-5 text-xs ${
+      className={`flex box-border outline-0 px-1 py-px text-xs ${
         isHighlighted
           ? `${
               isRowFocused ? 'text-white' : 'dark:text-dirty-red text-dirty-red'
             }`
           : 'dark:text-bright-gray'
-      } cursor-default flex-1`}
+      } cursor-default flex-1 ${rowHeightClass ?? 'h-5'}`}
     >
       {hasIcon && (
         <div className="h-full grid place-items-center min-w-[15px] pr-1">

--- a/packages/design-system/src/components/table/components/tableBody/bodyRow.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/bodyRow.tsx
@@ -41,6 +41,7 @@ interface BodyRowProps {
     e: React.MouseEvent<HTMLDivElement>,
     row: TableRow
   ) => void;
+  rowHeightClass?: string;
 }
 
 const BodyRow = ({
@@ -55,6 +56,7 @@ const BodyRow = ({
   onRowClick,
   onKeyDown,
   onRowContextMenu,
+  rowHeightClass,
 }: BodyRowProps) => {
   const rowKey = getRowObjectKey(row);
   const isHighlighted = row.originalData?.highlighted;
@@ -123,6 +125,7 @@ const BodyRow = ({
               showBodyCellPrefixIcon ? showBodyCellPrefixIcon(row) : false
             }
             icon={bodyCellPrefixIcon ?? undefined}
+            rowHeightClass={rowHeightClass}
           />
         )
       )}

--- a/packages/design-system/src/components/table/components/tableBody/index.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/index.tsx
@@ -30,12 +30,14 @@ interface TableBodyProps {
   isRowFocused: boolean;
   setIsRowFocused: (state: boolean) => void;
   selectedKey: string | undefined | null;
+  rowHeightClass?: string;
 }
 
 const TableBody = ({
   isRowFocused,
   setIsRowFocused,
   selectedKey,
+  rowHeightClass,
 }: TableBodyProps) => {
   const {
     rows,
@@ -125,7 +127,8 @@ const TableBody = ({
   );
 
   const tableRowClassName = classNames(
-    'h-5 outline-0 flex divide-x divide-american-silver dark:divide-quartz',
+    'outline-0 flex divide-x divide-american-silver dark:divide-quartz',
+    rowHeightClass ?? 'h-5',
     selectedKey === null &&
       (isRowFocused
         ? 'bg-gainsboro dark:bg-outer-space'
@@ -163,6 +166,7 @@ const TableBody = ({
           }}
           onKeyDown={handleKeyDown}
           onRowContextMenu={onRowContextMenu}
+          rowHeightClass={rowHeightClass}
         />
       ))}
       <div

--- a/packages/design-system/src/components/table/useTable/types.ts
+++ b/packages/design-system/src/components/table/useTable/types.ts
@@ -16,9 +16,23 @@
 /**
  * External dependencies.
  */
-import type { CookieTableData, ErroredOutUrlsData } from '@google-psat/common';
+import type {
+  AdsAndBiddersType,
+  CookieTableData,
+  InterestGroups,
+  NoBidsType,
+  singleAuctionEvent,
+  ErroredOutUrlsData,
+} from '@google-psat/common';
 
-export type TableData = (CookieTableData | ErroredOutUrlsData) & {
+export type TableData = (
+  | CookieTableData
+  | InterestGroups
+  | singleAuctionEvent
+  | NoBidsType[keyof NoBidsType]
+  | AdsAndBiddersType[keyof AdsAndBiddersType]
+  | ErroredOutUrlsData
+) & {
   highlighted?: boolean;
 };
 

--- a/packages/design-system/src/components/table/useTable/useColumnResizing/index.tsx
+++ b/packages/design-system/src/components/table/useTable/useColumnResizing/index.tsx
@@ -202,10 +202,6 @@ const useColumnResizing = (
         );
       }
     }
-
-    return () => {
-      setColumns([]);
-    };
   }, [getPreferences, setColumnsCallback, tablePersistentSettingsKey]);
 
   useEffect(() => {

--- a/packages/design-system/src/components/table/useTable/useColumnSorting/index.tsx
+++ b/packages/design-system/src/components/table/useTable/useColumnSorting/index.tsx
@@ -74,8 +74,8 @@ const useColumnSorting = (
     )?.sortingComparator;
 
     const _sortedData = [...data].sort((a, b) => {
-      let candidateA = getValueByKey(sortKey, a);
-      let candidateB = getValueByKey(sortKey, b);
+      let candidateA = getValueByKey(sortKey, a) ?? '';
+      let candidateB = getValueByKey(sortKey, b) ?? '';
 
       if (sortingComparator) {
         return sortingComparator(candidateA, candidateB) * (ascending ? 1 : -1);

--- a/packages/design-system/src/components/tabs/index.tsx
+++ b/packages/design-system/src/components/tabs/index.tsx
@@ -69,7 +69,7 @@ const Tabs = ({ items, activeTab, setActiveTab }: TabsProps) => {
             onClick={() => setActiveTab(index)}
             onKeyDown={handleKeyDown}
             className={classNames(
-              'pb-1.5 px-3 border-b-2 hover:opacity-80 outline-none text-sm',
+              'pb-1.5 px-1.5 border-b-2 hover:opacity-80 outline-none text-sm text-nowrap',
               {
                 'border-bright-navy-blue dark:border-jordy-blue text-bright-navy-blue dark:text-jordy-blue':
                   index === activeTab,

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -40,6 +40,7 @@
     "marked-alert": "^2.0.2",
     "mermaid": "^11.2.0",
     "p-queue": "^7.3.4",
+		"pretty-print-json": "^3.0.2",
     "re-resizable": "^6.9.9",
     "react": "^18.2.0",
     "react-copy-to-clipboard": "^5.1.0",

--- a/packages/extension/src/contentScript/popovers/toggleFrameHighlighting.ts
+++ b/packages/extension/src/contentScript/popovers/toggleFrameHighlighting.ts
@@ -16,10 +16,31 @@
 /**
  * Toggles highlighting of iframes by adding or removing a CSS class.
  * @param {boolean} [highlight] - Indicates whether to highlight the iframes (default is true).
+ * @param {string} [adUnit] -  Indicates which frame to highlight in case for protected audience.
+ * @param {boolean} [isForPa] -  Indicates wheter its being used for protected audience.
  * @returns {void}
  */
-const toggleFrameHighlighting = (highlight = true): void => {
+const toggleFrameHighlighting = (
+  highlight = true,
+  adUnit = '',
+  isForPa = false
+): void => {
   const iframes = document.querySelectorAll('iframe');
+
+  if (isForPa) {
+    const adUnitDiv = document.getElementById(adUnit);
+    adUnitDiv?.classList.toggle('ps-highlighted-frame', highlight);
+    iframes.forEach((iframe) => {
+      iframe.classList.toggle('ps-highlighted-frame', false);
+    });
+    return;
+  }
+
+  const divHighLighted = document.querySelectorAll('div.ps-highlighted-frame');
+
+  divHighLighted.forEach((div) => {
+    div.classList.toggle('ps-highlighted-frame', false);
+  });
 
   iframes.forEach((iframe) => {
     iframe.classList.toggle('ps-highlighted-frame', highlight);

--- a/packages/extension/src/contentScript/popovers/tooltip/createTooltipHTML.ts
+++ b/packages/extension/src/contentScript/popovers/tooltip/createTooltipHTML.ts
@@ -62,4 +62,21 @@ const createTooltipHTML = (
   return tooltipHTML;
 };
 
+export const createTooltipHTMLForPA = (
+  info: Record<string, string>
+): HTMLElement => {
+  const tooltipHTML = document.createElement('div');
+  // eslint-disable-next-line guard-for-in
+  for (const label in info) {
+    const value = info[label];
+    const p: HTMLParagraphElement = document.createElement('p');
+
+    if (value) {
+      p.innerHTML = `<strong>${label}</strong>: <span>${value}</span>`;
+      tooltipHTML.appendChild(p);
+    }
+  }
+
+  return tooltipHTML;
+};
 export default createTooltipHTML;

--- a/packages/extension/src/contentScript/types.ts
+++ b/packages/extension/src/contentScript/types.ts
@@ -22,6 +22,13 @@ export interface ResponseType {
   removeAllFramePopovers?: boolean;
   blockedCookies?: number;
   blockedReasons?: string;
+  isForProtectedAudience?: boolean;
+  selectedAdUnit?: string;
+  numberOfBidders?: number;
+  bidders?: string[];
+  winningBid?: number;
+  winningBidder?: string;
+  bidCurrency?: string;
 }
 
 // @see https://developer.mozilla.org/en-US/docs/Web/API/CookieStore/getAll

--- a/packages/extension/src/contentScript/utils/getTooltipInfoData.ts
+++ b/packages/extension/src/contentScript/utils/getTooltipInfoData.ts
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 /**
- * Internal Dependencies.
+ * External dependencies.
  */
 import { I18n } from '@google-psat/i18n';
+
+/**
+ * Internal dependencies.
+ */
 import { NUMBER_OF_ALLOWED_FEATURES_IN_COMPACT_VIEW } from '../constants';
 import type { ResponseType } from '../types';
 

--- a/packages/extension/src/contentScript/utils/getTooltipInfoData.ts
+++ b/packages/extension/src/contentScript/utils/getTooltipInfoData.ts
@@ -18,6 +18,7 @@
  */
 import { I18n } from '@google-psat/i18n';
 import { NUMBER_OF_ALLOWED_FEATURES_IN_COMPACT_VIEW } from '../constants';
+import type { ResponseType } from '../types';
 
 const getTooltipInfoData = (
   frameType: string,
@@ -94,6 +95,25 @@ const getTooltipInfoData = (
 
     info[I18n.getMessage('allowedFeatures')] = allowedFeaturesValue;
   }
+
+  return infoData;
+};
+
+export const getTooltipInfoDataForPA = (
+  data: ResponseType
+): { [key: string]: Record<string, string> } => {
+  const info: Record<string, string> = {};
+  const attr: Record<string, string> = {};
+  const infoData = {
+    info: info,
+    attr: attr,
+  };
+
+  info['bidders'] = data.bidders?.join(', ') ?? '';
+  info['winningBid'] = `${data.winningBid} ${data.bidCurrency}`;
+  info['numberOfBidders'] = `${data.numberOfBidders}`;
+  info['winningBidder'] = data.winningBidder ?? '';
+  info['selectedAdUnit'] = data.selectedAdUnit ?? '';
 
   return infoData;
 };

--- a/packages/extension/src/store/PAStore.ts
+++ b/packages/extension/src/store/PAStore.ts
@@ -128,6 +128,16 @@ class PAStore {
       return;
     }
 
+    const isAuctionIDAvailable = this.doesAuctionExistInTab(
+      tabId,
+      uniqueAuctionId,
+      'interestGroupAccessed'
+    );
+
+    if (!isAuctionIDAvailable) {
+      return;
+    }
+
     const {
       bid: initialBidValue,
       componentSellerOrigin,
@@ -279,6 +289,59 @@ class PAStore {
       dataStore.auctionEvents[tabId][uniqueAuctionId] = [];
     }
     return dataStore.auctionEvents[tabId][uniqueAuctionId];
+  }
+
+  /**
+   * Push into auction events
+   * @param {string} tabId The ID of the tab auction event is associated with.
+   * @param {string} uniqueAuctionId The ID of the auction event whose array is to be fetched.
+   * @param {string} eventType The type of event that called this.
+   * @returns {object | null} An object holder reporesenting the event data.
+   */
+  doesAuctionExistInTab(
+    tabId: string,
+    uniqueAuctionId: string,
+    eventType = 'interestGroupAuctionEventOccurred'
+  ) {
+    if (uniqueAuctionId === 'globalEvents') {
+      return true;
+    }
+
+    if (!dataStore.auctionEvents[tabId][uniqueAuctionId]) {
+      if (eventType !== 'interestGroupAccessed') {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    if (
+      dataStore.auctionEvents[tabId][uniqueAuctionId].filter(
+        (event) => event.type === 'started'
+      ).length > 0
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Fetch parent auction id for a tab
+   * @param {string} tabId The ID of the tab for which auction data needs to be fetched.
+   * @returns {Set} An object containing auction data.
+   */
+  getParentAuctionId(tabId: string) {
+    const parentAuctionIds = new Set<string>();
+    Object.keys(dataStore.auctionEvents[tabId]).forEach((uniqueAuctionId) => {
+      const parentAuctionId = dataStore.auctionEvents[tabId][
+        uniqueAuctionId
+      ].filter((event) => event.type === 'started')?.[0].parentAuctionId;
+
+      if (parentAuctionId) {
+        parentAuctionIds.add(parentAuctionId);
+      }
+    });
+
+    return parentAuctionIds;
   }
 }
 

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/adUnits/adMatrix.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/adUnits/adMatrix.tsx
@@ -17,43 +17,72 @@
 /**
  * External dependencies.
  */
-import React from 'react';
+import React, { useMemo } from 'react';
 import { MatrixComponent } from '@google-psat/design-system';
 
+/**
+ * Internal dependencies.
+ */
+import { useProtectedAudience } from '../../../../stateProviders';
+
 const AdMatrix = () => {
-  const matrixData = [
-    {
-      title: 'Ad Units',
-      count: 5,
-      color: '#5CC971',
-      description: 'Placeholder',
-      countClassName: 'text-emerald',
-    },
-    {
-      title: 'Bidders',
-      count: 10,
-      color: '#F3AE4E',
-      description: 'Placeholder',
-      countClassName: 'text-max-yellow-red',
-    },
-    {
-      title: 'Bids',
-      count: 15,
-      color: '#4C79F4',
-      description: 'Placeholder',
-      countClassName: 'text-blue-berry',
-    },
-    {
-      title: 'No Bids',
-      count: 20,
-      color: '#EC7159',
-      description: 'Placeholder',
-      countClassName: 'text-burnt-sienna',
-    },
-  ];
+  const { adsAndBidders, receivedBids, noBids } = useProtectedAudience(
+    ({ state }) => ({
+      adsAndBidders: state.adsAndBidders,
+      receivedBids: state.receivedBids,
+      noBids: state.noBids,
+    })
+  );
+
+  const biddersCount = useMemo(() => {
+    const bidders = Object.values(adsAndBidders).reduce((acc, ad) => {
+      if (ad.bidders) {
+        ad.bidders.forEach((bidder) => {
+          acc.add(bidder);
+        });
+      }
+      return acc;
+    }, new Set());
+
+    return bidders.size;
+  }, [adsAndBidders]);
+
+  const matrixData = useMemo(
+    () => [
+      {
+        title: 'Ad Units',
+        count: Object.values(adsAndBidders).length,
+        color: '#5CC971',
+        description: 'Placeholder',
+        countClassName: 'text-[#5CC971]',
+      },
+      {
+        title: 'Bidders',
+        count: biddersCount,
+        color: '#F3AE4E',
+        description: 'Placeholder',
+        countClassName: 'text-[#F3AE4E]',
+      },
+      {
+        title: 'Bids',
+        count: receivedBids.length,
+        color: '#4C79F4',
+        description: 'Placeholder',
+        countClassName: 'text-[#4C79F4]',
+      },
+      {
+        title: 'No Bids',
+        count: Object.values(noBids).length,
+        color: '#EC7159',
+        description: 'Placeholder',
+        countClassName: 'text-[#EC7159]',
+      },
+    ],
+    [adsAndBidders, biddersCount, noBids, receivedBids.length]
+  );
 
   return (
-    <div className="grid grid-cols-4 gap-x-2 max-w-2xl">
+    <div className="grid grid-cols-4 gap-x-2 max-w-2xl mb-4">
       {matrixData.map((dataComponent, index) => {
         if (dataComponent && dataComponent.countClassName) {
           return (

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/adUnits/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/adUnits/index.tsx
@@ -16,19 +16,74 @@
 /**
  * External dependencies.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
+import { SIDEBAR_ITEMS_KEYS, useSidebar } from '@google-psat/design-system';
 
 /**
  * Internal dependencies.
  */
 import AdMatrix from './adMatrix';
 import AdTable from './adTable';
+import { useProtectedAudience, useSettings } from '../../../../stateProviders';
 
 const AdUnits = () => {
+  const { adsAndBidders, setSelectedAdUnit } = useProtectedAudience(
+    ({ state, actions }) => ({
+      adsAndBidders: state.adsAndBidders,
+      setSelectedAdUnit: actions.setSelectedAdUnit,
+    })
+  );
+
+  const { isUsingCDP } = useSettings(({ state }) => ({
+    isUsingCDP: state.isUsingCDP,
+  }));
+
+  const { updateSelectedItemKey } = useSidebar(({ actions }) => ({
+    updateSelectedItemKey: actions.updateSelectedItemKey,
+  }));
+
+  useEffect(() => {
+    return () => {
+      setSelectedAdUnit(null);
+    };
+  }, [setSelectedAdUnit]);
+
+  if (!isUsingCDP) {
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        <p className="text-sm text-raisin-black dark:text-bright-gray">
+          To view ad units, enable PSAT to use CDP via the{' '}
+          <button
+            className="text-bright-navy-blue dark:text-jordy-blue"
+            onClick={() => {
+              document
+                .getElementById('cookies-landing-scroll-container')
+                ?.scrollTo(0, 0);
+              updateSelectedItemKey(SIDEBAR_ITEMS_KEYS.SETTINGS);
+            }}
+          >
+            Settings Page
+          </button>
+          .
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-col gap-4 h-full w-full">
-      <AdMatrix />
-      <AdTable />
+    <div className="flex flex-col h-full w-full">
+      {adsAndBidders && Object.keys(adsAndBidders).length > 0 ? (
+        <>
+          <AdMatrix />
+          <AdTable />
+        </>
+      ) : (
+        <div className="w-full h-full flex items-center justify-center">
+          <p className="text-sm text-raisin-black dark:text-bright-gray">
+            No ad units were recorded.
+          </p>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/auctionTable.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/auctionTable.tsx
@@ -178,9 +178,7 @@ const AuctionTable = ({
       >
         <div className="flex justify-between items-center p-2">
           <p>Started by: {auctionEvents?.[0]?.auctionConfig?.seller}</p>
-          <p>
-            Date {new Date(auctionEvents?.[0]?.time * 1000 || '').toUTCString()}
-          </p>
+          <p>{new Date(auctionEvents?.[0]?.time * 1000 || '').toUTCString()}</p>
         </div>
         <div className="flex-1 border border-american-silver dark:border-quartz overflow-auto">
           <TableProvider

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/auctionTable.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/auctionTable.tsx
@@ -16,91 +16,206 @@
 /**
  * External dependencies.
  */
-import React, { useMemo } from 'react';
-import { noop } from '@google-psat/common';
+import React, { useMemo, useState } from 'react';
+import { noop, type singleAuctionEvent } from '@google-psat/common';
 import {
-  BottomTrayIcon,
   Table,
   TableProvider,
+  type TableFilter,
   type TableColumn,
   type TableRow,
+  type InfoType,
 } from '@google-psat/design-system';
+import { Resizable } from 're-resizable';
+
+/**
+ * Internal dependencies.
+ */
+import BottomTray from './bottomTray';
 
 interface AuctionTableProps {
-  setSelectedJSON: (json: any) => void;
+  auctionEvents: singleAuctionEvent[];
+  parentOrigin?: string;
 }
 
-const AuctionTable = ({ setSelectedJSON }: AuctionTableProps) => {
+const AuctionTable = ({
+  auctionEvents,
+  parentOrigin = '',
+}: AuctionTableProps) => {
+  const [selectedJSON, setSelectedJSON] = useState<singleAuctionEvent | null>(
+    null
+  );
+
   const tableColumns = useMemo<TableColumn[]>(
     () => [
       {
         header: 'Event Time',
-        accessorKey: 'eventTime',
+        accessorKey: 'formattedTime',
         cell: (info) => info,
+        enableHiding: false,
+        widthWeightagePercentage: 10,
       },
       {
         header: 'Event',
-        accessorKey: 'event',
+        accessorKey: 'type',
         cell: (info) => info,
+        sortingComparator: (a, b) => {
+          const aString = (a as string).toLowerCase().trim();
+          const bString = (b as string).toLowerCase().trim();
+
+          return aString > bString ? 1 : -1;
+        },
+        widthWeightagePercentage: 20,
       },
       {
         header: 'Interest Group Origin',
-        accessorKey: 'interestGroupOrigin',
+        accessorKey: 'ownerOrigin',
         cell: (info) => info,
+        widthWeightagePercentage: 20,
       },
       {
         header: 'Interest Group Name',
-        accessorKey: 'interestGroupName',
+        accessorKey: 'name',
         cell: (info) => info,
+        widthWeightagePercentage: 17,
       },
       {
         header: 'Bid',
         accessorKey: 'bid',
         cell: (info) => info,
+        widthWeightagePercentage: 5,
       },
       {
         header: 'Bid Currency',
         accessorKey: 'bidCurrency',
         cell: (info) => info,
+        widthWeightagePercentage: 8,
       },
       {
         header: 'Component Seller',
-        accessorKey: 'componentSeller',
+        accessorKey: 'componentSellerOrigin',
         cell: (info) => info,
+        widthWeightagePercentage: 20,
       },
     ],
     []
   );
 
+  const tableFilters = useMemo<TableFilter>(
+    () => ({
+      type: {
+        title: 'Event',
+        sortValues: true,
+      },
+      ownerOrigin: {
+        title: 'Interest Group Origin',
+        sortValues: true,
+      },
+      name: {
+        title: 'Interest Group Name',
+        sortValues: true,
+      },
+      bid: {
+        title: 'Bid',
+        hasStaticFilterValues: true,
+        filterValues: {
+          ['0 - 20']: {
+            selected: false,
+          },
+          ['20 - 40']: {
+            selected: false,
+          },
+          ['40 - 60']: {
+            selected: false,
+          },
+          ['60 - 80']: {
+            selected: false,
+          },
+          ['80 - 100']: {
+            selected: false,
+          },
+          ['100+']: {
+            selected: false,
+          },
+        },
+        comparator: (value: InfoType, filterValue: string) => {
+          const bid = value as number;
+
+          if (filterValue === '100+') {
+            return bid > 100;
+          }
+
+          const [min, max] = filterValue.split(' - ').map(Number);
+
+          return bid >= min && bid <= max;
+        },
+      },
+      bidCurrency: {
+        title: 'Bid Currency',
+        sortValues: true,
+      },
+      componentSellerOrigin: {
+        title: 'Component Seller',
+        sortValues: true,
+      },
+    }),
+    []
+  );
+
   return (
-    <div className="w-full h-full text-outer-space-crayola dark:text-bright-gray flex flex-col p-4 pb-0">
-      <div className="flex justify-between items-center px-1">
-        <p>Started by: https://example.com</p>
-        <p>Date</p>
-      </div>
-      <div className="border border-american-silver dark:border-quartz">
-        <TableProvider
-          data={[]}
-          tableColumns={tableColumns}
-          tableFilterData={undefined}
-          tableSearchKeys={undefined}
-          tablePersistentSettingsKey="adtable"
-          onRowContextMenu={noop}
-          onRowClick={noop}
-          getRowObjectKey={(row: TableRow) => {
-            return row.originalData.name;
-          }}
-        >
-          <Table hideFiltering={true} selectedKey={''} hideSearch={true} />
-        </TableProvider>
-      </div>
-      <button
-        className="flex gap-1 items-center hover:opacity-70 px-1"
-        onClick={() => setSelectedJSON({})}
+    <div className="w-full h-full text-outer-space-crayola dark:text-bright-gray flex flex-col">
+      <Resizable
+        defaultSize={{
+          width: '100%',
+          height: '80%',
+        }}
+        enable={{
+          bottom: true,
+        }}
+        minHeight="20%"
+        maxHeight="90%"
+        className="w-full flex flex-col"
       >
-        <BottomTrayIcon />
-        Show Config
-      </button>
+        <div className="flex justify-between items-center p-2">
+          <p>Started by: {auctionEvents?.[0]?.auctionConfig?.seller}</p>
+          <p>
+            Date {new Date(auctionEvents?.[0]?.time * 1000 || '').toUTCString()}
+          </p>
+        </div>
+        <div className="flex-1 border border-american-silver dark:border-quartz overflow-auto">
+          <TableProvider
+            data={auctionEvents}
+            tableColumns={tableColumns}
+            tableFilterData={tableFilters}
+            tableSearchKeys={undefined}
+            tablePersistentSettingsKey={
+              'adtable' +
+              auctionEvents?.[0]?.auctionConfig?.seller +
+              parentOrigin
+            }
+            onRowContextMenu={noop}
+            onRowClick={(row) => setSelectedJSON(row as singleAuctionEvent)}
+            getRowObjectKey={(row: TableRow) => {
+              return (
+                // @ts-ignore
+                ((row.originalData as singleAuctionEvent).auctionConfig
+                  ?.seller || '') +
+                (row.originalData as singleAuctionEvent).time
+              );
+            }}
+          >
+            <Table
+              selectedKey={
+                // @ts-ignore
+                (selectedJSON?.auctionConfig?.seller || '') +
+                  selectedJSON?.time || ''
+              }
+              hideSearch={true}
+            />
+          </TableProvider>
+        </div>
+      </Resizable>
+      <BottomTray selectedJSON={selectedJSON} />
     </div>
   );
 };

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/bottomTray.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/bottomTray.tsx
@@ -18,20 +18,33 @@
  * External dependencies.
  */
 import React from 'react';
+import { I18n } from '@google-psat/i18n';
+import { prettyPrintJson } from 'pretty-print-json';
 
 interface BottomTrayProps {
   selectedJSON?: any;
 }
 
 const BottomTray = ({ selectedJSON }: BottomTrayProps) => {
-  if (!selectedJSON) {
-    return null;
-  }
-
   return (
-    <div className="z-20 flex-1 text-raisin-black dark:text-bright-gray border border-gray-300 dark:border-quartz shadow h-full min-w-[10rem] bg-white dark:bg-raisin-black">
+    <div className="flex-1 z-20 text-raisin-black dark:text-bright-gray border border-gray-300 dark:border-quartz shadow min-w-[10rem] bg-white dark:bg-raisin-black overflow-auto">
       <div className="text-xs py-1 px-1.5">
-        <pre>{JSON.stringify(selectedJSON, null, 2)}</pre>
+        {selectedJSON ? (
+          <pre>
+            <div
+              className="json-container"
+              dangerouslySetInnerHTML={{
+                __html: prettyPrintJson.toHtml(selectedJSON),
+              }}
+            />
+          </pre>
+        ) : (
+          <div className="h-full p-8 flex items-center">
+            <p className="text-lg w-full font-bold text-granite-gray dark:text-manatee text-center">
+              {I18n.getMessage('selectRowToPreview')}
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/breakpoints.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/breakpoints.tsx
@@ -22,27 +22,27 @@ import { BreakpointIcon } from '@google-psat/design-system';
 
 const Breakpoints = () => {
   return (
-    <div className="flex gap-4 text-raisin-black dark:text-bright-gray p-4 pb-0">
+    <div className="flex gap-4 text-raisin-black dark:text-bright-gray p-4">
       <div className="flex gap-2 justify-center items-center">
         <BreakpointIcon className="fill-granite-gray" />
         Ad Worklet Breakpoints
       </div>
-      <label className="cursor-pointer flex gap-2 justify-center items-center">
+      <div className="flex gap-2 justify-center items-center">
         <input type="checkbox" />
         Bidder Bidding Phase Start
-      </label>
-      <label className="cursor-pointer flex gap-2 justify-center items-center">
+      </div>
+      <div className="flex gap-2 justify-center items-center">
         <input type="checkbox" />
         Bidder Reporting Phase Start
-      </label>
-      <label className="cursor-pointer flex gap-2 justify-center items-center">
+      </div>
+      <div className="flex gap-2 justify-center items-center">
         <input type="checkbox" />
         Seller Scoring Phase Start
-      </label>
-      <label className="cursor-pointer flex gap-2 justify-center items-center">
+      </div>
+      <div className="flex gap-2 justify-center items-center">
         <input type="checkbox" />
         Seller Reporting Phase Start
-      </label>
+      </div>
     </div>
   );
 };

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/mutliSellerAuctionTable.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/mutliSellerAuctionTable.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies.
+ */
+import React, { useEffect } from 'react';
+import type { MultiSellerAuction } from '@google-psat/common';
+import {
+  Sidebar,
+  useSidebar,
+  type SidebarItems,
+} from '@google-psat/design-system';
+import { Resizable } from 're-resizable';
+
+/**
+ * Internal dependencies.
+ */
+import AuctionTable from './auctionTable';
+
+interface MultiSellerAuctionTableProps {
+  auctionEvents: MultiSellerAuction;
+  setSidebarData: React.Dispatch<React.SetStateAction<SidebarItems>>;
+}
+
+const MultiSellerAuctionTable = ({
+  auctionEvents,
+  setSidebarData,
+}: MultiSellerAuctionTableProps) => {
+  useEffect(() => {
+    const data = Object.keys(auctionEvents).reduce<SidebarItems>(
+      (acc, parentAuctionId) => {
+        const singleAuctionEvents = auctionEvents[parentAuctionId];
+        const children = Object.entries(
+          singleAuctionEvents
+        ).reduce<SidebarItems>((childrenAcc, [uniqueAuctionId, events]) => {
+          if (uniqueAuctionId === '0') {
+            return childrenAcc;
+          }
+
+          childrenAcc[uniqueAuctionId] = {
+            title: events?.[0]?.auctionConfig?.seller,
+            panel: {
+              Element: AuctionTable,
+              props: {
+                auctionEvents: events,
+                parentOrigin: events?.[0]?.auctionConfig?.seller,
+              },
+            },
+            children: {},
+          };
+
+          return childrenAcc;
+        }, {});
+
+        acc[parentAuctionId] = {
+          title: singleAuctionEvents['0']?.[0]?.auctionConfig?.seller,
+          panel: {
+            Element: AuctionTable,
+            props: {
+              auctionEvents: Object.values(singleAuctionEvents)[0],
+              parentOrigin:
+                singleAuctionEvents['0']?.[0]?.auctionConfig?.seller,
+            },
+          },
+          children,
+        };
+
+        return acc;
+      },
+      {}
+    );
+
+    setSidebarData(data);
+  }, [auctionEvents, setSidebarData]);
+
+  const { activePanel } = useSidebar(({ state }) => ({
+    activePanel: state.activePanel,
+  }));
+
+  const { Element, props } = activePanel.panel;
+
+  return (
+    <div className="w-full h-full flex border-t border-chinese-silver dark:border-quartz">
+      <Resizable
+        defaultSize={{
+          width: 250,
+          height: '100%',
+        }}
+        minWidth={100}
+        maxWidth={800}
+        enable={{
+          right: true,
+        }}
+      >
+        <Sidebar />
+      </Resizable>
+      <div className="flex-1 h-full flex flex-col overflow-auto">
+        {Element && <Element {...props} />}
+      </div>
+    </div>
+  );
+};
+
+export default MultiSellerAuctionTable;

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/bids/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/bids/index.tsx
@@ -18,15 +18,19 @@
  * External dependencies.
  */
 import { PillToggle } from '@google-psat/design-system';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { I18n } from '@google-psat/i18n';
 import { Resizable } from 're-resizable';
+import { prettyPrintJson } from 'pretty-print-json';
+import type { NoBidsType, singleAuctionEvent } from '@google-psat/common';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies.
  */
 import ReceivedBidsTable from './receivedBidsTable';
 import NoBidsTable from './noBidsTable';
+import { useProtectedAudience } from '../../../../stateProviders';
 
 enum PillToggleOptions {
   ReceivedBids = 'Received Bids',
@@ -34,14 +38,28 @@ enum PillToggleOptions {
 }
 
 const Bids = () => {
-  const [selectedRow, setSelectedRow] = useState<any>(null);
+  const [selectedRow, setSelectedRow] = useState<
+    singleAuctionEvent | NoBidsType[keyof NoBidsType] | null
+  >(null);
   const [pillToggle, setPillToggle] = useState<string>(
     PillToggleOptions.ReceivedBids
   );
+  const { receivedBids, noBids } = useProtectedAudience(({ state }) => ({
+    receivedBids: state.receivedBids,
+    noBids: state.noBids,
+  }));
+
+  const showBottomTray = useMemo(() => {
+    if (pillToggle === PillToggleOptions.ReceivedBids) {
+      return receivedBids.length > 0;
+    }
+
+    return Object.keys(noBids).length > 0;
+  }, [noBids, pillToggle, receivedBids.length]);
 
   return (
-    <div className="flex flex-col gap-4 pt-4 h-full w-full">
-      <div className="px-4">
+    <div className="flex flex-col pt-4 h-full w-full">
+      <div className="px-4 pb-4">
         <PillToggle
           firstOption={PillToggleOptions.ReceivedBids}
           secondOption={PillToggleOptions.NoBids}
@@ -49,48 +67,62 @@ const Bids = () => {
           setPillToggle={setPillToggle}
         />
       </div>
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 overflow-auto text-outer-space-crayola">
+        {pillToggle === PillToggleOptions.ReceivedBids ? (
+          <div className="w-full h-full border-t border-american-silver dark:border-quartz overflow-auto">
+            <ReceivedBidsTable
+              setSelectedRow={setSelectedRow}
+              selectedRow={selectedRow}
+            />
+          </div>
+        ) : (
+          <div
+            className={classNames(
+              'h-full border-r border-t border-american-silver dark:border-quartz',
+              Object.keys(noBids).length > 0 ? 'w-[42rem]' : 'w-full'
+            )}
+          >
+            <NoBidsTable
+              setSelectedRow={setSelectedRow}
+              selectedRow={selectedRow}
+            />
+          </div>
+        )}
+      </div>
+      {showBottomTray && (
         <Resizable
           defaultSize={{
             width: '100%',
-            height: '80%',
+            height: '20%',
           }}
-          minHeight="20%"
+          minHeight="10%"
           maxHeight="90%"
           enable={{
-            bottom: true,
+            top: true,
           }}
         >
-          {pillToggle === PillToggleOptions.ReceivedBids ? (
-            <div className="w-full h-full border-t border-american-silver dark:border-quartz">
-              <ReceivedBidsTable
-                setSelectedRow={setSelectedRow}
-                selectedRow={selectedRow}
-              />
-            </div>
-          ) : (
-            <div className="w-[42rem] h-full border-r border-t border-american-silver dark:border-quartz">
-              <NoBidsTable
-                setSelectedRow={setSelectedRow}
-                selectedRow={selectedRow}
-              />
-            </div>
-          )}
+          <div className="text-raisin-black dark:text-bright-gray border border-gray-300 dark:border-quartz shadow h-full min-w-[10rem] bg-white dark:bg-raisin-black overflow-auto">
+            {selectedRow ? (
+              <div className="text-xs py-1 px-1.5">
+                <pre>
+                  <div
+                    className="json-container"
+                    dangerouslySetInnerHTML={{
+                      __html: prettyPrintJson.toHtml(selectedRow),
+                    }}
+                  />
+                </pre>
+              </div>
+            ) : (
+              <div className="h-full p-8 flex items-center">
+                <p className="text-lg w-full font-bold text-granite-gray dark:text-manatee text-center">
+                  {I18n.getMessage('selectRowToPreview')}
+                </p>
+              </div>
+            )}
+          </div>
         </Resizable>
-        <div className="flex-1 border border-gray-300 dark:border-quartz shadow min-w-[10rem]">
-          {selectedRow ? (
-            <div className="text-xs py-1 px-1.5">
-              <pre>{JSON.stringify(selectedRow, null, 2)}</pre>
-            </div>
-          ) : (
-            <div className="h-full p-8 flex items-center">
-              <p className="text-lg w-full font-bold text-granite-gray dark:text-manatee text-center">
-                {I18n.getMessage('selectRowToPreview')}
-              </p>
-            </div>
-          )}
-        </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/bids/receivedBidsTable.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/bids/receivedBidsTable.tsx
@@ -16,78 +16,197 @@
 /**
  * External dependencies.
  */
-import { noop } from '@google-psat/common';
 import {
+  noop,
+  type NoBidsType,
+  type singleAuctionEvent,
+} from '@google-psat/common';
+import {
+  SIDEBAR_ITEMS_KEYS,
   Table,
+  type TableFilter,
   TableProvider,
+  useSidebar,
+  type InfoType,
   type TableColumn,
   type TableRow,
 } from '@google-psat/design-system';
 import React, { useMemo } from 'react';
+import { useProtectedAudience, useSettings } from '../../../../stateProviders';
 
 interface ReceivedBidsTableProps {
-  setSelectedRow: (row: any) => void;
-  selectedRow: any;
+  setSelectedRow: React.Dispatch<
+    React.SetStateAction<
+      singleAuctionEvent | NoBidsType[keyof NoBidsType] | null
+    >
+  >;
+  selectedRow: singleAuctionEvent | NoBidsType[keyof NoBidsType] | null;
 }
 
 const ReceivedBidsTable = ({
   setSelectedRow,
   selectedRow,
 }: ReceivedBidsTableProps) => {
+  const receivedBids = useProtectedAudience(({ state }) => state.receivedBids);
+
+  const { isUsingCDP } = useSettings(({ state }) => ({
+    isUsingCDP: state.isUsingCDP,
+  }));
+
+  const { updateSelectedItemKey } = useSidebar(({ actions }) => ({
+    updateSelectedItemKey: actions.updateSelectedItemKey,
+  }));
+
   const tableColumns = useMemo<TableColumn[]>(
     () => [
       {
         header: 'Bidder',
-        accessorKey: 'bidder',
+        accessorKey: 'ownerOrigin',
         cell: (info) => info,
+        enableHiding: false,
+        widthWeightagePercentage: 20,
       },
       {
         header: 'Bid',
         accessorKey: 'bid',
         cell: (info) => info,
+        widthWeightagePercentage: 15,
       },
       {
-        header: 'Bid Currency',
+        header: 'Currency',
         accessorKey: 'bidCurrency',
         cell: (info) => info,
+        widthWeightagePercentage: 16,
       },
       {
         header: 'Ad Unit Code',
         accessorKey: 'adUnitCode',
         cell: (info) => info,
+        widthWeightagePercentage: 16,
       },
       {
         header: 'Ad Container Size',
         accessorKey: 'adContainerSize',
         cell: (info) => info,
+        widthWeightagePercentage: 16,
       },
       {
         header: 'Media Type',
         accessorKey: 'mediaType',
         cell: (info) => info,
+        widthWeightagePercentage: 16,
       },
     ],
     []
   );
 
+  const tableFilters = useMemo<TableFilter>(
+    () => ({
+      ownerOrigin: {
+        title: 'Bidder',
+        sortValues: true,
+      },
+      bid: {
+        title: 'Bid',
+        hasStaticFilterValues: true,
+        filterValues: {
+          ['0 - 20']: {
+            selected: false,
+          },
+          ['20 - 40']: {
+            selected: false,
+          },
+          ['40 - 60']: {
+            selected: false,
+          },
+          ['60 - 80']: {
+            selected: false,
+          },
+          ['80 - 100']: {
+            selected: false,
+          },
+          ['100+']: {
+            selected: false,
+          },
+        },
+        comparator: (value: InfoType, filterValue: string) => {
+          const bid = value as number;
+
+          if (filterValue === '100+') {
+            return bid > 100;
+          }
+
+          const [min, max] = filterValue.split(' - ').map(Number);
+
+          return bid >= min && bid <= max;
+        },
+      },
+      bidCurrency: {
+        title: 'Bid Currency',
+        sortValues: true,
+      },
+      adUnitCode: {
+        title: 'Ad Unit Code',
+        sortValues: true,
+      },
+    }),
+    []
+  );
+
+  if (!isUsingCDP) {
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        <p className="text-sm text-raisin-black dark:text-bright-gray">
+          To view bids data, enable PSAT to use CDP via the{' '}
+          <button
+            className="text-bright-navy-blue dark:text-jordy-blue"
+            onClick={() => {
+              document
+                .getElementById('cookies-landing-scroll-container')
+                ?.scrollTo(0, 0);
+              updateSelectedItemKey(SIDEBAR_ITEMS_KEYS.SETTINGS);
+            }}
+          >
+            Settings Page
+          </button>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  if (!receivedBids || receivedBids.length === 0) {
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        <p className="text-sm text-raisin-black dark:text-bright-gray">
+          No bids data was recorded.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <TableProvider
-      data={[]}
+      data={receivedBids}
       tableColumns={tableColumns}
-      tableFilterData={undefined}
+      tableFilterData={tableFilters}
       tableSearchKeys={undefined}
       tablePersistentSettingsKey="receivedBidsTable"
       onRowClick={(row) => {
-        setSelectedRow(row);
+        setSelectedRow(row as singleAuctionEvent);
       }}
       onRowContextMenu={noop}
       getRowObjectKey={(row: TableRow) => {
-        return row.originalData.name;
+        const data = row.originalData as singleAuctionEvent;
+        return data?.ownerOrigin + data?.uniqueAuctionId + data?.time;
       }}
     >
       <Table
-        hideFiltering={true}
-        selectedKey={selectedRow?.name}
+        selectedKey={
+          selectedRow?.ownerOrigin +
+          selectedRow?.uniqueAuctionId +
+          selectedRow?.time
+        }
         hideSearch={true}
       />
     </TableProvider>

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/index.tsx
@@ -29,6 +29,14 @@ import {
 import { I18n } from '@google-psat/i18n';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies.
+ */
+import InterestGroups from './interestGroups';
+import Auctions from './auctions';
+import Bids from './bids';
+import AdUnits from './adUnits';
+
 const InfoCard = ({ infoKey }: { infoKey: PSInfoKeyType }) => {
   return (
     <>
@@ -55,32 +63,34 @@ const ProtectedAudience = () => {
           className: 'p-4',
         },
       },
-      // {
-      //   title: 'Interest Groups',
-      //   content: {
-      //     Element: InterestGroups,
-      //     className: 'pt-4 overflow-hidden',
-      //   },
-      // },
-      // {
-      //   title: 'Ad Units',
-      //   content: {
-      //     Element: AdUnits,
-      //     className: 'overflow-hidden',
-      //   },
-      // },
-      // {
-      //   title: 'Auctions',
-      //   content: {
-      //     Element: Auctions,
-      //   },
-      // },
-      // {
-      //   title: 'Bids',
-      //   content: {
-      //     Element: Bids,
-      //   },
-      // },
+      {
+        title: 'Interest Groups',
+        content: {
+          Element: InterestGroups,
+          className: 'overflow-hidden',
+        },
+      },
+      {
+        title: 'Ad Units',
+        content: {
+          Element: AdUnits,
+          className: 'overflow-hidden',
+        },
+      },
+      {
+        title: 'Auctions',
+        content: {
+          Element: Auctions,
+          className: 'overflow-hidden',
+        },
+      },
+      {
+        title: 'Bids',
+        content: {
+          Element: Bids,
+          className: 'overflow-hidden',
+        },
+      },
     ],
     []
   );
@@ -90,7 +100,7 @@ const ProtectedAudience = () => {
   return (
     <div
       data-testid="protected-audience-content"
-      className="h-screen w-full flex flex-col"
+      className="h-screen w-full flex flex-col overflow-hidden"
     >
       <div className="p-4">
         <div className="flex gap-2 text-2xl font-bold items-baseline text-raisin-black dark:text-bright-gray">
@@ -103,7 +113,13 @@ const ProtectedAudience = () => {
         setActiveTab={setActiveTab}
       />
       <div
-        className={classNames(tabItems[activeTab].content.className, 'flex-1')}
+        className={classNames(
+          'overflow-auto',
+          tabItems[activeTab].content.className
+        )}
+        style={{
+          minHeight: 'calc(100% - 93px)',
+        }}
       >
         {ActiveTabContent && (
           <ActiveTabContent {...tabItems[activeTab].content.props} />

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/interestGroups/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/interestGroups/index.tsx
@@ -21,32 +21,58 @@ import React, { useMemo, useState } from 'react';
 import { Resizable } from 're-resizable';
 import {
   Table,
+  type TableFilter,
   TableProvider,
   type TableColumn,
-  type TableData,
   type TableRow,
+  useSidebar,
+  SIDEBAR_ITEMS_KEYS,
 } from '@google-psat/design-system';
 import { I18n } from '@google-psat/i18n';
-import { noop } from '@google-psat/common';
+import {
+  noop,
+  type InterestGroups as InterestGroupsType,
+} from '@google-psat/common';
+import { prettyPrintJson } from 'pretty-print-json';
+
+/**
+ * Internal dependencies.
+ */
+import { useProtectedAudience, useSettings } from '../../../../stateProviders';
 
 const InterestGroups = () => {
-  const [selectedRow, setSelectedRow] = useState<TableData | null>(null);
+  const [selectedRow, setSelectedRow] = useState<InterestGroupsType | null>(
+    null
+  );
+
+  const { interestGroupDetails } = useProtectedAudience(({ state }) => ({
+    interestGroupDetails: state.interestGroupDetails,
+  }));
+
+  const { isUsingCDP } = useSettings(({ state }) => ({
+    isUsingCDP: state.isUsingCDP,
+  }));
+
+  const { updateSelectedItemKey } = useSidebar(({ actions }) => ({
+    updateSelectedItemKey: actions.updateSelectedItemKey,
+  }));
 
   const tableColumns = useMemo<TableColumn[]>(
     () => [
       {
         header: 'Event Time',
-        accessorKey: 'eventTime',
-        cell: (info) => info,
+        accessorKey: 'formattedTime',
+        cell: (info) =>
+          (info as string)
+            .replace('T', ' | ')
+            .replace('Z', '')
+            .split('-')
+            .join('/'),
+        enableHiding: false,
       },
       {
         header: 'Access Type',
-        accessorKey: 'accessType',
-        cell: (info) => info,
-      },
-      {
-        header: 'Owner',
-        accessorKey: 'owner',
+        accessorKey: 'type',
         cell: (info) => info,
       },
       {
@@ -55,52 +81,131 @@ const InterestGroups = () => {
         cell: (info) => info,
       },
       {
+        header: 'Owner',
+        accessorKey: 'ownerOrigin',
+        cell: (info) => {
+          return new URL(info as string).hostname;
+        },
+      },
+      {
         header: 'Expiration Time',
-        accessorKey: 'expirationTime',
-        cell: (info) => info,
+        accessorKey: 'details.expirationTime',
+        cell: (info) => {
+          if (!info) {
+            return '';
+          }
+
+          return new Date(Number(info) * 1000)
+            .toISOString()
+            .replace('T', ' | ')
+            .replace('Z', '')
+            .split('-')
+            .join('/');
+        },
       },
     ],
     []
   );
 
+  const tableFilters = useMemo<TableFilter>(
+    () => ({
+      type: {
+        title: 'Access Type',
+        sortValues: true,
+      },
+      ownerOrigin: {
+        title: 'Owner',
+        sortValues: true,
+      },
+      name: {
+        title: 'Name',
+        sortValues: true,
+      },
+    }),
+    []
+  );
+
+  if (!isUsingCDP) {
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        <p className="text-sm text-raisin-black dark:text-bright-gray">
+          To view interest group events, enable PSAT to use CDP via the{' '}
+          <button
+            className="text-bright-navy-blue dark:text-jordy-blue"
+            onClick={() => {
+              document
+                .getElementById('cookies-landing-scroll-container')
+                ?.scrollTo(0, 0);
+              updateSelectedItemKey(SIDEBAR_ITEMS_KEYS.SETTINGS);
+            }}
+          >
+            Settings Page
+          </button>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  if (!interestGroupDetails || interestGroupDetails.length === 0) {
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        <p className="text-sm text-raisin-black dark:text-bright-gray">
+          No interests group events recorded.
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div className="w-full h-full text-outer-space-crayola border-x border-t border-american-silver dark:border-quartz flex flex-col">
+    <div className="w-full h-full text-outer-space-crayola mt-4 border-x border-t border-american-silver dark:border-quartz flex flex-col">
       <Resizable
         defaultSize={{
           width: '100%',
           height: '80%',
         }}
-        minHeight="20%"
+        minHeight="15%"
         maxHeight="90%"
         enable={{
           bottom: true,
         }}
       >
         <TableProvider
-          data={[]}
+          data={interestGroupDetails}
           tableColumns={tableColumns}
-          tableFilterData={undefined}
+          tableFilterData={tableFilters}
           tableSearchKeys={undefined}
           tablePersistentSettingsKey="interestGroupsTable"
           onRowClick={(row) => {
-            setSelectedRow(row);
+            setSelectedRow(row as InterestGroupsType);
           }}
           onRowContextMenu={noop}
           getRowObjectKey={(row: TableRow) => {
-            return row.originalData.name;
+            return (
+              ((row.originalData as InterestGroupsType).uniqueAuctionId ?? '') +
+              (row.originalData as InterestGroupsType).time
+            );
           }}
         >
           <Table
-            hideFiltering={true}
-            selectedKey={selectedRow?.name}
+            selectedKey={
+              (selectedRow?.uniqueAuctionId ?? '') + String(selectedRow?.time)
+            }
             hideSearch={true}
           />
         </TableProvider>
       </Resizable>
-      <div className="flex-1 border border-gray-300 dark:border-quartz shadow min-w-[10rem]">
+      <div className="flex-1 text-raisin-black dark:text-bright-gray border border-gray-300 dark:border-quartz shadow h-full min-w-[10rem] bg-white dark:bg-raisin-black overflow-auto">
         {selectedRow ? (
           <div className="text-xs py-1 px-1.5">
-            <pre>{JSON.stringify(selectedRow, null, 2)}</pre>
+            <pre>
+              <div
+                className="json-container"
+                dangerouslySetInnerHTML={{
+                  __html: prettyPrintJson.toHtml(selectedRow),
+                }}
+              />
+            </pre>
           </div>
         ) : (
           <div className="h-full p-8 flex items-center">

--- a/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
+++ b/packages/extension/src/view/devtools/hooks/useFrameOverlay.ts
@@ -23,7 +23,11 @@ import type { CookieTableData } from '@google-psat/common';
  * Internal dependencies.
  */
 import { WEBPAGE_PORT_NAME } from '../../../constants';
-import { useCookie, useSettings } from '../stateProviders';
+import {
+  useCookie,
+  useProtectedAudience,
+  useSettings,
+} from '../stateProviders';
 import { getCurrentTabId } from '../../../utils/getCurrentTabId';
 import { isOnRWS } from '../../../contentScript/utils';
 
@@ -56,6 +60,13 @@ const useFrameOverlay = (
     setCanStartInspecting: actions.setCanStartInspecting,
     canStartInspecting: state.canStartInspecting,
   }));
+
+  const { selectedAdUnit, adsAndBidders } = useProtectedAudience(
+    ({ state }) => ({
+      selectedAdUnit: state.selectedAdUnit,
+      adsAndBidders: state.adsAndBidders,
+    })
+  );
 
   const { allowedNumberOfTabs } = useSettings(({ state }) => ({
     allowedNumberOfTabs: state.allowedNumberOfTabs,
@@ -98,6 +109,9 @@ const useFrameOverlay = (
     });
 
     portRef.current.onMessage.addListener((response: Response) => {
+      if (selectedAdUnit) {
+        return;
+      }
       setSelectedFrame(response.attributes.iframeOrigin, true);
     });
 
@@ -111,7 +125,7 @@ const useFrameOverlay = (
     });
 
     setConnectedToPort(true);
-  }, [canStartInspecting, setSelectedFrame, setIsInspecting]);
+  }, [canStartInspecting, setSelectedFrame, setIsInspecting, selectedAdUnit]);
 
   const listenIfContentScriptSet = useCallback(
     async (
@@ -259,6 +273,53 @@ const useFrameOverlay = (
   }, [allowedNumberOfTabs, isCurrentTabBeingListenedTo, setIsInspecting]);
 
   useEffect(() => {
+    try {
+      if (selectedFrame) {
+        return;
+      }
+
+      if (!selectedAdUnit) {
+        return;
+      }
+
+      if (!connectedToPort && !canStartInspecting) {
+        connectToPort();
+      }
+
+      if (!isInspecting && portRef.current && canStartInspecting) {
+        portRef.current.postMessage({
+          isInspecting: false,
+        });
+
+        return;
+      }
+
+      if (chrome.runtime?.id && portRef.current && canStartInspecting) {
+        portRef.current?.postMessage({
+          isForProtectedAudience: true,
+          selectedAdUnit,
+          numberOfBidders: adsAndBidders[selectedAdUnit]?.bidders?.length,
+          bidders: adsAndBidders[selectedAdUnit]?.bidders,
+          winningBid: adsAndBidders[selectedAdUnit]?.winningBid,
+          bidCurrency: adsAndBidders[selectedAdUnit]?.bidCurrency,
+          winningBidder: adsAndBidders[selectedAdUnit]?.winningBidder,
+          isInspecting,
+        });
+      }
+    } catch (error) {
+      // Silently fail.
+    }
+  }, [
+    canStartInspecting,
+    connectToPort,
+    connectedToPort,
+    isInspecting,
+    selectedFrame,
+    selectedAdUnit,
+    adsAndBidders,
+  ]);
+
+  useEffect(() => {
     (async () => {
       try {
         if (!connectedToPort && !canStartInspecting) {
@@ -324,6 +385,7 @@ const useFrameOverlay = (
             blockedCookies: blockedCookies.length,
             blockedReasons: blockedReasons.join(', '),
             isInspecting,
+            isForProtectedAudience: Boolean(selectedAdUnit),
             isOnRWS: isFrameOnRWS,
           });
         }
@@ -332,6 +394,7 @@ const useFrameOverlay = (
       }
     })();
   }, [
+    selectedAdUnit,
     canStartInspecting,
     connectToPort,
     connectedToPort,

--- a/packages/extension/src/view/devtools/index.tsx
+++ b/packages/extension/src/view/devtools/index.tsx
@@ -24,6 +24,8 @@ import {
   Provider as TablePersistentSettingsProvider,
 } from '@google-psat/design-system';
 import { LibraryDetectionProvider } from '@google-psat/library-detection';
+// eslint-disable-next-line import/no-relative-packages -- Relative import is necessary, because package doesn't export css file.
+import './prettyJson.css';
 
 /**
  * Internal dependencies.
@@ -37,7 +39,9 @@ import {
 } from './stateProviders';
 
 const isDarkMode = chrome.devtools.panels.themeName === 'dark';
-document.body.classList.add(isDarkMode ? 'dark' : 'light');
+// dark-mode class is added to body to apply pretty-print-json dark theme.
+const classes = isDarkMode ? ['dark', 'dark-mode'] : ['light'];
+document.body.classList.add(...classes);
 
 const root = document.getElementById('root');
 

--- a/packages/extension/src/view/devtools/prettyJson.css
+++ b/packages/extension/src/view/devtools/prettyJson.css
@@ -1,0 +1,49 @@
+/*! Modified version of pretty-print-json v3.0.2 ~~ https://pretty-print-json.js.org */
+
+/* Layout */
+.json-container           { font-family: system-ui, sans-serif; font-style: normal; line-height: 16px; font-size: 12px; transition: background-color 400ms; }
+a.json-link               { text-decoration: none; border-bottom: 1px solid; outline: none; }
+a.json-link:hover         { background-color: transparent; outline: none; }
+ol.json-lines             { white-space: normal; padding-inline-start: 3em; margin: 0px; }
+ol.json-lines >li         { white-space: pre; text-indent: 0.7em; line-height: 1.5em; padding: 0px; }
+ol.json-lines >li::marker { font-family: system-ui, sans-serif; font-weight: normal; }
+.json-key, .json-string, .json-number, .json-boolean, .json-null, .json-mark, a.json-link, ol.json-lines >li { transition: all 400ms; }
+
+/* Custom Colors */
+ol.json-lines {
+   --colorGraphite: #303030;
+   --colorCharcoal: #222222;
+   --colorTar:      #161616;
+   }
+
+/* Colors */
+.json-key                         { color: #8E004B; }
+.json-string                      { color: #DE3730; }
+.json-number                      { color: #0842A0; }
+.json-boolean                     { color: #0842A0; }
+.json-null                        { color: #0842A0; }
+.json-mark                        { color: black; }
+a.json-link                       { color: #DE3730; }
+a.json-link:visited               { color: #DE3730; }
+a.json-link:hover                 { color: #DE3730; }
+a.json-link:active                { color: slategray; }
+ol.json-lines >li::marker         { color: dimgray; }
+ol.json-lines >li:nth-child(odd)  { background-color: gainsboro; }
+ol.json-lines >li:nth-child(even) { background-color: whitesmoke; }
+ol.json-lines >li:hover           { background-color: lemonchiffon; }
+
+/* Dark Mode */
+.dark-mode .json-key                         { color: #7CACF8; }
+.dark-mode .json-string                      { color: #5CD5FB; }
+.dark-mode .json-number                      { color: #9980FF; }
+.dark-mode .json-boolean                     { color: #9980FF; }
+.dark-mode .json-null                        { color: #9980FF; }
+.dark-mode .json-mark                        { color: silver; }
+.dark-mode a.json-link                       { color: #5CD5FB; }
+.dark-mode a.json-link:visited               { color: #5CD5FB; }
+.dark-mode a.json-link:hover                 { color: #5CD5FB; }
+.dark-mode a.json-link:active                { color: slategray; }
+.dark-mode ol.json-lines >li::marker         { color: silver; }
+.dark-mode ol.json-lines >li:nth-child(odd)  { background-color: var(--colorCharcoal); }
+.dark-mode ol.json-lines >li:nth-child(even) { background-color: var(--colorTar); }
+.dark-mode ol.json-lines >li:hover           { background-color: dimgray; }

--- a/packages/extension/src/view/devtools/stateProviders/cookie/cookieProvider.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/cookie/cookieProvider.tsx
@@ -342,35 +342,6 @@ const Provider = ({ children }: PropsWithChildren) => {
     };
   }, [messagePassingListener]);
 
-  const tabUpdateListener = useCallback(
-    async (_tabId: number, changeInfo: chrome.tabs.TabChangeInfo) => {
-      const tabId = chrome.devtools.inspectedWindow.tabId;
-      if (tabId === _tabId && changeInfo.url) {
-        setIsInspecting(false);
-        try {
-          const nextURL = new URL(changeInfo.url);
-          const nextDomain = nextURL?.hostname;
-          const currentURL = new URL(tabUrl ?? '');
-          const currentDomain = currentURL?.hostname;
-
-          if (selectedFrame && nextDomain === currentDomain) {
-            setSelectedFrame(nextURL.origin);
-          } else {
-            setSelectedFrame(null);
-          }
-
-          setTabUrl(changeInfo.url);
-        } catch (error) {
-          setSelectedFrame(null);
-        } finally {
-          setTabFrames(null);
-          await getAllFramesForCurrentTab();
-        }
-      }
-    },
-    [tabUrl, getAllFramesForCurrentTab, selectedFrame]
-  );
-
   const tabRemovedListener = useCallback(async () => {
     try {
       const availableTabs = await chrome.tabs.query({});
@@ -394,13 +365,11 @@ const Provider = ({ children }: PropsWithChildren) => {
   }, [intitialSync]);
 
   useEffect(() => {
-    chrome.tabs.onUpdated.addListener(tabUpdateListener);
     chrome.tabs.onRemoved.addListener(tabRemovedListener);
     return () => {
-      chrome.tabs.onUpdated.removeListener(tabUpdateListener);
       chrome.tabs.onRemoved.removeListener(tabRemovedListener);
     };
-  }, [tabUpdateListener, tabRemovedListener]);
+  }, [tabRemovedListener]);
 
   useEffect(() => {
     loadingTimeout.current = setTimeout(() => {

--- a/packages/extension/src/view/devtools/stateProviders/protectedAudience/context.ts
+++ b/packages/extension/src/view/devtools/stateProviders/protectedAudience/context.ts
@@ -16,6 +16,7 @@
 /**
  * External dependencies.
  */
+import React from 'react';
 import {
   createContext,
   type AuctionEventsType,
@@ -23,6 +24,7 @@ import {
   type ReceivedBids,
   type NoBidsType,
   type AdsAndBiddersType,
+  noop,
 } from '@google-psat/common';
 
 export interface ProtectedAudienceContextType {
@@ -33,6 +35,10 @@ export interface ProtectedAudienceContextType {
     receivedBids: ReceivedBids[];
     noBids: NoBidsType;
     adsAndBidders: AdsAndBiddersType;
+    selectedAdUnit: string | null;
+  };
+  actions: {
+    setSelectedAdUnit: React.Dispatch<React.SetStateAction<string | null>>;
   };
 }
 
@@ -44,6 +50,10 @@ const initialState: ProtectedAudienceContextType = {
     receivedBids: [],
     noBids: {},
     adsAndBidders: {},
+    selectedAdUnit: null,
+  },
+  actions: {
+    setSelectedAdUnit: noop,
   },
 };
 

--- a/packages/extension/src/view/devtools/stateProviders/protectedAudience/protectedAudienceProvider.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/protectedAudience/protectedAudienceProvider.tsx
@@ -218,11 +218,21 @@ const Provider = ({ children }: PropsWithChildren) => {
     },
     []
   );
-  const onCommittedNavigationListener = useCallback(() => {
-    setNoBids({});
-    setReceivedBids([]);
-    setAdsAndBidders({});
-  }, []);
+  const onCommittedNavigationListener = useCallback(
+    ({
+      frameId,
+      frameType,
+    }: chrome.webNavigation.WebNavigationFramedCallbackDetails) => {
+      if (frameType !== 'outermost_frame' && frameId !== 0) {
+        return;
+      }
+
+      setNoBids({});
+      setReceivedBids([]);
+      setAdsAndBidders({});
+    },
+    []
+  );
 
   useEffect(() => {
     chrome.runtime.onMessage.addListener(messagePassingListener);

--- a/packages/extension/src/view/devtools/stateProviders/protectedAudience/protectedAudienceProvider.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/protectedAudience/protectedAudienceProvider.tsx
@@ -53,6 +53,8 @@ const Provider = ({ children }: PropsWithChildren) => {
     ProtectedAudienceContextType['state']['interestGroupDetails']
   >([]);
 
+  const [selectedAdUnit, setSelectedAdUnit] = useState<string | null>(null);
+
   const [receivedBids, setReceivedBids] = useState<
     ProtectedAudienceContextType['state']['receivedBids']
   >([]);
@@ -138,11 +140,28 @@ const Provider = ({ children }: PropsWithChildren) => {
           if (computedBids) {
             const adUnitCodeToBidders: ProtectedAudienceContextType['state']['adsAndBidders'] =
               {};
-
             computedBids.receivedBids.forEach(
-              ({ adUnitCode, ownerOrigin, mediaContainerSize }) => {
+              ({
+                adUnitCode,
+                ownerOrigin,
+                mediaContainerSize,
+                bid,
+                bidCurrency,
+              }) => {
                 if (!adUnitCode) {
                   return;
+                }
+
+                let winningBid = bid ?? 0;
+                let winningBidder = ownerOrigin ?? '';
+
+                if (
+                  winningBid &&
+                  winningBid < adUnitCodeToBidders[adUnitCode]?.winningBid
+                ) {
+                  winningBid = adUnitCodeToBidders[adUnitCode]?.winningBid;
+                  winningBidder =
+                    adUnitCodeToBidders[adUnitCode]?.winningBidder;
                 }
 
                 adUnitCodeToBidders[adUnitCode] = {
@@ -163,6 +182,9 @@ const Provider = ({ children }: PropsWithChildren) => {
                       )
                     ),
                   ],
+                  bidCurrency: bidCurrency ?? '',
+                  winningBid,
+                  winningBidder,
                 };
               }
             );
@@ -196,14 +218,23 @@ const Provider = ({ children }: PropsWithChildren) => {
     },
     []
   );
+  const onCommittedNavigationListener = useCallback(() => {
+    setNoBids({});
+    setReceivedBids([]);
+    setAdsAndBidders({});
+  }, []);
 
   useEffect(() => {
     chrome.runtime.onMessage.addListener(messagePassingListener);
+    chrome.webNavigation.onCommitted.addListener(onCommittedNavigationListener);
 
     return () => {
       chrome.runtime.onMessage.removeListener(messagePassingListener);
+      chrome.webNavigation.onCommitted.removeListener(
+        onCommittedNavigationListener
+      );
     };
-  }, [messagePassingListener]);
+  }, [messagePassingListener, onCommittedNavigationListener]);
 
   const memoisedValue: ProtectedAudienceContextType = useMemo(() => {
     return {
@@ -214,9 +245,14 @@ const Provider = ({ children }: PropsWithChildren) => {
         receivedBids,
         noBids,
         adsAndBidders,
+        selectedAdUnit,
+      },
+      actions: {
+        setSelectedAdUnit,
       },
     };
   }, [
+    selectedAdUnit,
     auctionEvents,
     interestGroupDetails,
     isMultiSellerAuction,

--- a/packages/extension/src/view/devtools/stateProviders/protectedAudience/useProtectedAudience.ts
+++ b/packages/extension/src/view/devtools/stateProviders/protectedAudience/useProtectedAudience.ts
@@ -23,8 +23,8 @@ import { useContextSelector } from '@google-psat/common';
  */
 import Context, { type ProtectedAudienceContextType } from './context';
 
-export function useCookie(): ProtectedAudienceContextType;
-export function useCookie<T>(
+export function useProtectedAudience(): ProtectedAudienceContextType;
+export function useProtectedAudience<T>(
   selector: (state: ProtectedAudienceContextType) => T
 ): T;
 
@@ -33,7 +33,7 @@ export function useCookie<T>(
  * @param selector Selector function to partially select state.
  * @returns selected part of the state
  */
-export function useCookie<T>(
+export function useProtectedAudience<T>(
   selector: (
     state: ProtectedAudienceContextType
   ) => T | ProtectedAudienceContextType = (state) => state
@@ -41,4 +41,4 @@ export function useCookie<T>(
   return useContextSelector(Context, selector);
 }
 
-export default useCookie;
+export default useProtectedAudience;

--- a/packages/extension/src/view/devtools/stateProviders/protectedAudience/utils/computeInterestGroupDetails.ts
+++ b/packages/extension/src/view/devtools/stateProviders/protectedAudience/utils/computeInterestGroupDetails.ts
@@ -41,22 +41,29 @@ function computeInterestGroupDetails(
             details: {},
           };
         }
+        let result;
+        try {
+          result = (await chrome.debugger.sendCommand(
+            { tabId: chrome.devtools.inspectedWindow.tabId },
+            'Storage.getInterestGroupDetails',
+            {
+              name: event?.name,
+              ownerOrigin: event?.ownerOrigin,
+            }
+          )) as Protocol.Storage.GetInterestGroupDetailsResponse;
 
-        const result = (await chrome.debugger.sendCommand(
-          { tabId: chrome.devtools.inspectedWindow.tabId },
-          'Storage.getInterestGroupDetails',
-          {
-            name: event?.name,
-            ownerOrigin: event?.ownerOrigin,
-          }
-        )) as Protocol.Storage.GetInterestGroupDetailsResponse;
-
-        return {
-          ...event,
-          details: {
-            ...result.details,
-          },
-        };
+          return {
+            ...event,
+            details: {
+              ...result.details,
+            },
+          };
+        } catch (error) {
+          //Fail silently.
+          return {
+            ...event,
+          };
+        }
       })
   );
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -234,6 +234,9 @@ module.exports = {
       'baby-blue-eyes': '#A8C7FA',
       'leaf-green-dark': '#87DFB2',
       sapphire: '#0B57D0',
+      platinum: '#E5E5E5',
+      'anti-flash-white': '#F1F3F4',
+      'dark-gray-x11': '#A9A9A9',
       'dark-grey': '#AAAAAA',
     },
     colors: {

--- a/tests/shared.jest.config.cjs
+++ b/tests/shared.jest.config.cjs
@@ -22,7 +22,9 @@ const chrome = require('sinon-chrome/extensions');
 /** @type {import('jest').Config} */
 module.exports = {
   rootDir: '../',
-  transformIgnorePatterns: ['node_modules/(?!(p-queue|p-timeout))'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(p-queue|p-timeout|pretty-print-json))',
+  ],
   moduleNameMapper: {
     '^@google-psat\\/(.*)': '<rootDir>/packages/$1/src/',
     '\\.svg': join(__dirname, '/svgMock.cjs'),


### PR DESCRIPTION
## Description
This PR updates UI components and processing logic for rendering PA data from the service worker.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open the Privacy Sandbox panel and navigate to Protected Audience.
- Visit https://psat-pat-demos-shop.dev/items/1f45f?auctionType=multi, it should update the interest group table.
- Then visit https://psat-pat-demos-news.dev/?auctionType=multi to preview the ads related data in interest group, auctions, ad units and bids table.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/user-attachments/assets/346b826c-f6d3-4f8f-a92c-d70823d73d6c


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #785 #786 
