### PR TITLE
Fix: Ripple effect marking

### DIFF
--- a/packages/explorable-explanations/src/protectedAudience/components/rippleEffect.js
+++ b/packages/explorable-explanations/src/protectedAudience/components/rippleEffect.js
@@ -74,6 +74,7 @@ rippleEffect.start = (x = 0, y = 0) => {
       const elapsed = timestamp - startTime;
 
       if (elapsed > duration) {
+        clearArea(x, y);
         resolve();
         return;
       }
@@ -89,23 +90,26 @@ rippleEffect.start = (x = 0, y = 0) => {
   });
 };
 
-rippleEffect.create = (rippleX, rippleY, speed) => {
-  // Calculate the area to clear
-  const { ripples, numRipples, maxRadius } = config.rippleEffect;
+const clearArea = (x, y) => {
+  const { numRipples, maxRadius } = config.rippleEffect;
   const clearWidth = maxRadius * 2 + (numRipples - 1) * 40;
   const clearHeight = maxRadius * 1.5;
+
+  app.p.push();
+  app.p.fill(config.canvas.background);
+  app.p.noStroke();
+  app.p.rect(x - 1, y - clearHeight / 2 - 200, clearWidth, clearHeight + 400);
+  app.p.pop();
+};
+
+rippleEffect.create = (rippleX, rippleY, speed) => {
+  // Calculate the area to clear
+  const { ripples, maxRadius } = config.rippleEffect;
   const p = app.p;
 
   p.push();
   // Clear only the area used by the ripples
-  p.fill(config.canvas.background);
-  p.noStroke();
-  p.rect(
-    rippleX - 1,
-    rippleY - clearHeight / 2 - 200,
-    clearWidth,
-    clearHeight + 400
-  );
+  clearArea(rippleX, rippleY);
   let allComplete = true;
   p.translate(rippleX, rippleY);
 


### PR DESCRIPTION
## Description
- This PR adds code to clean up the marking left behind by the ripple effect if paused for long.
- Clean the ripple area on timeout.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/user-attachments/assets/d408a028-6d5d-40b9-a968-94696500f451


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #857 
