### PR TITLE
Feature: Dynamic web stories from backend.

### DIFF
--- a/packages/extension/src/view/devtools/components/webStories/contentPanel.tsx
+++ b/packages/extension/src/view/devtools/components/webStories/contentPanel.tsx
@@ -16,7 +16,7 @@
 /**
  * External dependencies.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 /**
  * Internal dependencies.
  */
@@ -25,6 +25,57 @@ import { getStoryMarkup, type SingleStoryJSON } from './createStoryIframe';
 const WebStories = () => {
   const [storyMarkup, setStoryMarkup] = useState('');
 
+  const getAuthorsAndPublisherLogo = useCallback(
+    async (mediaAuthorSet: Record<number, string>) => {
+      const response = await fetch(
+        'https://privacysandbox-stories.com/wp-json/web-stories/v1/users'
+      );
+      const responseJSON = await response.json();
+      const transformedMediaAuthorMap: Record<
+        number,
+        Record<string, string>
+      > = {};
+
+      const authorNameIdMap: Record<number, string> = {};
+
+      responseJSON.forEach((singleResponse: Record<string, any>) => {
+        authorNameIdMap[singleResponse.id] = singleResponse.name;
+      });
+
+      await Promise.all(
+        Object.keys(mediaAuthorSet).map(async (key: string) => {
+          const mediaResponse = await fetch(
+            'https://privacysandbox-stories.com/wp-json/web-stories/v1/media/' +
+              mediaAuthorSet[Number(key)]
+          );
+
+          //Check the media response and get the avif/webp image if available else use source_url.
+          const mediaResponseJSON = await mediaResponse.json();
+          const sourceUrl = mediaResponseJSON.source_url;
+          const splittedUrl = sourceUrl.split('/');
+          const urlWithoutName = sourceUrl.substring(
+            0,
+            sourceUrl.length - splittedUrl[splittedUrl.length - 1].length
+          );
+
+          const avifResource =
+            urlWithoutName +
+            mediaResponseJSON?.media_details?.sources?.['image/avif']?.file;
+          const webpResource =
+            urlWithoutName +
+            mediaResponseJSON?.media_details?.sources?.['image/webp']?.file;
+
+          transformedMediaAuthorMap[Number(key)] = {
+            name: authorNameIdMap[Number(key)],
+            publisherLogo: avifResource ?? webpResource ?? sourceUrl,
+          };
+        })
+      );
+      return transformedMediaAuthorMap;
+    },
+    []
+  );
+
   useEffect(() => {
     (async () => {
       const response = await fetch(
@@ -32,21 +83,37 @@ const WebStories = () => {
       );
 
       const responseJSON = await response.json();
-      const storyJSON: SingleStoryJSON[] = [];
+      let storyJSON: SingleStoryJSON[] = [];
+      const mediaAuthorSet: Record<number, string> = {};
       responseJSON.forEach((singleResponse: any) => {
         if (singleResponse?.status === 'publish') {
+          mediaAuthorSet[singleResponse.author] =
+            singleResponse?.meta?.web_stories_publisher_logo;
+
           storyJSON.push({
             heroImage: singleResponse?.story_poster?.url ?? '',
-            publisherLogo: 'https://assets.codepen.io/1780597/1pizza_logo.png',
-            publisherName: '',
+            publisherLogo: singleResponse?.meta?.web_stories_publisher_logo,
+            publisherName: singleResponse?.author,
             storyTitle: singleResponse?.title?.rendered,
             storyUrl: `${singleResponse?.link}#embedMode=2`,
           });
         }
       });
+
+      const authorsAndPublisherLogoMap = await getAuthorsAndPublisherLogo(
+        mediaAuthorSet
+      );
+
+      storyJSON = storyJSON.map((story) => {
+        const key = Number(story.publisherName);
+        story.publisherName = authorsAndPublisherLogoMap[key]?.name;
+        story.publisherLogo = authorsAndPublisherLogoMap[key]?.publisherLogo;
+        return story;
+      });
+
       setStoryMarkup(getStoryMarkup(storyJSON));
     })();
-  }, []);
+  }, [getAuthorsAndPublisherLogo]);
 
   return (
     <div

--- a/packages/extension/src/view/devtools/components/webStories/contentPanel.tsx
+++ b/packages/extension/src/view/devtools/components/webStories/contentPanel.tsx
@@ -16,15 +16,37 @@
 /**
  * External dependencies.
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 /**
  * Internal dependencies.
  */
-import { getStoryMarkup } from './createStoryIframe';
-import { STORY_JSON } from './story';
+import { getStoryMarkup, type SingleStoryJSON } from './createStoryIframe';
 
 const WebStories = () => {
-  const storyMarkup = getStoryMarkup(STORY_JSON);
+  const [storyMarkup, setStoryMarkup] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      const response = await fetch(
+        'https://privacysandbox-stories.com/wp-json/web-stories/v1/web-story/'
+      );
+
+      const responseJSON = await response.json();
+      const storyJSON: SingleStoryJSON[] = [];
+      responseJSON.forEach((singleResponse: any) => {
+        if (singleResponse?.status === 'publish') {
+          storyJSON.push({
+            heroImage: singleResponse?.story_poster?.url ?? '',
+            publisherLogo: 'https://assets.codepen.io/1780597/1pizza_logo.png',
+            publisherName: '',
+            storyTitle: singleResponse?.title?.rendered,
+            storyUrl: `${singleResponse?.link}#embedMode=2`,
+          });
+        }
+      });
+      setStoryMarkup(getStoryMarkup(storyJSON));
+    })();
+  }, []);
 
   return (
     <div
@@ -32,6 +54,7 @@ const WebStories = () => {
       className="h-full w-full text-raisin-black dark:text-bright-gray overflow-y-auto"
     >
       <iframe
+        scrolling="yes"
         srcDoc={storyMarkup}
         style={{ width: '100%', height: '100vh', border: 'none' }}
       />


### PR DESCRIPTION
## Description
This PR aims to build dynamic stories from the backend response.

## Relevant Technical Choices
- Fetch the set of stories from the backend parse the response and generate a single story object that looks like the following:
```
{
  heroImage: string;
  publisherLogo: string;
  publisherName: string;
  storyTitle: string;
  storyUrl: string;
}
```

## Testing Instructions
- Clone this branch.
- In the terminal run `npm i && npm run build:ext`.
- Now go to example.com and open the DevTools and open Privacy Sandbox tab.
- You should see a section in sidebar titled as Explorable Explanation with Web-Stories Icon.
- Click on the section. A set of stories with their hero image should be rendered on the main content.
- Clicking on the hero image will result in the story opening in a light box.


## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
~~- [ ] This code is covered by unit tests to verify that it works as intended.~~
~~- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).~~

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
