### PR TITLE
Fix: Use `time` key for `Event Time` column

### DIFF
--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/auctionTable.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/auctionTable.tsx
@@ -50,8 +50,9 @@ const AuctionTable = ({
     () => [
       {
         header: 'Event Time',
-        accessorKey: 'formattedTime',
-        cell: (info) => info,
+        accessorKey: 'time',
+        cell: (_, details) =>
+          (details as singleAuctionEvent).formattedTime.toString(),
         enableHiding: false,
         widthWeightagePercentage: 10,
       },


### PR DESCRIPTION
## Description
This PR updates the key from `formattedTime` to `time`, used for showing Event time.
This change makes the sorting comparison based on ms in `number`.
In UI, the `formattedtime` key will be rendered to the event time, as it is already calculated while creation the data array in the service worker.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Navigate to https://privacysandboxdemos.domain-aaa.com/
- Open PSAT and navigate to Protected Audience -> Auctions.
- Add IG and run an auction, the table should get updated.
- Click on the Event time column, it should sort the rows correctly based on time.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
