### PR TITLE
Feature: Add double dropdown arrow in non interactive mode to show non animated flow.

### DIFF
--- a/packages/explorable-explanations/src/protectedAudience/index.js
+++ b/packages/explorable-explanations/src/protectedAudience/index.js
@@ -46,6 +46,7 @@ app.setUpTimeLine = () => {
   app.bubbles.positions = [];
   app.bubbles.minifiedSVG = null;
   app.timeline.currentIndex = 0;
+  app.timeline.expandIconPositions = [];
   bubbles.clearAndRewriteBubbles();
   app.setup();
 

--- a/packages/explorable-explanations/src/protectedAudience/index.js
+++ b/packages/explorable-explanations/src/protectedAudience/index.js
@@ -211,6 +211,10 @@ app.addToPromiseQueue = (indexToStartFrom) => {
     utils.markVisitedValue(app.timeline.currentIndex, true);
     timeline.eraseAndRedraw();
     timeline.renderUserIcon();
+    flow.clearBelowTimelineCircles();
+    app.timeline.expandIconPositions.forEach((position) => {
+      app.p.image(app.p.openWithoutAnimation, position.x, position.y, 20, 20);
+    });
     app.setCurrentSite(null);
 
     cb(null, true);

--- a/packages/explorable-explanations/src/protectedAudience/index.js
+++ b/packages/explorable-explanations/src/protectedAudience/index.js
@@ -155,10 +155,24 @@ app.minifiedBubbleClickListener = (event, expandOverride) => {
 
 app.addToPromiseQueue = (indexToStartFrom) => {
   let currentIndex = indexToStartFrom;
+
   while (currentIndex < config.timeline.circles.length) {
     app.promiseQueue.push((cb) => {
+      const { currentIndex: _currentIndex, circlePositions } = app.timeline;
+      const {
+        circleProps: { diameter },
+        circles,
+      } = config.timeline;
+
+      if (!circles.every(({ visited }) => visited === true)) {
+        app.timeline.expandIconPositions.push({
+          x: circlePositions[_currentIndex].x - 10,
+          y: circlePositions[_currentIndex].y + diameter / 2,
+          index: _currentIndex,
+        });
+      }
       flow.clearBelowTimelineCircles();
-      utils.markVisitedValue(app.timeline.currentIndex, true);
+      utils.markVisitedValue(_currentIndex, true);
       bubbles.generateBubbles();
       bubbles.showMinifiedBubbles();
       timeline.eraseAndRedraw();
@@ -169,9 +183,12 @@ app.addToPromiseQueue = (indexToStartFrom) => {
 
     app.drawFlows(currentIndex);
     app.promiseQueue.push((cb) => {
+      const { currentIndex: _currentIndex } = app.timeline;
+      const { circles } = config.timeline;
+
       app.bubbles.interestGroupCounts +=
-        config.timeline.circles[app.timeline.currentIndex]?.igGroupsCount ?? 0;
-      app.setCurrentSite(config.timeline.circles[app.timeline.currentIndex]);
+        circles[_currentIndex]?.igGroupsCount ?? 0;
+      app.setCurrentSite(circles[_currentIndex]);
 
       cb(null, true);
     });

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions.js
@@ -543,7 +543,7 @@ auction.draw = (index) => {
   }
 
   app.promiseQueue.push((cb) => {
-    if (!app.isRevisitingNodeInInteractiveMode || !app.isInteractiveMode) {
+    if (!app.isRevisitingNodeInInteractiveMode) {
       flow.clearBelowTimelineCircles();
     }
     cb(null, true);

--- a/packages/explorable-explanations/src/protectedAudience/modules/flow.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/flow.js
@@ -40,7 +40,7 @@ flow.getTimelineCircleCoordinates = (index) => {
     return { x: positions.x, y: positions.y + 20 + diameter / 2 };
   }
 
-  return { x: positions.x, y: positions.y + diameter / 2 };
+  return { x: positions.x, y: positions.y + 1.5 + diameter / 2 };
 };
 
 /**

--- a/packages/explorable-explanations/src/protectedAudience/modules/joinInterestGroup.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/joinInterestGroup.js
@@ -195,7 +195,7 @@ joinInterestGroup.draw = (index) => {
   });
 
   app.promiseQueue.push((cb) => {
-    if (!app.isRevisitingNodeInInteractiveMode || !app.isInteractiveMode) {
+    if (!app.isRevisitingNodeInInteractiveMode) {
       flow.clearBelowTimelineCircles();
     }
     cb(null, true);

--- a/packages/explorable-explanations/src/protectedAudience/modules/timeline.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/timeline.js
@@ -192,14 +192,6 @@ timeline.drawCircle = (index, completed = false) => {
 
   app.p.pop();
 
-  app.up.image(
-    app.p.openWithoutAnimation,
-    position.x - 10,
-    position.y + diameter / 2,
-    20,
-    20
-  );
-
   if (app.isInteractiveMode) {
     if (app.usedNextOrPrev && app.timeline.currentIndex === index) {
       app.up.image(
@@ -221,8 +213,27 @@ timeline.drawCircle = (index, completed = false) => {
     app.up.text(circles[index].visitedIndex ?? '', position.x, position.y);
     app.up.pop();
 
+    app.p.image(
+      app.p.openWithoutAnimation,
+      position.x - 10,
+      position.y + diameter / 2,
+      20,
+      20
+    );
+
     return;
   }
+
+  app.p.push();
+  app.p.tint(255, 90);
+  app.p.image(
+    app.p.openWithoutAnimation,
+    position.x - 10,
+    position.y + diameter / 2,
+    20,
+    20
+  );
+  app.p.pop();
 
   app.up.image(
     app.p.completedCheckMark,

--- a/packages/explorable-explanations/src/protectedAudience/modules/timeline.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/timeline.js
@@ -55,29 +55,7 @@ timeline.init = () => {
     if (app.isInteractiveMode) {
       timeline.mouseMovedInInteractiveModeCallback(event);
     } else {
-      let hoveringOnExpandIconPositions = false;
-      if (!config.timeline.circles.every(({ visited }) => visited === true)) {
-        return;
-      }
-      app.timeline.expandIconPositions.forEach((positions) => {
-        if (
-          isInsideCircle(
-            offsetX,
-            offsetY,
-            positions.x,
-            positions.y + config.timeline.circleProps.diameter / 2,
-            20
-          )
-        ) {
-          hoveringOnExpandIconPositions = true;
-        }
-      });
-
-      if (hoveringOnExpandIconPositions) {
-        app.p.cursor('pointer');
-      } else {
-        app.p.cursor('default');
-      }
+      timeline.mouseMovedInNonInteractiveModeCallback(event);
     }
   };
 
@@ -85,60 +63,7 @@ timeline.init = () => {
     if (app.isInteractiveMode) {
       timeline.mouseClickedInInteractiveModeCallback();
     } else {
-      const {
-        circleProps: { diameter },
-        circles,
-      } = config.timeline;
-
-      if (!circles.every(({ visited }) => visited === true)) {
-        return;
-      }
-
-      let clickedIndex = -1;
-      app.timeline.expandIconPositions.forEach((positions) => {
-        if (
-          isInsideCircle(
-            app.mouseX,
-            app.mouseY,
-            positions.x,
-            positions.y + diameter / 2,
-            20
-          )
-        ) {
-          clickedIndex = positions.index;
-        }
-      });
-
-      if (clickedIndex === -1) {
-        return;
-      }
-
-      flow.clearBelowTimelineCircles();
-
-      if (circles[clickedIndex].type === 'advertiser') {
-        app.joinInterestGroup.joinings[clickedIndex][0].props.y1 += 20;
-      } else {
-        app.auction.auctions[clickedIndex][0].props.y1 += 20;
-      }
-
-      app.isRevisitingNodeInInteractiveMode = true;
-      app.drawFlows(clickedIndex);
-
-      app.promiseQueue.push((cb) => {
-        app.shouldRespondToClick = true;
-        timeline.renderUserIcon();
-        app.isRevisitingNodeInInteractiveMode = false;
-
-        if (circles[clickedIndex].type === 'advertiser') {
-          app.joinInterestGroup.joinings[clickedIndex][0].props.y1 -= 20;
-        } else {
-          app.auction.auctions[clickedIndex][0].props.y1 -= 20;
-        }
-
-        cb(null, true);
-      });
-
-      app.promiseQueue.start();
+      timeline.mouseClickedInNonInteractiveModeCallback();
     }
   };
 
@@ -585,6 +510,94 @@ timeline.mouseClickedInInteractiveModeCallback = () => {
     wipeAndRecreateMainCanvas();
     return;
   }
+};
+
+timeline.mouseMovedInNonInteractiveModeCallback = () => {
+  const { offsetX, offsetY } = event;
+
+  app.mouseX = offsetX;
+  app.mouseY = offsetY;
+
+  let hoveringOnExpandIconPositions = false;
+  if (!config.timeline.circles.every(({ visited }) => visited === true)) {
+    return;
+  }
+  app.timeline.expandIconPositions.forEach((positions) => {
+    if (
+      isInsideCircle(
+        offsetX,
+        offsetY,
+        positions.x,
+        positions.y + config.timeline.circleProps.diameter / 2,
+        20
+      )
+    ) {
+      hoveringOnExpandIconPositions = true;
+    }
+  });
+
+  if (hoveringOnExpandIconPositions) {
+    app.p.cursor('pointer');
+  } else {
+    app.p.cursor('default');
+  }
+};
+
+timeline.mouseClickedInNonInteractiveModeCallback = () => {
+  const {
+    circleProps: { diameter },
+    circles,
+  } = config.timeline;
+
+  if (!circles.every(({ visited }) => visited === true)) {
+    return;
+  }
+
+  let clickedIndex = -1;
+  app.timeline.expandIconPositions.forEach((positions) => {
+    if (
+      isInsideCircle(
+        app.mouseX,
+        app.mouseY,
+        positions.x,
+        positions.y + diameter / 2,
+        20
+      )
+    ) {
+      clickedIndex = positions.index;
+    }
+  });
+
+  if (clickedIndex === -1) {
+    return;
+  }
+
+  flow.clearBelowTimelineCircles();
+
+  if (circles[clickedIndex].type === 'advertiser') {
+    app.joinInterestGroup.joinings[clickedIndex][0].props.y1 += 20;
+  } else {
+    app.auction.auctions[clickedIndex][0].props.y1 += 20;
+  }
+
+  app.isRevisitingNodeInInteractiveMode = true;
+  app.drawFlows(clickedIndex);
+
+  app.promiseQueue.push((cb) => {
+    app.shouldRespondToClick = true;
+    timeline.renderUserIcon();
+    app.isRevisitingNodeInInteractiveMode = false;
+
+    if (circles[clickedIndex].type === 'advertiser') {
+      app.joinInterestGroup.joinings[clickedIndex][0].props.y1 -= 20;
+    } else {
+      app.auction.auctions[clickedIndex][0].props.y1 -= 20;
+    }
+
+    cb(null, true);
+  });
+
+  app.promiseQueue.start();
 };
 
 export default timeline;

--- a/packages/explorable-explanations/src/protectedAudience/utils/mouseHandlers/index.js
+++ b/packages/explorable-explanations/src/protectedAudience/utils/mouseHandlers/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { default as mouseClickedInInteractiveModeCallback } from './mouseClickedInInteractiveModeCallback';
+export { default as mouseClickedInNonInteractiveModeCallback } from './mouseClickedInInteractiveModeCallback';
+export { default as mouseMovedInTimeline } from './mouseMovedInTimeline';

--- a/packages/explorable-explanations/src/protectedAudience/utils/mouseHandlers/mouseClickedInInteractiveModeCallback.js
+++ b/packages/explorable-explanations/src/protectedAudience/utils/mouseHandlers/mouseClickedInInteractiveModeCallback.js
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import app from '../../app';
+import config from '../../config';
+import bubbles from '../../modules/bubbles';
+import flow from '../../modules/flow';
+import { isInsideCircle } from '../isInsideCircle';
+import {
+  wipeAndRecreateMainCanvas,
+  wipeAndRecreateUserCanvas,
+} from '../wipeAndRecreateCanvas';
+
+const mouseClickedInInteractiveModeCallback = (drawCircle, renderUserIcon) => {
+  const { mouseX, mouseY, isInteractiveMode, shouldRespondToClick } = app;
+  const p = app.p;
+  const up = app.up;
+
+  if (!isInteractiveMode || !shouldRespondToClick) {
+    return;
+  }
+
+  const { circlePositions, expandIconPositions } = app.timeline;
+  const {
+    circleProps: { diameter },
+    circles,
+    colors,
+    user,
+  } = config.timeline;
+
+  let clickedIndex = -1;
+
+  circlePositions.forEach(({ x, y }, index) => {
+    if (isInsideCircle(mouseX, mouseY, x, y, diameter / 2)) {
+      clickedIndex = index;
+    }
+  });
+
+  app.usedNextOrPrev = false;
+
+  expandIconPositions.forEach(({ x, y, index }) => {
+    if (isInsideCircle(mouseX, mouseY, x - 10, y + diameter / 2, 20)) {
+      app.isRevisitingNodeInInteractiveMode = true;
+      clickedIndex = index;
+    }
+  });
+
+  if (clickedIndex > -1 && !app.isRevisitingNodeInInteractiveMode) {
+    app.promiseQueue.end();
+    flow.clearBelowTimelineCircles();
+
+    app.shouldRespondToClick = false;
+    app.timeline.currentIndex = clickedIndex;
+
+    wipeAndRecreateUserCanvas();
+    renderUserIcon();
+    bubbles.generateBubbles();
+
+    if (circles[clickedIndex].visited) {
+      app.promiseQueue.push((cb) => {
+        wipeAndRecreateUserCanvas();
+        wipeAndRecreateMainCanvas();
+
+        p.push();
+        p.stroke(colors.grey);
+
+        circles.forEach((circle, index) => {
+          p.push();
+          p.stroke(colors.grey);
+          drawCircle(
+            index,
+            circle.visited && index !== clickedIndex ? true : false
+          );
+          p.pop();
+
+          if (circle.visited && index === clickedIndex) {
+            const position = circlePositions[clickedIndex];
+            up.image(
+              p.userIcon,
+              position.x - user.width / 2,
+              position.y - user.height / 2,
+              user.width,
+              user.height
+            );
+          }
+        });
+
+        p.pop();
+        cb(null, true);
+      });
+    }
+
+    app.drawFlows(clickedIndex);
+
+    app.promiseQueue.push((cb) => {
+      if (config.timeline.circles[clickedIndex].visited) {
+        app.visitedIndexOrder = app.visitedIndexOrder.filter((indexes) => {
+          if (indexes === clickedIndex) {
+            return false;
+          }
+          return true;
+        });
+
+        app.visitedIndexOrder.push(clickedIndex);
+
+        config.timeline.circles[clickedIndex].visitedIndex = app.visitedIndexes;
+        app.visitedIndexes = 1;
+
+        app.visitedIndexOrder.forEach((idx) => {
+          config.timeline.circles[idx].visitedIndex = app.visitedIndexes;
+          app.visitedIndexes++;
+        });
+
+        app.setCurrentSite(circles[clickedIndex]);
+        app.bubbles.positions.splice(
+          -(circles[clickedIndex].igGroupsCount ?? 0)
+        );
+
+        app.shouldRespondToClick = true;
+        bubbles.showMinifiedBubbles();
+        renderUserIcon();
+        return;
+      } else {
+        const positions = app.timeline.circlePositions[clickedIndex];
+        app.timeline.expandIconPositions.push({
+          x: positions.x + diameter / 2,
+          y: positions.y,
+          index: clickedIndex,
+        });
+
+        app.visitedIndexOrder.push(clickedIndex);
+        if (app.visitedIndexOrderTracker < app.visitedIndexOrder.length) {
+          app.visitedIndexOrderTracker = app.visitedIndexOrder.length - 1;
+        }
+
+        app.bubbles.interestGroupCounts +=
+          circles[clickedIndex]?.igGroupsCount ?? 0;
+        config.timeline.circles[clickedIndex].visited = true;
+        config.timeline.circles[clickedIndex].visitedIndex = app.visitedIndexes;
+        app.visitedIndexes += 1;
+        app.setCurrentSite(circles[clickedIndex]);
+      }
+
+      bubbles.showMinifiedBubbles();
+      app.shouldRespondToClick = true;
+
+      wipeAndRecreateUserCanvas();
+      wipeAndRecreateMainCanvas();
+      renderUserIcon();
+      flow.setButtonsDisabilityState();
+
+      cb(null, true);
+    });
+
+    app.promiseQueue.start();
+  } else if (clickedIndex > -1 && app.isRevisitingNodeInInteractiveMode) {
+    app.promiseQueue.end();
+    flow.clearBelowTimelineCircles();
+
+    if (circles[clickedIndex].type === 'advertiser') {
+      app.joinInterestGroup.joinings[clickedIndex][0].props.y1 += 20;
+    } else {
+      app.auction.auctions[clickedIndex][0].props.y1 += 20;
+    }
+
+    app.shouldRespondToClick = false;
+    app.drawFlows(clickedIndex);
+
+    app.promiseQueue.push((cb) => {
+      app.shouldRespondToClick = true;
+      renderUserIcon();
+      app.isRevisitingNodeInInteractiveMode = false;
+
+      if (circles[clickedIndex].type === 'advertiser') {
+        app.joinInterestGroup.joinings[clickedIndex][0].props.y1 -= 20;
+      } else {
+        app.auction.auctions[clickedIndex][0].props.y1 -= 20;
+      }
+
+      app.setCurrentSite(circles[clickedIndex]);
+
+      cb(null, true);
+    });
+
+    app.promiseQueue.start();
+
+    wipeAndRecreateUserCanvas();
+    wipeAndRecreateMainCanvas();
+    return;
+  }
+};
+
+export default mouseClickedInInteractiveModeCallback;

--- a/packages/explorable-explanations/src/protectedAudience/utils/mouseHandlers/mouseClickedInNonInteractiveModeCallback.js
+++ b/packages/explorable-explanations/src/protectedAudience/utils/mouseHandlers/mouseClickedInNonInteractiveModeCallback.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import app from '../../app';
+import config from '../../config';
+import flow from '../../modules/flow';
+import { isInsideCircle } from '../isInsideCircle';
+
+//Need to pass this from the caller to avoid circular dependencies
+const mouseClickedInNonInteractiveModeCallback = (renderUserIcon) => {
+  const {
+    circleProps: { diameter },
+    circles,
+  } = config.timeline;
+
+  if (!circles.every(({ visited }) => visited === true)) {
+    return;
+  }
+
+  let clickedIndex = -1;
+  app.timeline.expandIconPositions.forEach((positions) => {
+    if (
+      isInsideCircle(
+        app.mouseX,
+        app.mouseY,
+        positions.x,
+        positions.y + diameter / 2,
+        20
+      )
+    ) {
+      clickedIndex = positions.index;
+    }
+  });
+
+  if (clickedIndex === -1) {
+    return;
+  }
+
+  flow.clearBelowTimelineCircles();
+
+  if (circles[clickedIndex].type === 'advertiser') {
+    app.joinInterestGroup.joinings[clickedIndex][0].props.y1 += 20;
+  } else {
+    app.auction.auctions[clickedIndex][0].props.y1 += 20;
+  }
+
+  app.isRevisitingNodeInInteractiveMode = true;
+  app.drawFlows(clickedIndex);
+
+  app.promiseQueue.push((cb) => {
+    app.shouldRespondToClick = true;
+    renderUserIcon();
+    app.isRevisitingNodeInInteractiveMode = false;
+
+    if (circles[clickedIndex].type === 'advertiser') {
+      app.joinInterestGroup.joinings[clickedIndex][0].props.y1 -= 20;
+    } else {
+      app.auction.auctions[clickedIndex][0].props.y1 -= 20;
+    }
+
+    cb(null, true);
+  });
+
+  app.promiseQueue.start();
+};
+
+export default mouseClickedInNonInteractiveModeCallback;

--- a/packages/explorable-explanations/src/protectedAudience/utils/mouseHandlers/mouseMovedInTimeline.js
+++ b/packages/explorable-explanations/src/protectedAudience/utils/mouseHandlers/mouseMovedInTimeline.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import app from '../../app';
+import config from '../../config';
+import { isInsideCircle } from '../isInsideCircle';
+const mouseMovedInNonInteractiveModeCallback = (event) => {
+  const { offsetX, offsetY } = event;
+
+  app.mouseX = offsetX;
+  app.mouseY = offsetY;
+
+  let hoveringOnExpandIconPositions = false;
+  if (!config.timeline.circles.every(({ visited }) => visited === true)) {
+    return;
+  }
+  app.timeline.expandIconPositions.forEach((positions) => {
+    if (
+      isInsideCircle(
+        offsetX,
+        offsetY,
+        positions.x,
+        positions.y + config.timeline.circleProps.diameter / 2,
+        20
+      )
+    ) {
+      hoveringOnExpandIconPositions = true;
+    }
+  });
+
+  if (hoveringOnExpandIconPositions) {
+    app.p.cursor('pointer');
+  } else {
+    app.p.cursor('default');
+  }
+};
+
+export default mouseMovedInNonInteractiveModeCallback;


### PR DESCRIPTION
## Description
Previously, we added a double arrow drop down in the interactive mode to show the non-animated flow. The same has been applied in the non-interactive mode as well.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

- Clone this branch
- In the terminal run `npm i && npm run dev:ee:pa`.
- Now see when the animation is running, note that the double down arrow has opacity and pointer default indicating the arrows are not clickable.
- Once all the circles have been visited, the double down arrow opacity is removed and the icon is not clickable.

## Additional Information:
- This only works when all the circles have been visited and whole flow is completed.

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
~~- [ ] This code is covered by unit tests to verify that it works as intended.~~ NA
~~- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).~~ NA

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #857 
