### PR TITLE
Fix: Move settings from bottom to the top in the sidebar

### DIFF
--- a/packages/extension/src/view/devtools/tabs.ts
+++ b/packages/extension/src/view/devtools/tabs.ts
@@ -295,20 +295,6 @@ const TABS: SidebarItems = {
     children: {},
     containerClassName: 'h-6',
   },
-  [SIDEBAR_ITEMS_KEYS.EXPLORABLE_EXPLANATIONS]: {
-    title: () => 'Stories',
-    panel: {
-      Element: WebStories,
-    },
-    icon: {
-      Element: WebStoriesIcon,
-    },
-    selectedIcon: {
-      Element: WebStoriesIconWhite,
-    },
-    dropdownOpen: false,
-    children: {},
-  },
   [SIDEBAR_ITEMS_KEYS.WIKI]: {
     title: () => I18n.getMessage('wiki'),
     panel: {
@@ -322,7 +308,7 @@ const TABS: SidebarItems = {
     },
     dropdownOpen: false,
     children: {},
-    addSpacer: true,
+    addSpacer: false,
     containerClassName: 'h-6',
   },
   [SIDEBAR_ITEMS_KEYS.SETTINGS]: {
@@ -333,7 +319,7 @@ const TABS: SidebarItems = {
     icon: {
       Element: SettingsIcon,
       props: {
-        className: 'fill-gray w-4 h-4',
+        className: 'fill-granite-gray dark:fill-bright-gray w-4 h-4',
       },
     },
     selectedIcon: {
@@ -343,6 +329,7 @@ const TABS: SidebarItems = {
       },
     },
     dropdownOpen: false,
+    addSpacer: true,
     children: {},
     containerClassName: 'h-6 mb-2',
   },
@@ -351,15 +338,5 @@ const TABS: SidebarItems = {
 export default TABS;
 
 export const collapsedSidebarData: CollapsedSidebarItems = {
-  footerElements: {
-    [SIDEBAR_ITEMS_KEYS.SETTINGS]: {
-      icon: {
-        Element: SettingsIcon,
-        props: {
-          className: 'fill-granite-gray dark:fill-bright-gray',
-        },
-      },
-      title: () => I18n.getMessage('settings'),
-    },
-  },
+  footerElements: {},
 };


### PR DESCRIPTION
## Description

Move settings from bottom to the top in the sidebar

## Relevant Technical Choices

Remove spacer added to the previous item in the sidebar

## Testing Instructions

1. Pull the branch `fix/setting-menu-item`
2. Build the project npm run build:all
4. Navigate to example.com
5. Open privacy sandbox tab on DevTools
6. Observer: the "Settings" sidebar item is under the "Wiki" item at the top, not in the bottom

## Screenshot/Screencast

- Before:

<img width="339" alt="Screenshot 2025-01-29 at 10 25 09 PM" src="https://github.com/user-attachments/assets/d2f96d5f-e444-468c-8932-44375faa0a98" />

- After:

<img width="404" alt="Screenshot 2025-01-29 at 10 23 48 PM" src="https://github.com/user-attachments/assets/b52e0ce6-9000-43a6-ba35-2c7798f877e9" />

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- NA ~[ ] This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).
