### PR TITLE
Feature: Add tab highlighting capabilities

### DIFF
--- a/packages/design-system/src/components/tabs/index.tsx
+++ b/packages/design-system/src/components/tabs/index.tsx
@@ -99,7 +99,7 @@ const Tabs = ({ showBottomBorder = true, fontSizeClass }: TabsProps) => {
                   }
                 )}
               >
-                <span>{title}</span>
+                {title}
               </button>
               <div
                 className={classNames(

--- a/packages/design-system/src/components/tabs/index.tsx
+++ b/packages/design-system/src/components/tabs/index.tsx
@@ -81,6 +81,11 @@ const Tabs = ({ showBottomBorder = true, fontSizeClass }: TabsProps) => {
         {titles.map((title, index) => {
           const isHighlighted = isTabHighlighted(index);
           const isNumber = typeof isHighlighted === 'number';
+          const count = isNumber
+            ? isHighlighted > 9
+              ? '9+'
+              : isHighlighted
+            : '';
 
           return (
             <div className="flex" key={index}>
@@ -115,7 +120,7 @@ const Tabs = ({ showBottomBorder = true, fontSizeClass }: TabsProps) => {
                   }
                 )}
               >
-                {isNumber ? isHighlighted : ''}
+                {count}
               </div>
             </div>
           );

--- a/packages/design-system/src/components/tabs/index.tsx
+++ b/packages/design-system/src/components/tabs/index.tsx
@@ -80,9 +80,17 @@ const Tabs = ({ showBottomBorder = true, fontSizeClass }: TabsProps) => {
       >
         {titles.map((title, index) => (
           <div className="flex" key={index}>
-            {isTabHighlighted(index) && (
-              <span className="h-1.5 w-1.5 rounded-full bg-[#FDCA40] animate-ping" />
-            )}
+            <span
+              className={classNames(
+                'h-2 w-2 rounded-full animate-ping',
+                {
+                  'bg-transparent': !isTabHighlighted(index),
+                },
+                {
+                  'bg-[#FDCA40]': isTabHighlighted(index),
+                }
+              )}
+            />
             <button
               onClick={() => setActiveTab(index)}
               onKeyDown={handleKeyDown}

--- a/packages/design-system/src/components/tabs/index.tsx
+++ b/packages/design-system/src/components/tabs/index.tsx
@@ -80,17 +80,6 @@ const Tabs = ({ showBottomBorder = true, fontSizeClass }: TabsProps) => {
       >
         {titles.map((title, index) => (
           <div className="flex" key={index}>
-            <span
-              className={classNames(
-                'h-2 w-2 rounded-full animate-ping',
-                {
-                  'bg-transparent': !isTabHighlighted(index),
-                },
-                {
-                  'bg-[#FDCA40]': isTabHighlighted(index),
-                }
-              )}
-            />
             <button
               onClick={() => setActiveTab(index)}
               onKeyDown={handleKeyDown}
@@ -108,6 +97,19 @@ const Tabs = ({ showBottomBorder = true, fontSizeClass }: TabsProps) => {
             >
               <span>{title}</span>
             </button>
+            <div
+              className={classNames(
+                'h-4 w-4 rounded-full text-center text-xxxs font-bold text-bright-gray',
+                {
+                  'bg-transparent': !isTabHighlighted(index),
+                },
+                {
+                  'bg-[#cc3300]': isTabHighlighted(index),
+                }
+              )}
+            >
+              {isTabHighlighted(index) && 1}
+            </div>
           </div>
         ))}
       </div>

--- a/packages/design-system/src/components/tabs/index.tsx
+++ b/packages/design-system/src/components/tabs/index.tsx
@@ -31,11 +31,14 @@ interface TabsProps {
 }
 
 const Tabs = ({ showBottomBorder = true, fontSizeClass }: TabsProps) => {
-  const { activeTab, setActiveTab, titles } = useTabs(({ state, actions }) => ({
-    activeTab: state.activeTab,
-    setActiveTab: actions.setActiveTab,
-    titles: state.titles,
-  }));
+  const { activeTab, setActiveTab, titles, isTabHighlighted } = useTabs(
+    ({ state, actions }) => ({
+      activeTab: state.activeTab,
+      setActiveTab: actions.setActiveTab,
+      titles: state.titles,
+      isTabHighlighted: actions.isTabHighlighted,
+    })
+  );
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -76,24 +79,28 @@ const Tabs = ({ showBottomBorder = true, fontSizeClass }: TabsProps) => {
         )}
       >
         {titles.map((title, index) => (
-          <button
-            key={index}
-            onClick={() => setActiveTab(index)}
-            onKeyDown={handleKeyDown}
-            className={classNames(
-              'pb-1.5 px-2 border-b-2 hover:opacity-80 outline-none text-nowrap',
-              {
-                'border-bright-navy-blue dark:border-jordy-blue text-bright-navy-blue dark:text-jordy-blue':
-                  index === activeTab,
-              },
-              {
-                'border-transparent text-raisin-black dark:text-bright-gray':
-                  index !== activeTab,
-              }
+          <div className="flex" key={index}>
+            {isTabHighlighted(index) && (
+              <span className="h-1.5 w-1.5 rounded-full bg-[#FDCA40] animate-ping" />
             )}
-          >
-            {title}
-          </button>
+            <button
+              onClick={() => setActiveTab(index)}
+              onKeyDown={handleKeyDown}
+              className={classNames(
+                'pb-1.5 px-1.5 border-b-2 hover:opacity-80 outline-none text-nowrap',
+                {
+                  'border-bright-navy-blue dark:border-jordy-blue text-bright-navy-blue dark:text-jordy-blue':
+                    index === activeTab,
+                },
+                {
+                  'border-transparent text-raisin-black dark:text-bright-gray':
+                    index !== activeTab,
+                }
+              )}
+            >
+              <span>{title}</span>
+            </button>
+          </div>
         ))}
       </div>
     </div>

--- a/packages/design-system/src/components/tabs/index.tsx
+++ b/packages/design-system/src/components/tabs/index.tsx
@@ -78,40 +78,48 @@ const Tabs = ({ showBottomBorder = true, fontSizeClass }: TabsProps) => {
           fontSizeClass ? fontSizeClass : 'text-sm'
         )}
       >
-        {titles.map((title, index) => (
-          <div className="flex" key={index}>
-            <button
-              onClick={() => setActiveTab(index)}
-              onKeyDown={handleKeyDown}
-              className={classNames(
-                'pb-1.5 px-1.5 border-b-2 hover:opacity-80 outline-none text-nowrap',
-                {
-                  'border-bright-navy-blue dark:border-jordy-blue text-bright-navy-blue dark:text-jordy-blue':
-                    index === activeTab,
-                },
-                {
-                  'border-transparent text-raisin-black dark:text-bright-gray':
-                    index !== activeTab,
-                }
-              )}
-            >
-              <span>{title}</span>
-            </button>
-            <div
-              className={classNames(
-                'h-4 w-4 rounded-full text-center text-xxxs font-bold text-bright-gray',
-                {
-                  'bg-transparent': !isTabHighlighted(index),
-                },
-                {
-                  'bg-[#cc3300]': isTabHighlighted(index),
-                }
-              )}
-            >
-              {isTabHighlighted(index) && 1}
+        {titles.map((title, index) => {
+          const isHighlighted = isTabHighlighted(index);
+          const isNumber = typeof isHighlighted === 'number';
+
+          return (
+            <div className="flex" key={index}>
+              <button
+                onClick={() => setActiveTab(index)}
+                onKeyDown={handleKeyDown}
+                className={classNames(
+                  'pb-1.5 px-1.5 border-b-2 hover:opacity-80 outline-none text-nowrap',
+                  {
+                    'border-bright-navy-blue dark:border-jordy-blue text-bright-navy-blue dark:text-jordy-blue':
+                      index === activeTab,
+                  },
+                  {
+                    'border-transparent text-raisin-black dark:text-bright-gray':
+                      index !== activeTab,
+                  }
+                )}
+              >
+                <span>{title}</span>
+              </button>
+              <div
+                className={classNames(
+                  'h-1.5 w-1.5 rounded-full text-center text-xxxs font-bold text-bright-gray',
+                  {
+                    'bg-transparent': !isHighlighted,
+                  },
+                  {
+                    'bg-mahogany': isHighlighted,
+                  },
+                  {
+                    'h-4 w-4': isNumber,
+                  }
+                )}
+              >
+                {isNumber ? isHighlighted : ''}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/design-system/src/components/tabs/index.tsx
+++ b/packages/design-system/src/components/tabs/index.tsx
@@ -81,11 +81,11 @@ const Tabs = ({ showBottomBorder = true, fontSizeClass }: TabsProps) => {
         {titles.map((title, index) => {
           const isHighlighted = isTabHighlighted(index);
           const isNumber = typeof isHighlighted === 'number';
-          const count = isNumber
-            ? isHighlighted > 9
-              ? '9+'
-              : isHighlighted
-            : '';
+          let count: string | number = '';
+
+          if (isNumber) {
+            count = isHighlighted > 9 ? '9+' : isHighlighted;
+          }
 
           return (
             <div className="flex" key={index}>

--- a/packages/design-system/src/components/tabs/index.tsx
+++ b/packages/design-system/src/components/tabs/index.tsx
@@ -71,7 +71,7 @@ const Tabs = ({ showBottomBorder = true, fontSizeClass }: TabsProps) => {
     >
       <div
         className={classNames(
-          'flex gap-10 mx-4',
+          'flex gap-8 mx-4',
           fontSizeClass ? fontSizeClass : 'text-sm'
         )}
       >
@@ -81,7 +81,7 @@ const Tabs = ({ showBottomBorder = true, fontSizeClass }: TabsProps) => {
             onClick={() => setActiveTab(index)}
             onKeyDown={handleKeyDown}
             className={classNames(
-              'pb-1.5 px-1.5 border-b-2 hover:opacity-80 outline-none text-nowrap',
+              'pb-1.5 px-2 border-b-2 hover:opacity-80 outline-none text-nowrap',
               {
                 'border-bright-navy-blue dark:border-jordy-blue text-bright-navy-blue dark:text-jordy-blue':
                   index === activeTab,

--- a/packages/design-system/src/components/tabs/tests/index.tsx
+++ b/packages/design-system/src/components/tabs/tests/index.tsx
@@ -40,17 +40,19 @@ describe('Tabs', () => {
       activeTab: 0,
       titles: ['title1', 'title2'],
       setActiveTab,
-      isTabHighlighted: jest.fn(() => false),
+      isTabHighlighted: jest.fn((tab: number) => (tab === 0 ? 1 : 99)),
     });
 
     render(<Tabs />);
 
     expect(screen.getByText('title1')).toBeInTheDocument();
     expect(screen.getByText('title1')).toHaveClass('border-b-2');
+    expect(screen.getByText('1')).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('title2'));
 
     expect(screen.getByText('title2')).toHaveClass('border-b-2');
+    expect(screen.getByText('9+')).toBeInTheDocument();
 
     fireEvent.keyDown(screen.getByText('title2'), { key: 'Tab' });
 

--- a/packages/design-system/src/components/tabs/tests/index.tsx
+++ b/packages/design-system/src/components/tabs/tests/index.tsx
@@ -40,6 +40,7 @@ describe('Tabs', () => {
       activeTab: 0,
       titles: ['title1', 'title2'],
       setActiveTab,
+      isTabHighlighted: jest.fn(() => false),
     });
 
     render(<Tabs />);

--- a/packages/design-system/src/components/tabs/useTabs/context.ts
+++ b/packages/design-system/src/components/tabs/useTabs/context.ts
@@ -37,6 +37,8 @@ export interface TabsStoreContext {
   actions: {
     setStorage: (data: string, index?: number) => void;
     setActiveTab: (tab: number) => void;
+    highlightTab: (tab: number) => void;
+    isTabHighlighted: (tab: number) => boolean;
   };
 }
 
@@ -53,6 +55,8 @@ const initialState: TabsStoreContext = {
   actions: {
     setStorage: noop,
     setActiveTab: noop,
+    highlightTab: noop,
+    isTabHighlighted: () => false,
   },
 };
 

--- a/packages/design-system/src/components/tabs/useTabs/context.ts
+++ b/packages/design-system/src/components/tabs/useTabs/context.ts
@@ -37,8 +37,8 @@ export interface TabsStoreContext {
   actions: {
     setStorage: (data: string, index?: number) => void;
     setActiveTab: (tab: number) => void;
-    highlightTab: (tab: number) => void;
-    isTabHighlighted: (tab: number) => boolean;
+    highlightTab: (tab: number, count?: boolean | number) => void;
+    isTabHighlighted: (tab: number) => boolean | number;
   };
 }
 

--- a/packages/design-system/src/components/tabs/useTabs/context.ts
+++ b/packages/design-system/src/components/tabs/useTabs/context.ts
@@ -37,7 +37,11 @@ export interface TabsStoreContext {
   actions: {
     setStorage: (data: string, index?: number) => void;
     setActiveTab: (tab: number) => void;
-    highlightTab: (tab: number, count?: boolean | number) => void;
+    highlightTab: (
+      tab: number,
+      count?: boolean | number,
+      increment?: boolean
+    ) => void;
     isTabHighlighted: (tab: number) => boolean | number;
   };
 }

--- a/packages/design-system/src/components/tabs/useTabs/provider.tsx
+++ b/packages/design-system/src/components/tabs/useTabs/provider.tsx
@@ -96,15 +96,22 @@ export const TabsProvider = ({
     [activeTab]
   );
 
-  const highlightTab = useCallback((tab: number) => {
-    setHighlightedTabs((prev) => [...prev, tab]);
-    unhighlightTabTimeoutsRef.current = [
-      ...(unhighlightTabTimeoutsRef.current ?? []),
-      setTimeout(() => {
-        setHighlightedTabs((prev) => prev.filter((i) => i !== tab));
-      }, 5000),
-    ];
-  }, []);
+  const highlightTab = useCallback(
+    (tab: number) => {
+      if (tab === activeTab) {
+        return;
+      }
+
+      setHighlightedTabs((prev) => [...prev, tab]);
+      unhighlightTabTimeoutsRef.current = [
+        ...(unhighlightTabTimeoutsRef.current ?? []),
+        setTimeout(() => {
+          setHighlightedTabs((prev) => prev.filter((i) => i !== tab));
+        }, 10000),
+      ];
+    },
+    [activeTab]
+  );
 
   const isTabHighlighted = useCallback(
     (tab: number) => {
@@ -112,6 +119,12 @@ export const TabsProvider = ({
     },
     [highlightedTabs]
   );
+
+  useEffect(() => {
+    if (highlightedTabs.includes(activeTab)) {
+      setHighlightedTabs((prev) => prev.filter((i) => i !== activeTab));
+    }
+  }, [activeTab, highlightedTabs]);
 
   return (
     <TabsContext.Provider

--- a/packages/design-system/src/components/tabs/useTabs/provider.tsx
+++ b/packages/design-system/src/components/tabs/useTabs/provider.tsx
@@ -89,14 +89,16 @@ export const TabsProvider = ({
   );
 
   const highlightTab = useCallback(
-    (tab: number, count: number | boolean = true) => {
+    (tab: number, count: number | boolean = true, increment = false) => {
       if (tab === activeTabRef.current) {
         return;
       }
 
       setHighlightedTabs((prev) => {
         const next = { ...prev };
-        next[tab] = count;
+        const prevCount = typeof next[tab] === 'number' ? next[tab] : 0;
+
+        next[tab] = increment ? prevCount + 1 : count;
         return next;
       });
     },

--- a/packages/design-system/src/components/tabs/useTabs/provider.tsx
+++ b/packages/design-system/src/components/tabs/useTabs/provider.tsx
@@ -41,7 +41,9 @@ export const TabsProvider = ({
   const [storage, _setStorage] = useState<string[]>(
     Array(items.length).fill('')
   );
-  const [highlightedTabs, setHighlightedTabs] = useState<number[]>([]);
+  const [highlightedTabs, setHighlightedTabs] = useState<
+    Record<number, number | boolean>
+  >({});
 
   useEffect(() => {
     activeTabRef.current = activeTab;
@@ -86,26 +88,37 @@ export const TabsProvider = ({
     [activeTab]
   );
 
-  const highlightTab = useCallback((tab: number) => {
-    if (tab === activeTabRef.current) {
-      return;
-    }
+  const highlightTab = useCallback(
+    (tab: number, count: number | boolean = true) => {
+      if (tab === activeTabRef.current) {
+        return;
+      }
 
-    setHighlightedTabs((prev) => [...prev, tab]);
-  }, []);
+      setHighlightedTabs((prev) => {
+        const next = { ...prev };
+        next[tab] = count;
+        return next;
+      });
+    },
+    []
+  );
 
   const isTabHighlighted = useCallback(
     (tab: number) => {
-      return highlightedTabs.includes(tab);
+      return highlightedTabs?.[tab] ?? false;
     },
     [highlightedTabs]
   );
 
   useEffect(() => {
-    if (highlightedTabs.includes(activeTab)) {
-      setHighlightedTabs((prev) => prev.filter((i) => i !== activeTab));
+    if (highlightedTabs[activeTabRef.current]) {
+      setHighlightedTabs((prev) => {
+        const next = { ...prev };
+        next[activeTabRef.current] = false;
+        return next;
+      });
     }
-  }, [activeTab, highlightedTabs]);
+  }, [activeTab, highlightTab, highlightedTabs]);
 
   return (
     <TabsContext.Provider

--- a/packages/design-system/src/components/tabs/useTabs/provider.tsx
+++ b/packages/design-system/src/components/tabs/useTabs/provider.tsx
@@ -102,7 +102,7 @@ export const TabsProvider = ({
       ...(unhighlightTabTimeoutsRef.current ?? []),
       setTimeout(() => {
         setHighlightedTabs((prev) => prev.filter((i) => i !== tab));
-      }, 1000),
+      }, 5000),
     ];
   }, []);
 

--- a/packages/design-system/src/components/tabs/useTabs/provider.tsx
+++ b/packages/design-system/src/components/tabs/useTabs/provider.tsx
@@ -37,6 +37,7 @@ export const TabsProvider = ({
 }: PropsWithChildren<TabsProviderProps>) => {
   const [tabItems, setTabItems] = useState(items);
   const [activeTab, setActiveTab] = useState(0);
+  const activeTabRef = useRef(activeTab);
   const [storage, _setStorage] = useState<string[]>(
     Array(items.length).fill('')
   );
@@ -44,6 +45,10 @@ export const TabsProvider = ({
   const unhighlightTabTimeoutsRef = useRef<
     ReturnType<typeof setTimeout>[] | null
   >(null);
+
+  useEffect(() => {
+    activeTabRef.current = activeTab;
+  }, [activeTab]);
 
   useEffect(() => {
     const timeouts = unhighlightTabTimeoutsRef.current;
@@ -96,22 +101,19 @@ export const TabsProvider = ({
     [activeTab]
   );
 
-  const highlightTab = useCallback(
-    (tab: number) => {
-      if (tab === activeTab) {
-        return;
-      }
+  const highlightTab = useCallback((tab: number) => {
+    if (tab === activeTabRef.current) {
+      return;
+    }
 
-      setHighlightedTabs((prev) => [...prev, tab]);
-      unhighlightTabTimeoutsRef.current = [
-        ...(unhighlightTabTimeoutsRef.current ?? []),
-        setTimeout(() => {
-          setHighlightedTabs((prev) => prev.filter((i) => i !== tab));
-        }, 10000),
-      ];
-    },
-    [activeTab]
-  );
+    setHighlightedTabs((prev) => [...prev, tab]);
+    unhighlightTabTimeoutsRef.current = [
+      ...(unhighlightTabTimeoutsRef.current ?? []),
+      setTimeout(() => {
+        setHighlightedTabs((prev) => prev.filter((i) => i !== tab));
+      }, 10000),
+    ];
+  }, []);
 
   const isTabHighlighted = useCallback(
     (tab: number) => {

--- a/packages/design-system/src/components/tabs/useTabs/provider.tsx
+++ b/packages/design-system/src/components/tabs/useTabs/provider.tsx
@@ -42,25 +42,10 @@ export const TabsProvider = ({
     Array(items.length).fill('')
   );
   const [highlightedTabs, setHighlightedTabs] = useState<number[]>([]);
-  const unhighlightTabTimeoutsRef = useRef<
-    ReturnType<typeof setTimeout>[] | null
-  >(null);
 
   useEffect(() => {
     activeTabRef.current = activeTab;
   }, [activeTab]);
-
-  useEffect(() => {
-    const timeouts = unhighlightTabTimeoutsRef.current;
-
-    return () => {
-      if (timeouts) {
-        timeouts.forEach((timeout) => {
-          clearTimeout(timeout);
-        });
-      }
-    };
-  }, []);
 
   useEffect(() => {
     setTabItems(items);
@@ -107,12 +92,6 @@ export const TabsProvider = ({
     }
 
     setHighlightedTabs((prev) => [...prev, tab]);
-    unhighlightTabTimeoutsRef.current = [
-      ...(unhighlightTabTimeoutsRef.current ?? []),
-      setTimeout(() => {
-        setHighlightedTabs((prev) => prev.filter((i) => i !== tab));
-      }, 10000),
-    ];
   }, []);
 
   const isTabHighlighted = useCallback(

--- a/packages/design-system/src/components/tabs/useTabs/tests/index.tsx
+++ b/packages/design-system/src/components/tabs/useTabs/tests/index.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/*
+ * Internal dependencies
+ */
+import { TabsProvider } from '../provider';
+import { useTabs } from '../useTabs';
+
+const customRender = (options?: any) => {
+  return render(
+    <TabsProvider {...options}>
+      <TestingComponent />
+    </TabsProvider>
+  );
+};
+
+const TestingComponent = () => {
+  const { activeTab, setActiveTab, titles, highlightTab, isTabHighlighted } =
+    useTabs(({ state, actions }) => ({
+      activeTab: state.activeTab,
+      setActiveTab: actions.setActiveTab,
+      titles: state.titles,
+      highlightTab: actions.highlightTab,
+      isTabHighlighted: actions.isTabHighlighted,
+    }));
+
+  return (
+    <div>
+      <button onClick={() => setActiveTab(0)}>select title1</button>
+      <button onClick={() => setActiveTab(1)}>select title2</button>
+      <button onClick={() => highlightTab(0, 1)}>highlight tab 1</button>
+      <button onClick={() => highlightTab(0, true, true)}>
+        increment tab 1
+      </button>
+      <button onClick={() => highlightTab(1, 99)}>highlight tab 2</button>
+      <button onClick={() => highlightTab(1)}>highlight 2 without count</button>
+
+      {titles.map((title, index) => {
+        const isHighlighted = isTabHighlighted(index);
+        const isNumber = typeof isHighlighted === 'number';
+        const count = isNumber
+          ? isHighlighted > 9
+            ? '9+'
+            : isHighlighted
+          : isHighlighted
+          ? 'placeholder' + index
+          : 'empty' + index;
+
+        return (
+          <>
+            <button
+              key={index}
+              onClick={() => setActiveTab(index)}
+              className={activeTab === index ? 'border-b-2' : ''}
+            >
+              {title}
+            </button>
+            <p>{count}</p>
+          </>
+        );
+      })}
+    </div>
+  );
+};
+
+describe('useTabs', () => {
+  it('should render tabs context provider, with tabs navigation and highlight functionality', () => {
+    const items = [
+      { title: 'title1', content: 'content1' },
+      { title: 'title2', content: 'content2' },
+    ];
+
+    customRender({ items });
+
+    const title1 = screen.getByText('title1');
+    const title2 = screen.getByText('title2');
+
+    expect(title1).toBeInTheDocument();
+    expect(title2).toBeInTheDocument();
+
+    // Click on the second tab
+    fireEvent.click(screen.getByText('select title2'));
+    expect(title2).toHaveClass('border-b-2');
+
+    // Highlight the first tab with a count of 1
+    fireEvent.click(screen.getByText('highlight tab 1'));
+    expect(screen.getByText('1')).toBeInTheDocument();
+
+    // Increment the count of the first tab
+    fireEvent.click(screen.getByText('increment tab 1'));
+    expect(screen.getByText('2')).toBeInTheDocument();
+
+    // select the first tab and count should be empty
+    fireEvent.click(screen.getByText('select title1'));
+    expect(screen.getByText('title1')).toHaveClass('border-b-2');
+    expect(screen.getByText('empty0')).toBeInTheDocument();
+
+    // Highlight the second tab with a count of 99, which should be 9+
+    fireEvent.click(screen.getByText('highlight tab 2'));
+    expect(screen.getByText('9+')).toBeInTheDocument();
+
+    // Highlight the second tab without a count
+    fireEvent.click(screen.getByText('highlight 2 without count'));
+    expect(screen.getByText('placeholder1')).toBeInTheDocument();
+  });
+});

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
@@ -150,6 +150,8 @@ const Panel = ({
     }
 
     if (currentSiteData?.type === 'advertiser') {
+      highlightTab(1, false);
+      highlightTab(2, false);
       highlightTab(0);
     } else {
       highlightTab(1);

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
@@ -153,6 +153,7 @@ const Panel = ({
       highlightTab(0);
     } else {
       highlightTab(1);
+      highlightTab(2);
     }
   }, [currentSiteData, currentSiteData?.type, highlightTab, setActiveTab]);
 

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
@@ -118,8 +118,9 @@ const Panel = ({
     [setPlaying]
   );
 
-  const { setActiveTab } = useTabs(({ actions }) => ({
+  const { setActiveTab, highlightTab } = useTabs(({ actions }) => ({
     setActiveTab: actions.setActiveTab,
+    highlightTab: actions.highlightTab,
   }));
 
   useEffect(() => {
@@ -149,11 +150,11 @@ const Panel = ({
     }
 
     if (currentSiteData?.type === 'advertiser') {
-      setActiveTab(0);
+      highlightTab(0);
     } else {
-      setActiveTab(1);
+      highlightTab(1);
     }
-  }, [currentSiteData, currentSiteData?.type, setActiveTab]);
+  }, [currentSiteData, currentSiteData?.type, highlightTab, setActiveTab]);
 
   const handleResizeCallback = useMemo(() => {
     return new ResizeObserver(() => {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -217,6 +217,7 @@ module.exports = {
       'selection-yellow-light': '#8b8f18',
       'selection-yellow-dark': '#dbdb48',
       'cultured-grey': '#F7F7F7',
+      mahogany: '#CC3300',
     },
     borderColor: {
       ...colors,


### PR DESCRIPTION
## Description
This PR adds code to handle tab highlighting.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices
- `highlightTab` callback highlights the tab with a bubble alongside the title.
  - `count` param is used to set tab updates count.
  - `increment` param is used to increment the update count.
<!-- Please describe your changes. -->

## Testing Instructions
- Navigate to PA EE, let the animation run.
- When the user reaches publisher site, the tabs should not auto switch.
- The auction and bids tabs should be highlighted.
- Once the highlighted tab is navigated to, the bubble should disappear.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="825" alt="Screenshot 2025-02-04 at 12 31 14" src="https://github.com/user-attachments/assets/4432d74b-2ed3-458c-ab30-4a48ff88397f" />

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #857 
