### PR TITLE
Enhancement: Autoscroll table on row highlighting

### DIFF
--- a/packages/design-system/src/components/table/components/index.tsx
+++ b/packages/design-system/src/components/table/components/index.tsx
@@ -118,7 +118,7 @@ const Table = ({
   );
 
   return (
-    <div className="w-full h-full flex flex-col">
+    <div className="w-full h-full flex flex-col text-raisin-black dark:text-bright-gray">
       {!hideTableTopBar && (
         <>
           <TableTopBar

--- a/packages/design-system/src/components/table/components/tableBody/bodyRow.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/bodyRow.tsx
@@ -85,7 +85,7 @@ const BodyRow = ({
   useEffect(() => {
     if (isHighlighted) {
       const element = document.getElementById(index.toString());
-      element?.scrollIntoView({
+      element?.scrollIntoView?.({
         behavior: 'smooth',
         block: 'center',
         inline: 'start',

--- a/packages/design-system/src/components/table/components/tableBody/bodyRow.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/bodyRow.tsx
@@ -17,7 +17,7 @@
 /**
  * External dependencies.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import classnames from 'classnames';
 
 /**
@@ -81,6 +81,17 @@ const BodyRow = ({
         : 'bg-royal-blue text-white dark:bg-medium-persian-blue dark:text-chinese-silver')
   );
   const extraClasses = getExtraClasses();
+
+  useEffect(() => {
+    if (isHighlighted) {
+      const element = document.getElementById(index.toString());
+      element?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+        inline: 'start',
+      });
+    }
+  }, [index, isHighlighted]);
 
   return (
     <div

--- a/packages/design-system/src/components/table/components/tableBody/tests/bodyRow.tsx
+++ b/packages/design-system/src/components/table/components/tableBody/tests/bodyRow.tsx
@@ -116,4 +116,29 @@ describe('BodyRow', () => {
     expect(BodyRowProp.onRowClick).toHaveBeenCalled();
     expect(BodyRowProp.isRowFocused).toBe(true);
   });
+
+  it('should autoscroll to the highlighted row', () => {
+    globalThis.document.getElementById = jest.fn(() => ({
+      scrollIntoView: jest.fn(),
+    }));
+
+    BodyRowProp.row.originalData.highlighted = true;
+
+    render(
+      <BodyRow
+        index={0}
+        // @ts-ignore
+        row={BodyRowProp.row}
+        columns={BodyRowProp.columns}
+        selectedKey={BodyRowProp.selectedKey}
+        getRowObjectKey={BodyRowProp.getRowObjectKey}
+        getExtraClasses={() => ''}
+        isRowFocused={BodyRowProp.isRowFocused}
+        onRowClick={BodyRowProp.onRowClick}
+        onKeyDown={BodyRowProp.onKeyDown}
+      />
+    );
+
+    expect(globalThis.document.getElementById).toHaveBeenCalled();
+  });
 });

--- a/packages/design-system/src/test-data/cookieTableMockData.tsx
+++ b/packages/design-system/src/test-data/cookieTableMockData.tsx
@@ -55,7 +55,7 @@ export const originalData = [
     // @ts-ignore
     isCookieSet: false,
     frameUrls: 'https://psanalysis.rt.gw',
-    highlighted: true,
+    highlighted: false,
   },
   {
     parsedCookie: {

--- a/packages/explorable-explanations/src/protectedAudience/modules/bubbles.js
+++ b/packages/explorable-explanations/src/protectedAudience/modules/bubbles.js
@@ -499,6 +499,7 @@ bubbles.bubbleChart = (
   const eventHandler = (event, d) => {
     app.setHighlightedInterestGroup({
       interestGroupName: titles[d.data].split('\n')[0],
+      interestGroupOwner: 'https://www.' + groups[d.data],
       color: app.color(groups[d.data]),
     });
     event.stopPropagation();

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/index.tsx
@@ -166,6 +166,7 @@ const ExplorableExplanation = () => {
 
   const [highlightedInterestGroup, setHighlightedInterestGroup] = useState<{
     interestGroupName: string;
+    interestGroupOwner: string;
     color: string;
   } | null>(null);
 

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/index.tsx
@@ -246,6 +246,7 @@ const ExplorableExplanation = () => {
         interactiveMode={interactiveMode}
         info={info}
         setInfo={setInfo}
+        highlightedInterestGroup={highlightedInterestGroup}
         setHighlightedInterestGroup={setHighlightedInterestGroup}
         isMultiSeller={isMultiSeller}
         setIsMultiSeller={setIsMultiSeller}

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
@@ -48,6 +48,11 @@ declare module 'react' {
 interface PanelProps {
   setCurrentSite: (siteData: CurrentSiteData | null) => void;
   currentSiteData: CurrentSiteData | null;
+  highlightedInterestGroup: {
+    interestGroupName: string;
+    interestGroupOwner: string;
+    color: string;
+  } | null;
   setHighlightedInterestGroup: React.Dispatch<
     React.SetStateAction<{
       interestGroupName: string;
@@ -66,6 +71,7 @@ interface PanelProps {
 const Panel = ({
   currentSiteData,
   setCurrentSite,
+  highlightedInterestGroup,
   setHighlightedInterestGroup,
   isMultiSeller,
   setIsMultiSeller,
@@ -108,6 +114,12 @@ const Panel = ({
   const { setActiveTab } = useTabs(({ actions }) => ({
     setActiveTab: actions.setActiveTab,
   }));
+
+  useEffect(() => {
+    if (highlightedInterestGroup) {
+      setActiveTab(0);
+    }
+  }, [highlightedInterestGroup, setActiveTab]);
 
   useEffect(() => {
     if (info) {

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
@@ -51,6 +51,7 @@ interface PanelProps {
   setHighlightedInterestGroup: React.Dispatch<
     React.SetStateAction<{
       interestGroupName: string;
+      interestGroupOwner: string;
       color: string;
     } | null>
   >;

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/tableTabPanels/info.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/tableTabPanels/info.tsx
@@ -24,20 +24,18 @@ interface InfoProps {
     description?: string;
     info: string;
     key: number;
-  };
+  } | null;
 }
 
 const Info = ({ data }: InfoProps) => {
-  const { title, description, info } = data;
-
   return (
     <div className="flex-1 text-raisin-black dark:text-bright-gray border border-gray-300 dark:border-quartz shadow h-full w-full min-w-[10rem] bg-white dark:bg-raisin-black overflow-auto">
-      {info ? (
+      {data?.info ? (
         <div className="p-2">
           <h3 className="text-sm font-medium">
-            {title + ' ' + (description || '')}
+            {data?.title + ' ' + (data?.description || '')}
           </h3>
-          <div className="text-[12.5px] mt-1">{info}</div>
+          <div className="text-[12.5px] mt-1">{data?.info}</div>
         </div>
       ) : (
         <div className="h-full box-border p-8 flex items-center">

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/interestGroups/table.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/interestGroups/table.tsx
@@ -38,6 +38,7 @@ interface InterestGroupsProps {
   interestGroupDetails: InterestGroupsType[];
   highlightedInterestGroup?: {
     interestGroupName: string;
+    interestGroupOwner: string;
     color: string;
   } | null;
 }
@@ -124,7 +125,9 @@ const IGTable = ({
 
     return interestGroupDetails.map((interestGroup) => {
       const isHighlighted =
-        interestGroup.name === highlightedInterestGroup.interestGroupName;
+        interestGroup.name === highlightedInterestGroup.interestGroupName &&
+        new URL(interestGroup?.ownerOrigin || '').host ===
+          new URL(highlightedInterestGroup?.interestGroupOwner || '').host;
 
       return {
         ...interestGroup,


### PR DESCRIPTION
## Description
This PR adds code for the autoscrolling table to the highlighted row.
- When an IG bubble is clicked, the related row to that IG will be highlighted, and if the row is outside the screen preview, the table auto-scrolls to the required row.
  - This is not limited to the IG table, the changes are inside the table's body row, so if any table has enabled highlighting, this logic should work.
- Alongside this PR also updates the comparison logic for highlighting by comparing the owner of the IG.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/user-attachments/assets/1e6cd7f2-dba6-44d4-814a-a76e43175f87


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #857 
