### PR TITLE
Bring back the story links for all cards in all sections

### DIFF
--- a/packages/extension/src/view/devtools/components/antiCovertTracking/antiCovertTracking.tsx
+++ b/packages/extension/src/view/devtools/components/antiCovertTracking/antiCovertTracking.tsx
@@ -26,21 +26,29 @@ const content = [
     title: () => I18n.getMessage('ipProtection'),
     description: () => I18n.getMessage('ipProtectionDescription'),
     url: 'https://developers.google.com/privacy-sandbox/protections/ip-protection',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/a-new-path-for-privacy-sandbox-on-the-web/',
   },
   {
     title: () => I18n.getMessage('bounceTrackingMitigations'),
     description: () => I18n.getMessage('bounceTrackingMitigationsDescription'),
     url: 'https://developers.google.com/privacy-sandbox/protections/bounce-tracking-mitigations',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/a-new-path-for-privacy-sandbox-on-the-web/',
   },
   {
     title: () => I18n.getMessage('userAgentReduction'),
     description: () => I18n.getMessage('userAgentReductionDescription'),
     url: 'https://developers.google.com/privacy-sandbox/protections/user-agent',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/a-new-path-for-privacy-sandbox-on-the-web/',
   },
   {
     title: () => I18n.getMessage('privateStateTokens'),
     description: () => I18n.getMessage('privateStateTokensDescription'),
     url: 'https://developers.google.com/privacy-sandbox/protections/private-state-tokens',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/a-new-path-for-privacy-sandbox-on-the-web/',
   },
 ];
 

--- a/packages/extension/src/view/devtools/components/privateAdvertising/privateAdvertising.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/privateAdvertising.tsx
@@ -26,16 +26,22 @@ const content = [
     title: () => I18n.getMessage('topics'),
     description: () => I18n.getMessage('topicsDescription'),
     url: 'https://developers.google.com/privacy-sandbox/relevance/topics',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/a-new-path-for-privacy-sandbox-on-the-web/',
   },
   {
     title: () => I18n.getMessage('protectedAudience'),
     description: () => I18n.getMessage('protectedAudienceDescription'),
     url: 'https://developers.google.com/privacy-sandbox/relevance/protected-audience',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/a-new-path-for-privacy-sandbox-on-the-web/',
   },
   {
     title: () => I18n.getMessage('attributionReporting'),
     description: () => I18n.getMessage('attributionReportingDescription'),
     url: 'https://developers.google.com/privacy-sandbox/relevance/attribution-reporting',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/a-new-path-for-privacy-sandbox-on-the-web/',
   },
   {
     title: () => I18n.getMessage('privateAggregation'),

--- a/packages/extension/src/view/devtools/components/siteBoundaries/siteBoundaries.tsx
+++ b/packages/extension/src/view/devtools/components/siteBoundaries/siteBoundaries.tsx
@@ -25,21 +25,29 @@ const content = [
     title: () => I18n.getMessage('chips'),
     description: () => I18n.getMessage('chipsDescription'),
     url: 'https://developers.google.com/privacy-sandbox/3pcd/chips',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/a-new-path-for-privacy-sandbox-on-the-web/',
   },
   {
     title: () => I18n.getMessage('storageAccessAPI'),
     description: () => I18n.getMessage('storageAccessAPIDescription'),
     url: 'https://developers.google.com/privacy-sandbox/3pcd/storage-access-api',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/a-new-path-for-privacy-sandbox-on-the-web/',
   },
   {
     title: () => I18n.getMessage('rws'),
     description: () => I18n.getMessage('rwsDescription'),
     url: 'https://developers.google.com/privacy-sandbox/3pcd/related-website-sets',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/a-new-path-for-privacy-sandbox-on-the-web/',
   },
   {
     title: () => I18n.getMessage('fedcm'),
     description: () => I18n.getMessage('fedcmDescription'),
     url: 'https://developers.google.com/privacy-sandbox/3pcd/fedcm',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/a-new-path-for-privacy-sandbox-on-the-web/',
   },
 ];
 


### PR DESCRIPTION
## Description

Brings back the dummy story link for testing in for all the cards in all the sections.

## Relevant Technical Choices

<!-- Please describe your changes. -->
N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->
1. Build the extension from source.
2. Verify the presence of dummy web story link in all the cards in all sections.


## Additional Information:



## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->
![image](https://github.com/user-attachments/assets/db487f62-221d-4b09-8ae5-88e8bc7af251)

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] [N/A] ~This code is covered by unit tests to verify that it works as intended.~
- [ ] [Skipped] ~The QA of this PR is done by a member of the QA team (to be checked by QA).~
