### PR TITLE
Fix: Update Interest group table to show only join and leave events

### DIFF
--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/interestGroups/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/interestGroups/index.tsx
@@ -17,7 +17,7 @@
 /**
  * External dependencies.
  */
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { Resizable } from 're-resizable';
 import {
   Table,
@@ -65,6 +65,7 @@ const InterestGroups = ({ filters }: InterestGroupsProps) => {
   // }, []);
 
   const [selectedRow, setSelectedRow] = useState<TableData | null>(null);
+  const [filterData, setFilterData] = useState(false);
 
   const { interestGroupDetails } = useProtectedAudience(({ state }) => ({
     interestGroupDetails: state.interestGroupDetails,
@@ -77,6 +78,28 @@ const InterestGroups = ({ filters }: InterestGroupsProps) => {
   const { updateSelectedItemKey } = useSidebar(({ actions }) => ({
     updateSelectedItemKey: actions.updateSelectedItemKey,
   }));
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setFilterData(event.target.checked);
+    },
+    []
+  );
+
+  const topBarExtraInterface = useCallback(() => {
+    return (
+      <div className="flex items-center justify-center w-max gap-1">
+        <input
+          onChange={handleChange}
+          type="checkbox"
+          id="showAllEvents"
+          name="showAllEvents"
+          value="Show All Events"
+        />
+        <label htmlFor="showAllEvents">Show All Events</label>
+      </div>
+    );
+  }, [handleChange]);
 
   const tableColumns = useMemo<TableColumn[]>(
     () => [
@@ -192,7 +215,13 @@ const InterestGroups = ({ filters }: InterestGroupsProps) => {
         }}
       >
         <TableProvider
-          data={interestGroupDetails}
+          data={
+            filterData
+              ? interestGroupDetails
+              : interestGroupDetails.filter(
+                  (event) => event.type === 'leave' || event.type === 'join'
+                )
+          }
           tableColumns={tableColumns}
           tableFilterData={tableFilters}
           tableSearchKeys={undefined}
@@ -209,6 +238,7 @@ const InterestGroups = ({ filters }: InterestGroupsProps) => {
           }}
         >
           <Table
+            extraInterfaceToTopBar={topBarExtraInterface}
             selectedKey={
               (selectedRow?.uniqueAuctionId ?? '') + String(selectedRow?.time)
             }

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/interestGroups/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/interestGroups/index.tsx
@@ -88,15 +88,20 @@ const InterestGroups = ({ filters }: InterestGroupsProps) => {
 
   const topBarExtraInterface = useCallback(() => {
     return (
-      <div className="flex items-center justify-center w-max gap-1">
-        <input
-          onChange={handleChange}
-          type="checkbox"
-          id="showAllEvents"
-          name="showAllEvents"
-          value="Show All Events"
-        />
-        <label htmlFor="showAllEvents">Show All Events</label>
+      <div className="h-full flex items-center justify-center w-max gap-1">
+        <div className="h-full w-px bg-american-silver dark:bg-quartz mr-2" />
+        <div className="flex items-center justify-center w-max gap-1">
+          <input
+            onChange={handleChange}
+            type="checkbox"
+            id="showAllEvents"
+            name="showAllEvents"
+            value="Show All Events"
+          />
+          <label htmlFor="showAllEvents" className="text-xs leading-none">
+            Show All Events
+          </label>
+        </div>
       </div>
     );
   }, [handleChange]);

--- a/packages/extension/src/view/devtools/stateProviders/protectedAudience/protectedAudienceProvider.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/protectedAudience/protectedAudienceProvider.tsx
@@ -370,9 +370,7 @@ const Provider = ({ children }: PropsWithChildren) => {
     return {
       state: {
         auctionEvents,
-        interestGroupDetails: interestGroupDetails.filter(
-          (event) => event.type === 'leave' || event.type === 'join'
-        ),
+        interestGroupDetails,
         isMultiSellerAuction,
         receivedBids,
         noBids,

--- a/packages/extension/src/view/devtools/stateProviders/protectedAudience/protectedAudienceProvider.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/protectedAudience/protectedAudienceProvider.tsx
@@ -370,7 +370,9 @@ const Provider = ({ children }: PropsWithChildren) => {
     return {
       state: {
         auctionEvents,
-        interestGroupDetails,
+        interestGroupDetails: interestGroupDetails.filter(
+          (event) => event.type === 'leave' || event.type === 'join'
+        ),
         isMultiSellerAuction,
         receivedBids,
         noBids,

--- a/packages/extension/src/view/devtools/stateProviders/protectedAudience/utils/computeInterestGroupDetails.ts
+++ b/packages/extension/src/view/devtools/stateProviders/protectedAudience/utils/computeInterestGroupDetails.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * Internal dependencies
+ * External dependencies
  */
 import type { singleAuctionEvent } from '@google-psat/common';
 import type Protocol from 'devtools-protocol';
@@ -62,6 +62,7 @@ function computeInterestGroupDetails(
           //Fail silently.
           return {
             ...event,
+            details: {},
           };
         }
       })


### PR DESCRIPTION
## Description
In this PR, we are updating the interest group tables data only having `join` or `leave` events and filtering out the rest.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Clone this branch.
- In the terminal run `npm i && npm run build:ext`.
- Go to example.com and enable CDP and multi-tab debugging.
- Now in the same tab go to https://psat-pat-demos-shop.dev/items/1f45f
- Then in another tab go to https://psat-pat-demos-news.dev/
- The Interest Group Table in Protected Audience should now only show join events and not the bid and win events.

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
