### PR TITLE
Enhancement: Update synthetic data for distinction

### DIFF
--- a/packages/explorable-explanations/src/index.js
+++ b/packages/explorable-explanations/src/index.js
@@ -20,4 +20,6 @@ export {
   interestGroupSketch,
   sketch,
 } from './protectedAudience';
+export { branchesData } from './protectedAudience/modules/auctions/setupBranches.js';
+export { adunitData } from './protectedAudience/modules/auctions/setUpAdUnitCode.js';
 export { default as config } from './protectedAudience/config.js';

--- a/packages/explorable-explanations/src/index.js
+++ b/packages/explorable-explanations/src/index.js
@@ -20,7 +20,7 @@ export {
   interestGroupSketch,
   sketch,
 } from './protectedAudience';
-export { branchesData } from './protectedAudience/modules/auctions/setupBranches.js';
-export { adunitData } from './protectedAudience/modules/auctions/setUpAdUnitCode.js';
-export { sspUrls } from './protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.js';
-export { default as config } from './protectedAudience/config.js';
+export {
+  default as config,
+  publisherData,
+} from './protectedAudience/config.js';

--- a/packages/explorable-explanations/src/index.js
+++ b/packages/explorable-explanations/src/index.js
@@ -22,4 +22,5 @@ export {
 } from './protectedAudience';
 export { branchesData } from './protectedAudience/modules/auctions/setupBranches.js';
 export { adunitData } from './protectedAudience/modules/auctions/setUpAdUnitCode.js';
+export { sspUrls } from './protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.js';
 export { default as config } from './protectedAudience/config.js';

--- a/packages/explorable-explanations/src/protectedAudience/config.js
+++ b/packages/explorable-explanations/src/protectedAudience/config.js
@@ -145,3 +145,45 @@ const config = {
 };
 
 export default config;
+
+export const publisherData = {
+  'pub1.com': {
+    branches: [
+      { date: 'Sun, 01 October 2023', time: '12:00:00 GMT', type: 'datetime' },
+      { date: 'Sun, 01 October 2023', time: '12:01:00 GMT', type: 'datetime' },
+      { date: 'Sun, 01 October 2023', time: '12:02:00 GMT', type: 'datetime' },
+    ],
+    adunits: ['div-200-1', 'div-200-2', 'div-200-3'],
+    ssps: [
+      ['SSP A', 'https://ssp-a.com'],
+      ['SSP B', 'https://ssp-b.com'],
+      ['SSP C', 'https://ssp-c.com'],
+    ],
+  },
+  'pub2.com': {
+    branches: [
+      { date: 'Sun, 01 October 2023', time: '14:00:00 GMT', type: 'datetime' },
+      { date: 'Sun, 01 October 2023', time: '14:01:00 GMT', type: 'datetime' },
+      { date: 'Sun, 01 October 2023', time: '14:02:00 GMT', type: 'datetime' },
+    ],
+    adunits: ['div-400-1', 'div-400-2', 'div-400-3'],
+    ssps: [
+      ['SSP D', 'https://ssp-d.com'],
+      ['SSP E', 'https://ssp-e.com'],
+      ['SSP F', 'https://ssp-f.com'],
+    ],
+  },
+  'pub3.com': {
+    branches: [
+      { date: 'Sun, 01 October 2023', time: '16:00:00 GMT', type: 'datetime' },
+      { date: 'Sun, 01 October 2023', time: '16:01:00 GMT', type: 'datetime' },
+      { date: 'Sun, 01 October 2023', time: '16:02:00 GMT', type: 'datetime' },
+    ],
+    adunits: ['div-600-1', 'div-600-2', 'div-600-3'],
+    ssps: [
+      ['SSP G', 'https://ssp-g.com'],
+      ['SSP H', 'https://ssp-h.com'],
+      ['SSP I', 'https://ssp-i.com'],
+    ],
+  },
+};

--- a/packages/explorable-explanations/src/protectedAudience/config.js
+++ b/packages/explorable-explanations/src/protectedAudience/config.js
@@ -104,6 +104,13 @@ const config = {
         visited: false,
         visitedIndex: null,
       },
+      {
+        type: 'publisher',
+        website: 'pub3.com',
+        datetime: '2023-10-01 16:00',
+        visited: false,
+        visitedIndex: null,
+      },
     ],
     colors: {
       visitedBlue: '#1A73E8',

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/index.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/index.js
@@ -70,7 +70,7 @@ auction.setUp = (index) => {
   if (app.isMultiSeller) {
     setUpMultiSellerFirstSSPTagFlow(steps);
     setUpPublisherAdServerFlow(steps);
-    setUpComponentAuctions(steps);
+    setUpComponentAuctions(steps, index);
   } else {
     setUpSingleSellerFirstSSPTagFlow(steps);
     setUpRunadAuction(steps);

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.js
@@ -17,27 +17,9 @@
  * Internal dependencies.
  */
 import app from '../../../app';
-import config from '../../../config';
+import config, { publisherData } from '../../../config';
 import { Box, ProgressLine, Text, Custom } from '../../../components';
 import setUpRunadAuction from '../setUpRunadAuction';
-
-export const sspUrls = {
-  'pub1.com': [
-    ['SSP A', 'https://ssp-a.com'],
-    ['SSP B', 'https://ssp-b.com'],
-    ['SSP C', 'https://ssp-c.com'],
-  ],
-  'pub2.com': [
-    ['SSP D', 'https://ssp-d.com'],
-    ['SSP E', 'https://ssp-e.com'],
-    ['SSP F', 'https://ssp-f.com'],
-  ],
-  'pub3.com': [
-    ['SSP G', 'https://ssp-g.com'],
-    ['SSP H', 'https://ssp-h.com'],
-    ['SSP I', 'https://ssp-i.com'],
-  ],
-};
 
 const BOX_WIDTH = 1200;
 const BOX_HEIGHT = 1100;
@@ -95,7 +77,7 @@ const setUpComponentAuctions = (steps, index) => {
         BORDER_BOX_MARGIN * 2 +
         20,
       y: () => app.auction.nextTipCoordinates?.y - 225 - 15,
-      ssp: sspUrls[publisher][0][0],
+      ssp: publisherData[publisher].ssps[0][0],
       config: {
         bidValue: '$10',
       },
@@ -108,7 +90,7 @@ const setUpComponentAuctions = (steps, index) => {
         BOX_HEIGHT +
         BORDER_BOX_MARGIN * 2 +
         15,
-      ssp: sspUrls[publisher][1][0],
+      ssp: publisherData[publisher].ssps[1][0],
       config: {
         bidValue: '$8',
       },
@@ -121,7 +103,7 @@ const setUpComponentAuctions = (steps, index) => {
         BOX_HEIGHT +
         BORDER_BOX_MARGIN * 2 +
         15,
-      ssp: sspUrls[publisher][2][0],
+      ssp: publisherData[publisher].ssps[2][0],
       config: {
         bidValue: '$6',
       },

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.js
@@ -21,6 +21,24 @@ import config from '../../../config';
 import { Box, ProgressLine, Text, Custom } from '../../../components';
 import setUpRunadAuction from '../setUpRunadAuction';
 
+export const sspUrls = {
+  'pub1.com': [
+    ['SSP A', 'https://ssp-a.com'],
+    ['SSP B', 'https://ssp-b.com'],
+    ['SSP C', 'https://ssp-c.com'],
+  ],
+  'pub2.com': [
+    ['SSP D', 'https://ssp-d.com'],
+    ['SSP E', 'https://ssp-e.com'],
+    ['SSP F', 'https://ssp-f.com'],
+  ],
+  'pub3.com': [
+    ['SSP G', 'https://ssp-g.com'],
+    ['SSP H', 'https://ssp-h.com'],
+    ['SSP I', 'https://ssp-i.com'],
+  ],
+};
+
 const BOX_WIDTH = 1200;
 const BOX_HEIGHT = 1100;
 const FIRST_LINE_HEIGHT = 150;
@@ -29,8 +47,9 @@ const BOX_COLUMN_MARGIN = 390;
 
 const boxCordinates = {};
 
-const setUpComponentAuctions = (steps) => {
+const setUpComponentAuctions = (steps, index) => {
   const { box } = config.flow;
+  const publisher = config.timeline.circles[index].website;
 
   steps.push({
     component: ProgressLine,
@@ -76,7 +95,7 @@ const setUpComponentAuctions = (steps) => {
         BORDER_BOX_MARGIN * 2 +
         20,
       y: () => app.auction.nextTipCoordinates?.y - 225 - 15,
-      ssp: 'SSP A',
+      ssp: sspUrls[publisher][0][0],
       config: {
         bidValue: '$10',
       },
@@ -89,7 +108,7 @@ const setUpComponentAuctions = (steps) => {
         BOX_HEIGHT +
         BORDER_BOX_MARGIN * 2 +
         15,
-      ssp: 'SSP B',
+      ssp: sspUrls[publisher][1][0],
       config: {
         bidValue: '$8',
       },
@@ -102,19 +121,19 @@ const setUpComponentAuctions = (steps) => {
         BOX_HEIGHT +
         BORDER_BOX_MARGIN * 2 +
         15,
-      ssp: 'SSP C',
+      ssp: sspUrls[publisher][2][0],
       config: {
         bidValue: '$6',
       },
     },
   ];
 
-  componentAuctions.forEach((componentAuction, index) => {
+  componentAuctions.forEach((componentAuction, idx) => {
     setUpComponentAuction(
       steps,
       componentAuction,
       componentAuction.config,
-      index
+      idx
     );
   });
 

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/setUpAdUnitCode.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/setUpAdUnitCode.js
@@ -21,9 +21,16 @@ import config from '../../config';
 import flow from '../flow';
 import { Branches } from '../../components';
 
+export const adunitData = {
+  'pub1.com': ['div-200-1', 'div-200-2', 'div-200-3'],
+  'pub2.com': ['div-400-1', 'div-400-2', 'div-400-3'],
+  'pub3.com': ['div-600-1', 'div-600-2', 'div-600-3'],
+};
+
 const setUpAdUnitCode = (steps, index) => {
   const { colors } = config.flow;
   const { x, y } = flow.getTimelineCircleCoordinates(index);
+  const publisher = config.timeline.circles[index].website;
 
   // Setup Ad unit codes
   steps.push({
@@ -35,19 +42,19 @@ const setUpAdUnitCode = (steps, index) => {
       branches: [
         {
           title: 'adunit-code',
-          description: 'div-200-1',
+          description: adunitData[publisher][0],
           type: 'box',
           color: colors.box.browser,
         },
         {
           title: 'adunit-code',
-          description: 'div-200-2',
+          description: adunitData[publisher][1],
           type: 'box',
           color: colors.box.browser,
         },
         {
           title: 'adunit-code',
-          description: 'div-200-3',
+          description: adunitData[publisher][2],
           type: 'box',
           color: colors.box.browser,
         },

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/setUpAdUnitCode.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/setUpAdUnitCode.js
@@ -17,15 +17,9 @@
  * Internal dependencies.
  */
 import app from '../../app';
-import config from '../../config';
+import config, { publisherData } from '../../config';
 import flow from '../flow';
 import { Branches } from '../../components';
-
-export const adunitData = {
-  'pub1.com': ['div-200-1', 'div-200-2', 'div-200-3'],
-  'pub2.com': ['div-400-1', 'div-400-2', 'div-400-3'],
-  'pub3.com': ['div-600-1', 'div-600-2', 'div-600-3'],
-};
 
 const setUpAdUnitCode = (steps, index) => {
   const { colors } = config.flow;
@@ -42,19 +36,19 @@ const setUpAdUnitCode = (steps, index) => {
       branches: [
         {
           title: 'adunit-code',
-          description: adunitData[publisher][0],
+          description: publisherData[publisher].adunits[0],
           type: 'box',
           color: colors.box.browser,
         },
         {
           title: 'adunit-code',
-          description: adunitData[publisher][1],
+          description: publisherData[publisher].adunits[1],
           type: 'box',
           color: colors.box.browser,
         },
         {
           title: 'adunit-code',
-          description: adunitData[publisher][2],
+          description: publisherData[publisher].adunits[2],
           type: 'box',
           color: colors.box.browser,
         },

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/setupBranches.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/setupBranches.js
@@ -18,25 +18,7 @@
  */
 import app from '../../app';
 import { Branches } from '../../components';
-import config from '../../config';
-
-export const branchesData = {
-  'pub1.com': [
-    { date: 'Sun, 01 October 2023', time: '12:00:00 GMT', type: 'datetime' },
-    { date: 'Sun, 01 October 2023', time: '12:01:00 GMT', type: 'datetime' },
-    { date: 'Sun, 01 October 2023', time: '12:02:00 GMT', type: 'datetime' },
-  ],
-  'pub2.com': [
-    { date: 'Sun, 01 October 2023', time: '14:00:00 GMT', type: 'datetime' },
-    { date: 'Sun, 01 October 2023', time: '14:01:00 GMT', type: 'datetime' },
-    { date: 'Sun, 01 October 2023', time: '14:02:00 GMT', type: 'datetime' },
-  ],
-  'pub3.com': [
-    { date: 'Sun, 01 October 2023', time: '16:00:00 GMT', type: 'datetime' },
-    { date: 'Sun, 01 October 2023', time: '16:01:00 GMT', type: 'datetime' },
-    { date: 'Sun, 01 October 2023', time: '16:02:00 GMT', type: 'datetime' },
-  ],
-};
+import config, { publisherData } from '../../config';
 
 const setupBranches = (steps, index) => {
   const publisher = config.timeline.circles[index].website;
@@ -49,18 +31,18 @@ const setupBranches = (steps, index) => {
       currentIndex: index,
       branches: [
         {
-          date: branchesData[publisher][0].date,
-          time: branchesData[publisher][0].time,
+          date: publisherData[publisher].branches[0].date,
+          time: publisherData[publisher].branches[0].time,
           type: 'datetime',
         },
         {
-          date: branchesData[publisher][1].date,
-          time: branchesData[publisher][1].time,
+          date: publisherData[publisher].branches[1].date,
+          time: publisherData[publisher].branches[1].time,
           type: 'datetime',
         },
         {
-          date: branchesData[publisher][2].date,
-          time: branchesData[publisher][2].time,
+          date: publisherData[publisher].branches[2].date,
+          time: publisherData[publisher].branches[2].time,
           type: 'datetime',
         },
       ],

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/setupBranches.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/setupBranches.js
@@ -18,8 +18,29 @@
  */
 import app from '../../app';
 import { Branches } from '../../components';
+import config from '../../config';
+
+export const branchesData = {
+  'pub1.com': [
+    { date: 'Sun, 01 October 2023', time: '12:00:00 GMT', type: 'datetime' },
+    { date: 'Sun, 01 October 2023', time: '12:01:00 GMT', type: 'datetime' },
+    { date: 'Sun, 01 October 2023', time: '12:02:00 GMT', type: 'datetime' },
+  ],
+  'pub2.com': [
+    { date: 'Sun, 01 October 2023', time: '14:00:00 GMT', type: 'datetime' },
+    { date: 'Sun, 01 October 2023', time: '14:01:00 GMT', type: 'datetime' },
+    { date: 'Sun, 01 October 2023', time: '14:02:00 GMT', type: 'datetime' },
+  ],
+  'pub3.com': [
+    { date: 'Sun, 01 October 2023', time: '16:00:00 GMT', type: 'datetime' },
+    { date: 'Sun, 01 October 2023', time: '16:01:00 GMT', type: 'datetime' },
+    { date: 'Sun, 01 October 2023', time: '16:02:00 GMT', type: 'datetime' },
+  ],
+};
 
 const setupBranches = (steps, index) => {
+  const publisher = config.timeline.circles[index].website;
+
   steps.push({
     component: Branches,
     props: {
@@ -28,18 +49,18 @@ const setupBranches = (steps, index) => {
       currentIndex: index,
       branches: [
         {
-          date: 'Sun, 01 October 2023',
-          time: '6:30:00 GMT',
+          date: branchesData[publisher][0].date,
+          time: branchesData[publisher][0].time,
           type: 'datetime',
         },
         {
-          date: 'Sun, 01 October 2023',
-          time: '6:31:00 GMT',
+          date: branchesData[publisher][1].date,
+          time: branchesData[publisher][1].time,
           type: 'datetime',
         },
         {
-          date: 'Sun, 01 October 2023',
-          time: '6:32:00 GMT',
+          date: branchesData[publisher][2].date,
+          time: branchesData[publisher][2].time,
           type: 'datetime',
         },
       ],

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/panel/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/panel/index.tsx
@@ -90,6 +90,7 @@ const AuctionPanel = ({
                   props: {
                     auctionEvents: events,
                     parentOrigin: events[0]?.auctionConfig?.seller,
+                    startDate: time,
                   },
                 },
                 children: {},
@@ -114,6 +115,7 @@ const AuctionPanel = ({
                 parentOrigin:
                   auctionEventsData[adUnit][time][sellerUrl][sellerUrl][0]
                     ?.auctionConfig?.seller,
+                startDate: time,
               },
             },
             children,

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/table/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/auctions/table/index.tsx
@@ -36,11 +36,13 @@ import BottomTray from './bottomTray';
 interface AuctionTableProps {
   auctionEvents: singleAuctionEvent[];
   parentOrigin?: string;
+  startDate?: string;
 }
 
 const AuctionTable = ({
   auctionEvents,
   parentOrigin = '',
+  startDate = '',
 }: AuctionTableProps) => {
   const [selectedJSON, setSelectedJSON] = useState<singleAuctionEvent | null>(
     null
@@ -179,7 +181,11 @@ const AuctionTable = ({
       >
         <div className="flex justify-between items-center p-2">
           <p>Started by: {auctionEvents?.[0]?.auctionConfig?.seller}</p>
-          <p>{new Date(auctionEvents?.[0]?.time * 1000 || '').toUTCString()}</p>
+          <p>
+            {startDate
+              ? startDate
+              : new Date(auctionEvents?.[0]?.time * 1000 || '').toUTCString()}
+          </p>
         </div>
         <div className="flex-1 border border-american-silver dark:border-quartz overflow-auto">
           <TableProvider

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/auctionEventTransformers.ts
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/auctionEventTransformers.ts
@@ -17,6 +17,7 @@
  * External dependencies
  */
 import type { ReceivedBids, singleAuctionEvent } from '@google-psat/common';
+import { adunitData, branchesData } from '@google-psat/explorable-explanations';
 /**
  * Internal dependencies
  */
@@ -329,7 +330,6 @@ export const configuredAuctionEvents = (
   isMultiSeller: boolean,
   currentSiteData: CurrentSiteData
 ) => {
-  const dateTimeString = new Date(currentSiteData?.datetime).toUTCString();
   const websiteString = `https://www.${currentSiteData?.website}`;
   const sellersArray = [];
 
@@ -344,9 +344,14 @@ export const configuredAuctionEvents = (
     sellersArray.push(websiteString);
   }
 
+  const adunits = adunitData[currentSiteData?.website];
+  const dates = branchesData[currentSiteData?.website].map(
+    (branch) => branch.date + ' ' + branch.time
+  );
+
   const auctionData = {
-    'div-200-1': {
-      [dateTimeString]: {
+    [adunits[0]]: {
+      [dates[0]]: {
         [websiteString]: getFlattenedAuctionEvents(
           sellersArray,
           currentSiteData,
@@ -356,8 +361,8 @@ export const configuredAuctionEvents = (
         ),
       },
     },
-    'div-200-2': {
-      [dateTimeString]: {
+    [adunits[1]]: {
+      [dates[1]]: {
         [websiteString]: getFlattenedAuctionEvents(
           sellersArray,
           currentSiteData,
@@ -367,8 +372,8 @@ export const configuredAuctionEvents = (
         ),
       },
     },
-    'div-200-3': {
-      [dateTimeString]: {
+    [adunits[2]]: {
+      [dates[2]]: {
         [websiteString]: getFlattenedAuctionEvents(
           sellersArray,
           currentSiteData,
@@ -381,56 +386,56 @@ export const configuredAuctionEvents = (
   };
 
   const receivedBids = {
-    'div-200-1': getBidData(
-      auctionData['div-200-1']?.[dateTimeString]?.[websiteString],
+    [adunits[0]]: getBidData(
+      auctionData[adunits[0]]?.[dates[0]]?.[websiteString],
       sellersArray,
-      'div-200-1'
+      adunits[0]
     ),
-    'div-200-2': getBidData(
-      auctionData['div-200-2']?.[dateTimeString]?.[websiteString],
+    [adunits[1]]: getBidData(
+      auctionData[adunits[1]]?.[dates[1]]?.[websiteString],
       sellersArray,
-      'div-200-2'
+      adunits[1]
     ),
-    'div-200-3': getBidData(
-      auctionData['div-200-3']?.[dateTimeString]?.[websiteString],
+    [adunits[2]]: getBidData(
+      auctionData[adunits[2]]?.[dates[2]]?.[websiteString],
       sellersArray,
-      'div-200-3'
+      adunits[2]
     ),
   };
 
   const adsAndBidders = {
-    'div-200-1': {
-      adUnitCode: 'div-200-1',
+    [adunits[0]]: {
+      adUnitCode: adunits[0],
       bidders: sellersArray,
       mediaContainerSize: [[320, 320]],
       winningBid: getBidData(
-        auctionData['div-200-1']?.[dateTimeString]?.[websiteString],
+        auctionData[adunits[0]]?.[dates[0]]?.[websiteString],
         sellersArray,
-        'div-200-1'
+        adunits[0]
       ).filter(({ type }) => type === 'win')?.[0]?.bid,
       bidCurrency: 'USD',
       winningBidder: 'DSP 1',
     },
-    'div-200-2': {
-      adUnitCode: 'div-200-2',
+    [adunits[1]]: {
+      adUnitCode: adunits[1],
       bidders: sellersArray,
       mediaContainerSize: [[320, 320]],
       winningBid: getBidData(
-        auctionData['div-200-2']?.[dateTimeString]?.[websiteString],
+        auctionData[adunits[1]]?.[dates[1]]?.[websiteString],
         sellersArray,
-        'div-200-2'
+        adunits[1]
       ).filter(({ type }) => type === 'win')?.[0]?.bid,
       bidCurrency: 'USD',
       winningBidder: 'DSP 1',
     },
-    'div-200-3': {
-      adUnitCode: 'div-200-2',
+    [adunits[2]]: {
+      adUnitCode: adunits[2],
       bidders: sellersArray,
       mediaContainerSize: [[320, 320]],
       winningBid: getBidData(
-        auctionData['div-200-3']?.[dateTimeString]?.[websiteString],
+        auctionData[adunits[2]]?.[dates[2]]?.[websiteString],
         sellersArray,
-        'div-200-3'
+        adunits[2]
       ).filter(({ type }) => type === 'win')?.[0]?.bid,
       bidCurrency: 'USD',
       winningBidder: 'DSP 1',

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/auctionEventTransformers.ts
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/auctionEventTransformers.ts
@@ -17,11 +17,7 @@
  * External dependencies
  */
 import type { ReceivedBids, singleAuctionEvent } from '@google-psat/common';
-import {
-  adunitData,
-  branchesData,
-  sspUrls,
-} from '@google-psat/explorable-explanations';
+import { publisherData } from '@google-psat/explorable-explanations';
 /**
  * Internal dependencies
  */
@@ -340,15 +336,17 @@ export const configuredAuctionEvents = (
   if (isMultiSeller) {
     sellersArray.push(
       websiteString,
-      ...sspUrls[currentSiteData?.website].map((data) => data[1])
+      ...publisherData[currentSiteData?.website].ssps.map(
+        (data: string[]) => data[1]
+      )
     );
   } else {
     sellersArray.push(websiteString);
   }
 
-  const adunits = adunitData[currentSiteData?.website];
-  const dates = branchesData[currentSiteData?.website].map(
-    (branch) => branch.date + ' ' + branch.time
+  const adunits = publisherData[currentSiteData?.website].adunits;
+  const dates = publisherData[currentSiteData?.website].branches.map(
+    (branch: { date: string; time: string }) => branch.date + ' ' + branch.time
   );
 
   const auctionData = {

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/auctionEventTransformers.ts
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/auctionEventTransformers.ts
@@ -17,7 +17,11 @@
  * External dependencies
  */
 import type { ReceivedBids, singleAuctionEvent } from '@google-psat/common';
-import { adunitData, branchesData } from '@google-psat/explorable-explanations';
+import {
+  adunitData,
+  branchesData,
+  sspUrls,
+} from '@google-psat/explorable-explanations';
 /**
  * Internal dependencies
  */
@@ -336,9 +340,7 @@ export const configuredAuctionEvents = (
   if (isMultiSeller) {
     sellersArray.push(
       websiteString,
-      'https://ssp-a.com',
-      'https://ssp-b.com',
-      'https://ssp-c.com'
+      ...sspUrls[currentSiteData?.website].map((data) => data[1])
     );
   } else {
     sellersArray.push(websiteString);

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/constants.ts
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/constants.ts
@@ -740,6 +740,7 @@ export const SYNTHETIC_INTEREST_GROUPS: WebsiteInterestGroup = {
       },
     },
   ],
+  'pub3.com': [],
 };
 
 export const SYNTHETIC_AUCTION_EVENT_STARTED: singleAuctionEvent = {

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/index.tsx
@@ -200,9 +200,7 @@ const ExplorableExplanation = () => {
         content: {
           Element: Auctions,
           props: {
-            auctionEvents: {
-              ...auctionsData,
-            },
+            auctionEvents: auctionsData,
             customAdsAndBidders: auctionsData.adsAndBidders,
           },
         },


### PR DESCRIPTION
## Description
This PR updates the synthetic data for differentiation across all publisher nodes.
- Adds a new publisher at the end of the timeline.
- Fix the data time for the auction table.
- Update synthetic data to create a variable `publisherData` for different data.
  - Matches the date time of publisher nodes in the branches, the sidebar to the circle time.
  - Different SSP titles and URLs for each publisher node.
  - Different adunit codes for each publisher node.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="1320" alt="Screenshot 2025-01-23 at 14 27 53" src="https://github.com/user-attachments/assets/2ef40613-4c31-4c9a-bb6f-8dcf38a27d08" />

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #857 
