### PR TITLE
Feature: Add previous and next buttons for EE PA

### DIFF
--- a/packages/explorable-explanations/public/index.html
+++ b/packages/explorable-explanations/public/index.html
@@ -13,6 +13,20 @@
         <div id="ps-canvas">
             <div id="canvas-container">
                 <div class="controls">
+                    <button id="previous-div" disabled class="play-pause-button">
+                        <svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px"
+                            fill="#808080">
+                            <path
+                                d="M220-240v-480h80v480h-80Zm520 0L380-480l360-240v480Zm-80-240Zm0 90v-180l-136 90 136 90Z" />
+                        </svg>
+                    </button>
+                    <button id="next-div" class="play-pause-button">
+                        <svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px"
+                            fill="#808080">
+                            <path
+                                d="M660-240v-480h80v480h-80Zm-440 0v-480l360 240-360 240Zm80-240Zm0 90 136-90-136-90v180Z" />
+                        </svg>
+                    </button>
                     <div class="play-pause-button" id="play-pause-button">
                         <button id="play" class="hidden">
                             <img src="./icons/play-button.png" alt="play" />

--- a/packages/explorable-explanations/src/components/branches.js
+++ b/packages/explorable-explanations/src/components/branches.js
@@ -53,7 +53,7 @@ const Branches = async ({ x1, y1, branches }) => {
 
   return new Promise((resolve) => {
     const animate = () => {
-      if (window.cancelPromise) {
+      if (window.cancelPromise || window.cancelPromiseForPreviousAndNext) {
         resolve(endpoints);
         return;
       }
@@ -96,7 +96,7 @@ const drawAnimatedTimeline = (x, y, branches) => {
     // Draw the horizontal line
     p.line(x, y, x + progress, y);
 
-    if (window.cancelPromise) {
+    if (window.cancelPromise || window.cancelPromiseForPreviousAndNext) {
       resolve();
       return;
     }

--- a/packages/explorable-explanations/src/components/progressLine.js
+++ b/packages/explorable-explanations/src/components/progressLine.js
@@ -51,7 +51,7 @@ const ProgressLine = ({
 
   return new Promise((resolve) => {
     const animate = () => {
-      if (window.cancelPromise) {
+      if (window.cancelPromise || window.cancelPromiseForPreviousAndNext) {
         resolve();
         return;
       }

--- a/packages/explorable-explanations/src/lib/ripple-effect.js
+++ b/packages/explorable-explanations/src/lib/ripple-effect.js
@@ -46,7 +46,7 @@ rippleEffect.start = (x = 0, y = 0) => {
     config.rippleEffect.rippled = true;
 
     const animate = (timestamp) => {
-      if (window.cancelPromise) {
+      if (window.cancelPromise || window.cancelPromiseForPreviousAndNext) {
         resolve();
         return;
       }

--- a/packages/explorable-explanations/src/lib/utils.js
+++ b/packages/explorable-explanations/src/lib/utils.js
@@ -352,9 +352,15 @@ utils.markVisitedValue = (index, value) => {
 };
 
 utils.disableButtons = () => {
+  app.prevButton.style.cursor =
+    app.timeline.currentIndex > 0 ? 'pointer' : 'default';
   app.prevButton.disabled = app.timeline.currentIndex > 0 ? false : true;
   app.nextButton.disabled =
     app.timeline.currentIndex === config.timeline.circles.length ? true : false;
+  app.nextButton.style.cursor =
+    app.timeline.currentIndex === config.timeline.circles.length
+      ? 'default'
+      : 'pointer';
 };
 
 export default utils;

--- a/packages/explorable-explanations/src/lib/utils.js
+++ b/packages/explorable-explanations/src/lib/utils.js
@@ -356,9 +356,11 @@ utils.disableButtons = () => {
     app.timeline.currentIndex > 0 ? 'pointer' : 'default';
   app.prevButton.disabled = app.timeline.currentIndex > 0 ? false : true;
   app.nextButton.disabled =
-    app.timeline.currentIndex === config.timeline.circles.length ? true : false;
+    app.timeline.currentIndex === config.timeline.circles.length - 1
+      ? true
+      : false;
   app.nextButton.style.cursor =
-    app.timeline.currentIndex === config.timeline.circles.length
+    app.timeline.currentIndex === config.timeline.circles.length - 1
       ? 'default'
       : 'pointer';
 };

--- a/packages/explorable-explanations/src/lib/utils.js
+++ b/packages/explorable-explanations/src/lib/utils.js
@@ -127,6 +127,16 @@ utils.triangle = (size, x, y, direction = 'right', color = 'black') => {
 utils.delay = (ms) => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
+
+utils.wipeAndRecreateMainCanvas = () => {
+  const { height, width } = utils.calculateCanvasDimensions();
+  const canvas = app.p.createCanvas(width, height);
+  canvas.parent('ps-canvas');
+  canvas.style('z-index', 0);
+  app.p.background(config.canvas.background);
+  app.p.textSize(config.canvas.fontSize);
+};
+
 utils.wipeAndRecreateInterestCanvas = () => {
   const { height, width } = utils.calculateCanvasDimensions();
   const overlayCanvas = app.igp.createCanvas(width, height);
@@ -330,6 +340,21 @@ utils.isOverControls = (mouseX, mouseY) => {
   }
 
   return false;
+};
+
+utils.markVisitedValue = (index, value) => {
+  config.timeline.circles = config.timeline.circles.map((circle, i) => {
+    if (i < index && index >= 0) {
+      circle.visited = value;
+    }
+    return circle;
+  });
+};
+
+utils.disableButtons = () => {
+  app.prevButton.disabled = app.timeline.currentIndex > 0 ? false : true;
+  app.nextButton.disabled =
+    app.timeline.currentIndex === config.timeline.circles.length ? true : false;
 };
 
 export default utils;

--- a/packages/explorable-explanations/src/lib/utils.js
+++ b/packages/explorable-explanations/src/lib/utils.js
@@ -360,7 +360,7 @@ utils.disableButtons = () => {
       ? true
       : false;
   app.nextButton.style.cursor =
-    app.timeline.currentIndex === config.timeline.circles.length - 1
+    app.timeline.currentIndex >= config.timeline.circles.length - 1
       ? 'default'
       : 'pointer';
 };

--- a/packages/explorable-explanations/src/modules/auctions.js
+++ b/packages/explorable-explanations/src/modules/auctions.js
@@ -300,7 +300,7 @@ auction.draw = async (index) => {
   }
 
   for (const step of steps) {
-    if (window.cancelPromise) {
+    if (window.cancelPromise || window.cancelPromiseForPreviousAndNext) {
       return;
     }
 

--- a/packages/explorable-explanations/src/modules/bubbles.js
+++ b/packages/explorable-explanations/src/modules/bubbles.js
@@ -555,12 +555,17 @@ bubbles.clearAndRewriteBubbles = () => {
 
 bubbles.calculateTotalBubblesForAnimation = (index) => {
   let bubblesCount = 0;
+  if (config.isInteractiveMode) {
+    config.timeline.circles.forEach((circle) => {
+      if (circle.visited) {
+        bubblesCount += circle.igGroupsCount ?? 0;
+      }
+    });
+    return bubblesCount;
+  }
 
   config.timeline.circles.forEach((circle, currIndex) => {
-    if (
-      (currIndex < index && !config.isInteractiveMode) ||
-      (currIndex <= index && config.isInteractiveMode)
-    ) {
+    if (currIndex < index && !config.isInteractiveMode) {
       bubblesCount += circle.igGroupsCount ?? 0;
     }
   });

--- a/packages/explorable-explanations/src/modules/bubbles.js
+++ b/packages/explorable-explanations/src/modules/bubbles.js
@@ -52,6 +52,7 @@ bubbles.init = () => {
 bubbles.generateBubbles = (recalculate = false) => {
   const interestGroupsToBeAdded =
     config.timeline.circles[app.timeline.currentIndex]?.igGroupsCount ?? 0;
+
   if (!recalculate) {
     for (let index = 0; index < interestGroupsToBeAdded; index++) {
       app.bubbles.positions.push({
@@ -427,6 +428,7 @@ bubbles.bubbleChart = (
   const totalBubbles = bubbles.calculateTotalBubblesForAnimation(
     app.timeline.currentIndex
   );
+
   data = data.filter((_data, i) => {
     if (i < totalBubbles) {
       return true;

--- a/packages/explorable-explanations/src/modules/bubbles.js
+++ b/packages/explorable-explanations/src/modules/bubbles.js
@@ -246,6 +246,7 @@ bubbles.reverseBarrageAnimation = async (index) => {
     const target = igp.createVector(midPointX, midPointY);
     const { color: currentColor } = app.bubbles.positions[i];
     const color = currentColor;
+
     positionsOfCircles.push({
       x:
         dspTags?.props?.x() +

--- a/packages/explorable-explanations/src/modules/bubbles.js
+++ b/packages/explorable-explanations/src/modules/bubbles.js
@@ -565,7 +565,7 @@ bubbles.calculateTotalBubblesForAnimation = (index) => {
   }
 
   config.timeline.circles.forEach((circle, currIndex) => {
-    if (currIndex < index && !config.isInteractiveMode) {
+    if (currIndex < index) {
       bubblesCount += circle.igGroupsCount ?? 0;
     }
   });

--- a/packages/explorable-explanations/src/modules/bubbles.js
+++ b/packages/explorable-explanations/src/modules/bubbles.js
@@ -437,7 +437,7 @@ bubbles.bubbleChart = (
   if (data.length === 0) {
     return null;
   }
-  //console.log(data)
+
   const values = d3.map(data, value);
   const groups = groupFn === null ? null : d3.map(data, groupFn);
   const groupIntervals = d3.range(values.length).filter((i) => values[i] > 0);

--- a/packages/explorable-explanations/src/modules/bubbles.js
+++ b/packages/explorable-explanations/src/modules/bubbles.js
@@ -246,7 +246,6 @@ bubbles.reverseBarrageAnimation = async (index) => {
     const target = igp.createVector(midPointX, midPointY);
     const { color: currentColor } = app.bubbles.positions[i];
     const color = currentColor;
-
     positionsOfCircles.push({
       x:
         dspTags?.props?.x() +

--- a/packages/explorable-explanations/src/modules/bubbles.js
+++ b/packages/explorable-explanations/src/modules/bubbles.js
@@ -70,7 +70,6 @@ bubbles.generateBubbles = (recalculate = false) => {
 
     const groups = d3.map(app.bubbles.positions, (d) => d.group);
     const color = d3.scaleOrdinal(groups, d3.schemeTableau10);
-
     app.bubbles.positions = app.bubbles.positions.map((data, i) => {
       return {
         ...data,
@@ -143,7 +142,7 @@ bubbles.barrageAnimation = async (index) => {
         return;
       }
 
-      if (window.cancelPromise) {
+      if (window.cancelPromise || window.cancelPromiseForPreviousAndNext) {
         resolve();
         return;
       }
@@ -247,7 +246,6 @@ bubbles.reverseBarrageAnimation = async (index) => {
     const target = igp.createVector(midPointX, midPointY);
     const { color: currentColor } = app.bubbles.positions[i];
     const color = currentColor;
-
     positionsOfCircles.push({
       x:
         dspTags?.props?.x() +
@@ -272,7 +270,7 @@ bubbles.reverseBarrageAnimation = async (index) => {
         return;
       }
 
-      if (window.cancelPromise) {
+      if (window.cancelPromise || window.cancelPromiseForPreviousAndNext) {
         resolve();
         return;
       }
@@ -439,7 +437,7 @@ bubbles.bubbleChart = (
   if (data.length === 0) {
     return null;
   }
-
+  //console.log(data)
   const values = d3.map(data, value);
   const groups = groupFn === null ? null : d3.map(data, groupFn);
   const groupIntervals = d3.range(values.length).filter((i) => values[i] > 0);

--- a/packages/explorable-explanations/src/modules/bubbles.js
+++ b/packages/explorable-explanations/src/modules/bubbles.js
@@ -137,13 +137,13 @@ bubbles.barrageAnimation = async (index) => {
 
   await new Promise((resolve) => {
     const animate = () => {
-      if (app.timeline.isPaused) {
-        requestAnimationFrame(animate); // Keep the animation loop alive but paused.
+      if (window.cancelPromise || window.cancelPromiseForPreviousAndNext) {
+        resolve();
         return;
       }
 
-      if (window.cancelPromise || window.cancelPromiseForPreviousAndNext) {
-        resolve();
+      if (app.timeline.isPaused) {
+        requestAnimationFrame(animate); // Keep the animation loop alive but paused.
         return;
       }
 
@@ -265,13 +265,13 @@ bubbles.reverseBarrageAnimation = async (index) => {
 
   await new Promise((resolve) => {
     const animate = () => {
-      if (app.timeline.isPaused) {
-        requestAnimationFrame(animate);
+      if (window.cancelPromise || window.cancelPromiseForPreviousAndNext) {
+        resolve();
         return;
       }
 
-      if (window.cancelPromise || window.cancelPromiseForPreviousAndNext) {
-        resolve();
+      if (app.timeline.isPaused) {
+        requestAnimationFrame(animate);
         return;
       }
 

--- a/packages/explorable-explanations/src/modules/join-interest-group.js
+++ b/packages/explorable-explanations/src/modules/join-interest-group.js
@@ -150,7 +150,7 @@ joinInterestGroup.setUp = (index) => {
  */
 joinInterestGroup.draw = async (index) => {
   app.p.textAlign(app.p.CENTER, app.p.CENTER);
-
+  bubbles.generateBubbles();
   const steps = app.joinInterestGroup.joinings[index];
 
   if (!steps) {
@@ -173,8 +173,6 @@ joinInterestGroup.draw = async (index) => {
 
     await utils.delay(delay); // eslint-disable-line no-await-in-loop
   }
-
-  bubbles.generateBubbles();
 
   await bubbles.reverseBarrageAnimation(index);
 

--- a/packages/explorable-explanations/src/modules/join-interest-group.js
+++ b/packages/explorable-explanations/src/modules/join-interest-group.js
@@ -158,7 +158,7 @@ joinInterestGroup.draw = async (index) => {
   }
 
   for (const step of steps) {
-    if (window.cancelPromise) {
+    if (window.cancelPromise || window.cancelPromiseForPreviousAndNext) {
       return;
     }
 
@@ -184,10 +184,7 @@ joinInterestGroup.draw = async (index) => {
     bubbles.showMinifiedBubbles();
   }
 
-  if (window.cancelPromise && !config.isInteractiveMode) {
-    config.bubbles.interestGroupCounts =
-      bubbles.calculateTotalBubblesForAnimation(index);
-  } else {
+  if (!window.cancelPromiseForPreviousAndNext) {
     config.bubbles.interestGroupCounts +=
       config.timeline.circles[index]?.igGroupsCount ?? 0;
   }

--- a/packages/explorable-explanations/src/modules/join-interest-group.js
+++ b/packages/explorable-explanations/src/modules/join-interest-group.js
@@ -161,6 +161,7 @@ joinInterestGroup.draw = async (index) => {
     if (window.cancelPromise) {
       return;
     }
+
     const { component, props, callBack } = step;
 
     const returnValue = await component(props); // eslint-disable-line no-await-in-loop
@@ -183,8 +184,13 @@ joinInterestGroup.draw = async (index) => {
     bubbles.showMinifiedBubbles();
   }
 
-  config.bubbles.interestGroupCounts +=
-    config.timeline.circles[index]?.igGroupsCount ?? 0;
+  if (window.cancelPromise && !config.isInteractiveMode) {
+    config.bubbles.interestGroupCounts =
+      bubbles.calculateTotalBubblesForAnimation(index);
+  } else {
+    config.bubbles.interestGroupCounts +=
+      config.timeline.circles[index]?.igGroupsCount ?? 0;
+  }
 
   flow.clearBelowTimelineCircles();
 };

--- a/packages/explorable-explanations/src/modules/timeline.js
+++ b/packages/explorable-explanations/src/modules/timeline.js
@@ -32,6 +32,7 @@ const timeline = {};
  * and drawing the initial timeline and user icon.
  */
 timeline.init = () => {
+  app.timeline.circlePublisherIndices = [];
   config.timeline.circles.forEach((circle, index) => {
     if (circle.type === 'publisher') {
       app.timeline.circlePublisherIndices.push(index);
@@ -179,19 +180,16 @@ timeline.drawTimelineLine = () => {
   const p = app.p;
   let x = 0;
 
-  if (app.timeline.currentIndex === 0) {
-    p.push();
-    p.stroke(colors.grey);
-    p.line(
-      0,
-      yPositonForLine,
-      config.timeline.position.x +
-        circleVerticalSpace * (config.timeline.circles.length - 1),
-      yPositonForLine
-    );
-    p.pop();
-    return;
-  }
+  p.push();
+  p.stroke(colors.grey);
+  p.line(
+    0,
+    yPositonForLine,
+    config.timeline.position.x +
+      circleVerticalSpace * (config.timeline.circles.length - 1),
+    yPositonForLine
+  );
+  p.pop();
 
   while (
     x <=
@@ -200,7 +198,7 @@ timeline.drawTimelineLine = () => {
     app.timeline.currentIndex < config.timeline.circles.length
   ) {
     p.push();
-    p.stroke(26, 115, 232);
+    p.stroke(colors.visitedBlue);
     p.line(0, yPositonForLine, x, yPositonForLine);
     p.pop();
     x = x + 1;
@@ -269,7 +267,6 @@ timeline.eraseAndRedraw = () => {
   utils.wipeAndRecreateUserCanvas();
 
   if (currentIndex > 0) {
-    timeline.drawTimelineLine();
     let i = 0;
     while (i < currentIndex) {
       app.p.push();

--- a/packages/explorable-explanations/src/modules/timeline.js
+++ b/packages/explorable-explanations/src/modules/timeline.js
@@ -92,10 +92,10 @@ timeline.init = () => {
         utils.wipeAndRecreateUserCanvas();
         timeline.renderUserIcon();
         await app.drawFlows(clickedIndex);
+        config.timeline.circles[clickedIndex].visited = true;
         bubbles.clearAndRewriteBubbles();
         bubbles.showMinifiedBubbles();
         config.shouldRespondToClick = true;
-        config.timeline.circles[clickedIndex].visited = true;
         utils.wipeAndRecreateUserCanvas();
         timeline.renderUserIcon();
       }

--- a/packages/explorable-explanations/src/modules/timeline.js
+++ b/packages/explorable-explanations/src/modules/timeline.js
@@ -102,10 +102,10 @@ timeline.init = () => {
       }
     };
   } else {
-    app.timeline.drawTimelineLine();
-    app.timeline.renderUserIcon();
+    timeline.drawTimelineLine();
+    timeline.renderUserIcon();
   }
-  app.timeline.drawTimeline(config.timeline);
+  timeline.drawTimeline(config.timeline);
 };
 
 /**

--- a/packages/explorable-explanations/src/modules/timeline.js
+++ b/packages/explorable-explanations/src/modules/timeline.js
@@ -242,7 +242,6 @@ timeline.renderUserIcon = () => {
   }
 
   const user = config.timeline.user;
-  utils.wipeAndRecreateUserCanvas();
   timeline.eraseAndRedraw();
   utils.wipeAndRecreateInterestCanvas();
 
@@ -270,6 +269,8 @@ timeline.eraseAndRedraw = () => {
     });
     return;
   }
+
+  utils.wipeAndRecreateUserCanvas();
 
   if (currentIndex > 0) {
     let i = 0;

--- a/packages/explorable-explanations/src/modules/timeline.js
+++ b/packages/explorable-explanations/src/modules/timeline.js
@@ -135,30 +135,37 @@ timeline.drawTimeline = ({ position, circleProps, circles }) => {
   p.textAlign(p.CENTER, p.CENTER);
   // Draw circles and text at the timeline position
   circles.forEach((circleItem, index) => {
-    const xPositionForCircle =
-      config.timeline.position.x + diameter / 2 + circleVerticalSpace * index;
-    const yPositionForCircle = position.y + circleVerticalSpace;
+    if (!window.cancelPromiseForPreviousAndNext) {
+      const xPositionForCircle =
+        config.timeline.position.x + diameter / 2 + circleVerticalSpace * index;
+      const yPositionForCircle = position.y + circleVerticalSpace;
 
-    app.timeline.circlePositions.push({
-      x: xPositionForCircle,
-      y: yPositionForCircle,
-    });
+      app.timeline.circlePositions.push({
+        x: xPositionForCircle,
+        y: yPositionForCircle,
+      });
 
-    p.push();
-    p.stroke(config.timeline.colors.grey);
-    timeline.drawCircle(index);
-    p.pop();
+      p.push();
+      p.stroke(config.timeline.colors.grey);
+      timeline.drawCircle(index);
+      p.pop();
 
-    p.push();
-    p.fill(config.timeline.colors.black);
-    p.textSize(12);
-    p.strokeWeight(0.1);
-    p.textFont('ui-sans-serif');
-    if (!config.isInteractiveMode) {
-      p.text(circleItem.datetime, xPositionForCircle, position.y);
+      p.push();
+      p.fill(config.timeline.colors.black);
+      p.textSize(12);
+      p.strokeWeight(0.1);
+      p.textFont('ui-sans-serif');
+      if (!config.isInteractiveMode) {
+        p.text(circleItem.datetime, xPositionForCircle, position.y);
+      }
+      p.text(circleItem.website, xPositionForCircle, position.y + 20);
+      p.pop();
+    } else {
+      p.push();
+      p.stroke(config.timeline.colors.grey);
+      timeline.drawCircle(index);
+      p.pop();
     }
-    p.text(circleItem.website, xPositionForCircle, position.y + 20);
-    p.pop();
 
     timeline.drawLineAboveCircle(index);
   });

--- a/packages/explorable-explanations/src/modules/timeline.js
+++ b/packages/explorable-explanations/src/modules/timeline.js
@@ -242,7 +242,7 @@ timeline.renderUserIcon = () => {
   }
 
   const user = config.timeline.user;
-
+  utils.wipeAndRecreateUserCanvas();
   timeline.eraseAndRedraw();
   utils.wipeAndRecreateInterestCanvas();
 
@@ -270,8 +270,6 @@ timeline.eraseAndRedraw = () => {
     });
     return;
   }
-
-  utils.wipeAndRecreateUserCanvas();
 
   if (currentIndex > 0) {
     let i = 0;

--- a/packages/explorable-explanations/src/protectedAudience.js
+++ b/packages/explorable-explanations/src/protectedAudience.js
@@ -146,13 +146,11 @@ app.setupLoop = async () => {
     app.timeline.currentIndex < config.timeline.circles.length &&
     !config.isInteractiveMode
   ) {
+    window.cancelPromiseForPreviousAndNext = false;
     utils.disableButtons();
     if (window.cancelPromise) {
-      if (config.isInteractiveMode) {
-        return;
-      }
       window.cancelPromise = false;
-      continue;
+      return;
     }
 
     if (app.timeline.isPaused) {
@@ -166,7 +164,7 @@ app.setupLoop = async () => {
     // eslint-disable-next-line no-await-in-loop
     await app.drawFlows(app.timeline.currentIndex);
 
-    if (!window.cancelPromise && !config.isInteractiveMode) {
+    if (!window.cancelPromiseForPreviousAndNext) {
       app.timeline.currentIndex++;
     }
   }
@@ -189,7 +187,7 @@ app.handlePrevButton = () => {
     return;
   }
 
-  window.cancelPromise = true;
+  window.cancelPromiseForPreviousAndNext = true;
   app.timeline.currentIndex -= 1;
   app.prevButton.disabled = app.timeline.currentIndex > 0 ? false : true;
   utils.markVisitedValue(app.timeline.currentIndex, true);
@@ -208,10 +206,10 @@ app.handleNextButton = () => {
     return;
   }
 
-  window.cancelPromise = true;
-  bubbles.generateBubbles();
-  bubbles.showMinifiedBubbles();
+  window.cancelPromiseForPreviousAndNext = true;
   app.timeline.currentIndex += 1;
+  bubbles.generateBubbles(true);
+  bubbles.showMinifiedBubbles();
   utils.markVisitedValue(app.timeline.currentIndex, true);
   utils.wipeAndRecreateMainCanvas();
   timeline.drawTimelineLine();

--- a/packages/explorable-explanations/src/protectedAudience.js
+++ b/packages/explorable-explanations/src/protectedAudience.js
@@ -183,7 +183,7 @@ app.minifiedBubbleKeyPressListener = (event) => {
 };
 
 app.handlePrevButton = () => {
-  if (config.bubbles.isExpanded) {
+  if (config.bubbles.isExpanded || config.isInteractiveMode) {
     return;
   }
 
@@ -211,7 +211,7 @@ app.handlePrevButton = () => {
 };
 
 app.handleNextButton = () => {
-  if (config.bubbles.isExpanded) {
+  if (config.bubbles.isExpanded || config.isInteractiveMode) {
     return;
   }
 
@@ -294,6 +294,13 @@ app.toggleInteractiveMode = () => {
   config.bubbles.interestGroupCounts = 0;
   app.bubbles.minifiedSVG = null;
   app.bubbles.expandedSVG = null;
+  if (config.isInteractiveMode) {
+    app.prevButton.style.display = 'none';
+    app.nextButton.style.display = 'none';
+  } else {
+    app.prevButton.style.display = 'block';
+    app.nextButton.style.display = 'block';
+  }
 
   utils.setupInterestGroupCanvas(app.igp);
   utils.setupUserCanvas(app.up);

--- a/packages/explorable-explanations/src/protectedAudience.js
+++ b/packages/explorable-explanations/src/protectedAudience.js
@@ -192,6 +192,15 @@ app.handlePrevButton = () => {
   app.prevButton.disabled = app.timeline.currentIndex > 0 ? false : true;
   utils.markVisitedValue(app.timeline.currentIndex, true);
   bubbles.generateBubbles();
+  if (
+    app.bubbles.positions.length >
+    bubbles.calculateTotalBubblesForAnimation(app.timeline.currentIndex)
+  ) {
+    app.bubbles.positions = app.bubbles.positions.splice(
+      0,
+      bubbles.calculateTotalBubblesForAnimation(app.timeline.currentIndex)
+    );
+  }
   bubbles.showMinifiedBubbles();
   config.bubbles.interestGroupCounts =
     bubbles.calculateTotalBubblesForAnimation(app.timeline.currentIndex);
@@ -207,9 +216,18 @@ app.handleNextButton = () => {
   }
 
   window.cancelPromiseForPreviousAndNext = true;
-  app.timeline.currentIndex += 1;
-  bubbles.generateBubbles(true);
+  bubbles.generateBubbles();
   bubbles.showMinifiedBubbles();
+  if (
+    app.bubbles.positions.length >
+    bubbles.calculateTotalBubblesForAnimation(app.timeline.currentIndex + 1)
+  ) {
+    const endPosition =
+      app.bubbles.positions.length -
+      config.timeline.circles[app.timeline.currentIndex]?.igGroupsCount;
+    app.bubbles.positions = app.bubbles.positions.slice(0, endPosition);
+  }
+  app.timeline.currentIndex += 1;
   utils.markVisitedValue(app.timeline.currentIndex, true);
   utils.wipeAndRecreateMainCanvas();
   timeline.drawTimelineLine();

--- a/packages/explorable-explanations/src/protectedAudience.js
+++ b/packages/explorable-explanations/src/protectedAudience.js
@@ -202,6 +202,7 @@ app.handlePrevButton = () => {
   timeline.drawTimelineLine();
   timeline.drawTimeline(config.timeline);
   utils.disableButtons();
+
   if (app.timeline.isPaused) {
     timeline.renderUserIcon();
   }
@@ -222,6 +223,7 @@ app.handleNextButton = () => {
   config.bubbles.interestGroupCounts =
     bubbles.calculateTotalBubblesForAnimation(app.timeline.currentIndex);
   utils.disableButtons();
+
   if (app.timeline.isPaused) {
     timeline.renderUserIcon();
   }

--- a/packages/explorable-explanations/src/protectedAudience.js
+++ b/packages/explorable-explanations/src/protectedAudience.js
@@ -164,12 +164,13 @@ app.setupLoop = () => {
         app.timeline.currentIndex++;
       }
     }
-    setTimeout(loop, 100);
+
+    requestAnimationFrame(loop);
     timeline.eraseAndRedraw();
     timeline.renderUserIcon();
   };
 
-  loop();
+  requestAnimationFrame(loop);
 };
 
 app.drawFlows = async (index) => {

--- a/packages/explorable-explanations/src/protectedAudience.js
+++ b/packages/explorable-explanations/src/protectedAudience.js
@@ -147,6 +147,7 @@ app.setupLoop = () => {
       window.cancelPromise ||
       app.timeline.currentIndex >= config.timeline.circles.length
     ) {
+      timeline.eraseAndRedraw();
       return;
     }
 
@@ -158,14 +159,13 @@ app.setupLoop = () => {
       bubbles.showMinifiedBubbles();
       timeline.renderUserIcon();
 
-      // Draw flows for the current index
       await app.drawFlows(app.timeline.currentIndex);
 
       if (!window.cancelPromiseForPreviousAndNext) {
         app.timeline.currentIndex++;
       }
 
-      app.timeline.eraseAndRedraw();
+      timeline.eraseAndRedraw();
     }
     setTimeout(loop, 100);
   };

--- a/packages/explorable-explanations/src/protectedAudience.js
+++ b/packages/explorable-explanations/src/protectedAudience.js
@@ -191,20 +191,12 @@ app.handlePrevButton = () => {
   app.timeline.currentIndex -= 1;
   app.prevButton.disabled = app.timeline.currentIndex > 0 ? false : true;
   utils.markVisitedValue(app.timeline.currentIndex, true);
-  bubbles.generateBubbles();
-  if (
-    app.bubbles.positions.length >
-    bubbles.calculateTotalBubblesForAnimation(app.timeline.currentIndex)
-  ) {
-    app.bubbles.positions = app.bubbles.positions.splice(
-      0,
-      bubbles.calculateTotalBubblesForAnimation(app.timeline.currentIndex)
-    );
-  }
-  bubbles.showMinifiedBubbles();
-  config.bubbles.interestGroupCounts =
-    bubbles.calculateTotalBubblesForAnimation(app.timeline.currentIndex);
-  utils.wipeAndRecreateMainCanvas();
+  const totalBubbles = bubbles.calculateTotalBubblesForAnimation(
+    app.timeline.currentIndex
+  );
+
+  config.bubbles.interestGroupCounts = totalBubbles;
+  flow.clearBelowTimelineCircles();
   timeline.drawTimelineLine();
   timeline.drawTimeline(config.timeline);
   utils.disableButtons();
@@ -216,20 +208,10 @@ app.handleNextButton = () => {
   }
 
   window.cancelPromiseForPreviousAndNext = true;
-  bubbles.generateBubbles();
-  bubbles.showMinifiedBubbles();
-  if (
-    app.bubbles.positions.length >
-    bubbles.calculateTotalBubblesForAnimation(app.timeline.currentIndex + 1)
-  ) {
-    const endPosition =
-      app.bubbles.positions.length -
-      config.timeline.circles[app.timeline.currentIndex]?.igGroupsCount;
-    app.bubbles.positions = app.bubbles.positions.slice(0, endPosition);
-  }
+
   app.timeline.currentIndex += 1;
   utils.markVisitedValue(app.timeline.currentIndex, true);
-  utils.wipeAndRecreateMainCanvas();
+  flow.clearBelowTimelineCircles();
   timeline.drawTimelineLine();
   timeline.drawTimeline(config.timeline);
   config.bubbles.interestGroupCounts =
@@ -294,6 +276,7 @@ app.toggleInteractiveMode = () => {
   config.bubbles.interestGroupCounts = 0;
   app.bubbles.minifiedSVG = null;
   app.bubbles.expandedSVG = null;
+
   if (config.isInteractiveMode) {
     app.prevButton.style.display = 'none';
     app.nextButton.style.display = 'none';

--- a/packages/explorable-explanations/src/protectedAudience.js
+++ b/packages/explorable-explanations/src/protectedAudience.js
@@ -146,6 +146,7 @@ app.setupLoop = async () => {
     app.timeline.currentIndex < config.timeline.circles.length &&
     !config.isInteractiveMode
   ) {
+    utils.disableButtons();
     if (window.cancelPromise) {
       if (config.isInteractiveMode) {
         return;

--- a/packages/explorable-explanations/src/protectedAudience.js
+++ b/packages/explorable-explanations/src/protectedAudience.js
@@ -147,7 +147,6 @@ app.setupLoop = () => {
       window.cancelPromise ||
       app.timeline.currentIndex >= config.timeline.circles.length
     ) {
-      timeline.eraseAndRedraw();
       return;
     }
 
@@ -164,10 +163,10 @@ app.setupLoop = () => {
       if (!window.cancelPromiseForPreviousAndNext) {
         app.timeline.currentIndex++;
       }
-
-      timeline.eraseAndRedraw();
     }
     setTimeout(loop, 100);
+    timeline.eraseAndRedraw();
+    timeline.renderUserIcon();
   };
 
   loop();
@@ -204,7 +203,8 @@ app.handlePrevButton = () => {
   utils.disableButtons();
 
   if (app.timeline.isPaused) {
-    timeline.renderUserIcon();
+    bubbles.generateBubbles();
+    bubbles.showMinifiedBubbles();
   }
 };
 
@@ -225,7 +225,8 @@ app.handleNextButton = () => {
   utils.disableButtons();
 
   if (app.timeline.isPaused) {
-    timeline.renderUserIcon();
+    bubbles.generateBubbles();
+    bubbles.showMinifiedBubbles();
   }
 };
 
@@ -300,7 +301,7 @@ app.toggleInteractiveMode = () => {
   utils.setupMainCanvas(app.p);
   utils.markVisitedValue(config.timeline.circles.length, false);
 
-  app.timeline.eraseAndRedraw();
+  timeline.eraseAndRedraw();
 };
 
 // Write a callback function to get the value of the checkbox.

--- a/packages/explorable-explanations/src/protectedAudience.js
+++ b/packages/explorable-explanations/src/protectedAudience.js
@@ -167,8 +167,6 @@ app.setupLoop = async () => {
 
     if (!window.cancelPromise && !config.isInteractiveMode) {
       app.timeline.currentIndex++;
-      config.bubbles.interestGroupCounts =
-        bubbles.calculateTotalBubblesForAnimation(app.timeline.currentIndex);
     }
 
     if (app.timeline.currentIndex > 0) {
@@ -206,7 +204,11 @@ app.handleNextButton = () => {
     return;
   }
   window.cancelPromise = true;
+  bubbles.generateBubbles();
+  bubbles.showMinifiedBubbles();
   app.timeline.currentIndex += 1;
+  config.bubbles.interestGroupCounts =
+    bubbles.calculateTotalBubblesForAnimation(app.timeline.currentIndex);
   flow.clearBelowTimelineCircles();
 };
 


### PR DESCRIPTION
## Description
This PR aims to add Previous and Next buttons to the canvas where in if the user is in non-interactive mode and clicks on next button the user icon will move into the next website.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Clone this branch
- In the terminal run `npm run dev:ee:pa`.
- Now when animation is running click on next and previous button to see the effect

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
https://github.com/user-attachments/assets/f1d12af1-62d6-4896-90ed-df97aeb4c17f

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~[x] This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #857 
