### PR TITLE
Fix: Issues on PAT panels

### DIFF
--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/index.tsx
@@ -28,7 +28,6 @@ import {
 } from '@google-psat/design-system';
 import { I18n } from '@google-psat/i18n';
 import classNames from 'classnames';
-import ExplorableExplanation from './explorableExplanation';
 
 /**
  * Internal dependencies.
@@ -62,12 +61,6 @@ const ProtectedAudience = () => {
             infoKey: PSInfoKey.ProtectedAudience,
           },
           className: 'p-4',
-        },
-      },
-      {
-        title: 'Explorable Explanation',
-        content: {
-          Element: ExplorableExplanation,
         },
       },
       {

--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/index.tsx
@@ -77,6 +77,7 @@ const Topics = () => {
             githubUrl:
               'https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v2.md',
           },
+          className: 'overflow-hidden',
         },
       },
       {
@@ -89,6 +90,7 @@ const Topics = () => {
             githubUrl:
               'https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md',
           },
+          className: 'overflow-hidden',
         },
       },
     ],

--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/taxonomyTree/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/taxonomyTree/index.tsx
@@ -104,10 +104,14 @@ const TaxonomyTree = ({ taxonomyUrl, githubUrl }: TaxonomyTreeProps) => {
     const nodeIds = value.split('/');
 
     nodeIds.forEach((id, idx) => {
-      const _id = id.trim().split(' ').join('') || 'tax-tree-root-node'; // if no id is provided it's the root of the tree
+      const _id = id.trim().split(' ').join('');
       const nextId = nodeIds[idx + 1]?.trim().split(' ').join('');
 
-      clicker(_id, nextId);
+      if (idx !== 0 && _id === '') {
+        return;
+      }
+
+      clicker(_id || 'tax-tree-root-node', nextId); // if no id is provided it's the root of the tree
     });
   }, []);
 
@@ -124,7 +128,7 @@ const TaxonomyTree = ({ taxonomyUrl, githubUrl }: TaxonomyTreeProps) => {
   }, []);
 
   return (
-    <div className="relative">
+    <div className="relative h-full flex flex-col">
       <SearchDropdown values={taxonomyArray} onSelect={nodeClickHandler} />
       <a
         href={githubUrl}
@@ -138,7 +142,7 @@ const TaxonomyTree = ({ taxonomyUrl, githubUrl }: TaxonomyTreeProps) => {
           width="14"
         />
       </a>
-      <div className="p-4" ref={divRef} />
+      <div className="p-4 overflow-auto" ref={divRef} />
     </div>
   );
 };

--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/taxonomyTree/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/taxonomyTree/index.tsx
@@ -103,7 +103,7 @@ const TaxonomyTree = ({ taxonomyUrl, githubUrl }: TaxonomyTreeProps) => {
     const nodeIds = value.split('/');
 
     nodeIds.forEach((id, idx) => {
-      const _id = id.trim().split(' ').join('');
+      const _id = id.trim().split(' ').join('') || 'tax-tree-root-node'; // if no id is provided it's the root of the tree
       const nextId = nodeIds[idx + 1]?.trim().split(' ').join('');
 
       clicker(_id, nextId);

--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/taxonomyTree/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/taxonomyTree/index.tsx
@@ -72,23 +72,22 @@ const TaxonomyTree = ({ taxonomyUrl, githubUrl }: TaxonomyTreeProps) => {
 
   const nodeClickHandler = useCallback((value: string) => {
     const clicker = (id: string, nextId?: string) => {
-      if (nextId && document.getElementById(nextId)) {
-        return;
-      }
+      const shouldClick = Boolean(!(nextId && document.getElementById(nextId)));
 
       const svgGroup = document.getElementById(id);
 
       if (svgGroup) {
-        const clickEvent = new MouseEvent('click', {
-          view: window,
-          bubbles: true,
-          cancelable: true,
-        });
+        if (shouldClick) {
+          const clickEvent = new MouseEvent('click', {
+            view: window,
+            bubbles: true,
+            cancelable: true,
+          });
 
-        svgGroup.dispatchEvent(clickEvent);
+          svgGroup.dispatchEvent(clickEvent);
+        }
 
         svgGroup.scrollIntoView({ behavior: 'smooth', block: 'center' });
-
         svgGroup.style.fill = 'orangered';
         svgGroup.style.transition = 'fill 1s';
 

--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/taxonomyTree/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/taxonomyTree/index.tsx
@@ -39,7 +39,7 @@ interface TaxonomyTreeProps {
 
 const TaxonomyTree = ({ taxonomyUrl, githubUrl }: TaxonomyTreeProps) => {
   const divRef = useRef<HTMLDivElement>(null);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const [taxonomyArray, setTaxonomyArray] = useState<string[]>([]);
 
   useEffect(() => {
@@ -92,11 +92,13 @@ const TaxonomyTree = ({ taxonomyUrl, githubUrl }: TaxonomyTreeProps) => {
         svgGroup.style.fill = 'orangered';
         svgGroup.style.transition = 'fill 1s';
 
-        timeoutRef.current = setTimeout(() => {
+        const timeout = setTimeout(() => {
           svgGroup.style.fill = '';
           svgGroup.style.fontWeight = '';
           svgGroup.style.transition = '';
         }, 3000);
+
+        timeoutRef.current.push(timeout);
       }
     };
 
@@ -111,9 +113,13 @@ const TaxonomyTree = ({ taxonomyUrl, githubUrl }: TaxonomyTreeProps) => {
   }, []);
 
   useEffect(() => {
+    const timeouts = timeoutRef.current;
+
     return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
+      if (timeouts) {
+        timeouts.forEach((timeout) => {
+          clearTimeout(timeout);
+        });
       }
     };
   }, []);

--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/taxonomyTree/tree.js
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/taxonomyTree/tree.js
@@ -131,7 +131,10 @@ const Tree = async (
     const nodeEnter = node
       .enter()
       .append('g')
-      .attr('id', (d) => d.data.name.split(' ').join(''))
+      .attr(
+        'id',
+        (d) => d.data.name.split(' ').join('') || 'tax-tree-root-node'
+      ) // if no name means it is root of the tree
       .attr('transform', () => `translate(${source.y0},${source.x0})`)
       .attr('fill-opacity', 0)
       .attr('stroke-opacity', 0)


### PR DESCRIPTION
## Description
This PR fixes issues on PAT panels

- EE PAT doesn't have animation integrated, so removed it from the tabs.
- Handle the issue of the search not working if the root node is closed.
- Handle highlighting of the node on the path of the searched node.
- Search bar in sticky in Topics Taxonomy tree
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open PSAT and navigate to the Protected Audience panel.
- The EE tab should not be visible.
- Now navigate to the Topics panel.
- Inside the Taxonomy panel, collapse the root and search for any topic.
- It should open the correct path for the topic.
- Now search `TV dramas` in the search bar, and open the tree path through the dropdown.
- Click on Arts and Entertainment node, and close child nodes.
- Again search for `TV dramas`  and open it.
- It should highlight all the nodes on the path.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
