### PR TITLE
Explorable Explanation: Add legend content and remove 'General Use' from info tab

### DIFF
--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -68,3 +68,4 @@ export * from './chipsBar';
 export { default as FiltersSidebar } from './filtersSidebar';
 export * from './filtersSidebar';
 export { default as DraggableTray } from './draggableTray';
+export { default as Link } from './link';

--- a/packages/design-system/src/components/link/index.tsx
+++ b/packages/design-system/src/components/link/index.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies.
+ */
+import React, { useCallback } from 'react';
+
+interface LinkProps {
+  href: string;
+  children: React.ReactElement | string;
+}
+
+const Link = ({ href, children, ...rest }: LinkProps) => {
+  const onClick = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+      event.preventDefault();
+      chrome.tabs.update({ url: href });
+    },
+    [href]
+  );
+
+  return (
+    <a
+      onClick={onClick}
+      href={href}
+      className="text-bright-navy-blue"
+      {...rest}
+    >
+      {children}
+    </a>
+  );
+};
+
+export default Link;

--- a/packages/explorable-explanations/src/protectedAudience/modules/flowConfig.jsx
+++ b/packages/explorable-explanations/src/protectedAudience/modules/flowConfig.jsx
@@ -24,18 +24,17 @@ export const ADVERTIZER_CONFIG = {
     info: (
       <>
         <p>
+          These are script tags embedded in the advertiser's webpage that enable
+          communication with DSP servers. DSP tags help associate users with
+          interest groups for retargeting and audience building in future ad
+          campaigns.
+        </p>
+        <p className="mt-1">
           They collect user data, which is sent to DSP servers for processing
           (see the next DSPs box) and the received JSON response from DSP
           servers is passed as a parameter to the{' '}
           <code className="text-upsed-tomato">joinAdInterestGroup()</code>{' '}
           function to join interest groups.
-        </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
-          These are script tags embedded in the advertiser's webpage that enable
-          communication with DSP servers. DSP tags help associate users with
-          interest groups for retargeting and audience building in future ad
-          campaigns.
         </p>
       </>
     ),
@@ -45,23 +44,19 @@ export const ADVERTIZER_CONFIG = {
     info: (
       <>
         <p>
-          It receives the user data from the DSP tags, processes it, and sends
-          JSON responses to the DSP tags for joining interest groups (see DSP
-          Tags box).
-        </p>
-        <p>
-          These <strong>interest groups</strong> are added to the user's browser
-          and are shown with small bubbles here. They store user profiles based
-          on demographics, location, and behavior while ensuring compliance with
-          privacy standards like the Protected Audience API.
-        </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
           DSP servers on the advertiser's side handle user tracking, data
           processing, and interest group management. They process user behavior
           and decide if the user should be added to specific interest groups.
           (called from the DSP Tag). DSPs are the owners of the interest groups
           that the user joins.
+        </p>
+        <p className="mt-1">
+          It receives the user data from the DSP tags, processes it, and sends
+          JSON responses to the DSP tags for joining interest groups (see DSP
+          Tags box). These <strong>interest groups</strong> are added to the
+          user's browser and are shown with small bubbles here. They store user
+          profiles based on demographics, location, and behavior while ensuring
+          compliance with privacy standards like the Protected Audience API.
         </p>
       </>
     ),
@@ -74,13 +69,6 @@ export const SINGLE_SELLER_CONFIG = {
     info: (
       <>
         <p>
-          The SSP ad tag sends an ad request to the SSP server indicating that
-          the browser supports Protected Audience API. It also returns
-          contextual auction responses to the{' '}
-          <code className="text-upsed-tomato">runAdAuction()</code> function.
-        </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
           <p>
             An SSP tag is a script placed on the publisher's page that enables
             the SSP to initiate ad requests and pass them to DSPs. It does the
@@ -97,6 +85,12 @@ export const SINGLE_SELLER_CONFIG = {
             </li>
           </ul>
         </p>
+        <p className="mt-1">
+          The SSP ad tag sends an ad request to the SSP server indicating that
+          the browser supports Protected Audience API. It also returns
+          contextual auction responses to the{' '}
+          <code className="text-upsed-tomato">runAdAuction()</code> function.
+        </p>
       </>
     ),
   },
@@ -105,28 +99,23 @@ export const SINGLE_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          An SSP is a platform that helps publishers manage, sell, and optimize
+          their ad inventory programmatically. It connects publishers with
+          multiple demand sources like DSPs, advertisers, and ad exchanges to
+          facilitate real-time bidding (RTB) auctions.
+        </p>
+        <p>
+          The SSP server sends ad requests received from the SSP Tag to the DSPs
+          who bid on the ad space via RTB. It also returns the winning ad
+          creative that is used while scoring the ad in{' '}
+          <code className="text-upsed-tomato">scoreAd()</code>.
+        </p>
+        <p>Example: Google Ad Manager, Magnite.</p>
+        <p className="mt-1">
           SSP server sends contextual OpenRTB bid requests to DSP indicating
           that the browser supports Protected Audience API. It also runs
           contextual auction and returns the winner along with auctions
           configuration to SSP tags.
-        </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
-          <p>
-            An SSP is a platform that helps publishers manage, sell, and
-            optimize their ad inventory programmatically. It connects publishers
-            with multiple demand sources like DSPs, advertisers, and ad
-            exchanges to facilitate real-time bidding (RTB) auctions.
-          </p>
-          <p>
-            The SSP server sends ad requests received from the SSP Tag to the
-            DSPs who bid on the ad space via RTB.
-          </p>
-          <p>
-            It also returns the winning ad creative that is used while scoring
-            the ad in <code className="text-upsed-tomato">scoreAd()</code>.
-          </p>
-          <p>Example: Google Ad Manager, Magnite.</p>
         </p>
       </>
     ),
@@ -136,26 +125,21 @@ export const SINGLE_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          On the publisher side, DSP servers process ad requests, evaluate bids,
+          and serve ads based on campaign targeting and bidding strategies. They
+          handle bid generation, ad selection, and reporting during ad auctions
+          initiated by SSPs. The DSP server evaluates bid requests in real-time,
+          using signals such as interest groups, contextual relevance, and
+          advertiser budgets to decide whether to bid.
+        </p>
+        <p>
+          When contacted by SSP during contextual auction they respond with bids
+          based on the results calculated on the basis of ad requests received
+          via SSP. The DSPs and the SSP communicate using RTB protocols.
+        </p>
+        <p className="mt-1">
           DSP responds with an OpenRTB bid response containing signals for the
           on-device auction.
-        </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
-          <p>
-            On the publisher side, DSP servers process ad requests, evaluate
-            bids, and serve ads based on campaign targeting and bidding
-            strategies. They handle bid generation, ad selection, and reporting
-            during ad auctions initiated by SSPs. The DSP server evaluates bid
-            requests in real-time, using signals such as interest groups,
-            contextual relevance, and advertiser budgets to decide whether to
-            bid.
-          </p>
-          <p>
-            When contacted by SSP during contextual auction they respond with
-            bids based on the results calculated on the basis of ad requests
-            received via SSP. The DSPs and the SSP communicate using RTB
-            protocols.
-          </p>
         </p>
       </>
     ),
@@ -193,6 +177,12 @@ export const SINGLE_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          A secure DSP-side server that handles bid generation using key/value
+          pairs for interest group and contextual data. It ensures data
+          processing aligns with privacy requirements, creating competitive bids
+          based on predefined values.
+        </p>
+        <p className="mt-1">
           Chrome calls{' '}
           <a
             className="text-bright-navy-blue"
@@ -204,15 +194,6 @@ export const SINGLE_SELLER_CONFIG = {
           </a>{' '}
           to fetch real-time bidding signals.
         </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
-          <p>
-            A secure DSP-side server that handles bid generation using key/value
-            pairs for interest group and contextual data. It ensures data
-            processing aligns with privacy requirements, creating competitive
-            bids based on predefined values.
-          </p>
-        </p>
       </>
     ),
   },
@@ -222,6 +203,12 @@ export const SINGLE_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          A DSP-side function that generates a bid for an auction based on
+          interest group data, contextual signals, and advertiser preferences.
+          Outputs include bid amount, ad creative, and metadata, ensuring
+          relevance and competitiveness in the auction.
+        </p>
+        <p className="mt-1">
           Chrome calls{' '}
           <a
             className="text-bright-navy-blue"
@@ -233,13 +220,6 @@ export const SINGLE_SELLER_CONFIG = {
           </a>{' '}
           DSP JavaScript function for each participating interest group.
         </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>A DSP-side function
-          that generates a bid for an auction based on interest group data,
-          contextual signals, and advertiser preferences. Outputs include bid
-          amount, ad creative, and metadata, ensuring relevance and
-          competitiveness in the auction.
-        </p>
       </>
     ),
   },
@@ -248,27 +228,22 @@ export const SINGLE_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          On the publisher side, DSP servers process ad requests, evaluate bids,
+          and serve ads based on campaign targeting and bidding strategies. They
+          handle bid generation, ad selection, and reporting during ad auctions
+          initiated by SSPs. The DSP server evaluates bid requests in real-time,
+          using signals such as interest groups, contextual relevance, and
+          advertiser budgets to decide whether to bid.
+        </p>
+        <p>
+          When contacted by SSP during contextual auction they respond with bids
+          based on the results calculated on the basis of ad requests received
+          via SSP. The DSPs and the SSP communicate using RTB protocols.
+        </p>
+        <p className="mt-1">
           DSP responds with a bid when{' '}
           <code className="text-upsed-tomato">generateBid()</code> function is
           called from their respective DSP tags.
-        </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
-          <p>
-            On the publisher side, DSP servers process ad requests, evaluate
-            bids, and serve ads based on campaign targeting and bidding
-            strategies. They handle bid generation, ad selection, and reporting
-            during ad auctions initiated by SSPs. The DSP server evaluates bid
-            requests in real-time, using signals such as interest groups,
-            contextual relevance, and advertiser budgets to decide whether to
-            bid.
-          </p>
-          <p>
-            When contacted by SSP during contextual auction they respond with
-            bids based on the results calculated on the basis of ad requests
-            received via SSP. The DSPs and the SSP communicate using RTB
-            protocols.
-          </p>
         </p>
       </>
     ),
@@ -279,6 +254,11 @@ export const SINGLE_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          A secure SSP-side server responsible for ad scoring and auction
+          facilitation. It uses key/value pairs to evaluate bids and ensures
+          data privacy and compliance during ad auctions.
+        </p>
+        <p className="mt-1">
           Chrome calls{' '}
           <a
             className="text-bright-navy-blue"
@@ -290,12 +270,6 @@ export const SINGLE_SELLER_CONFIG = {
           </a>{' '}
           to fetch real-time scoring signals.
         </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>A secure SSP-side
-          server responsible for ad scoring and auction facilitation. It uses
-          key/value pairs to evaluate bids and ensures data privacy and
-          compliance during ad auctions.
-        </p>
       </>
     ),
   },
@@ -305,6 +279,13 @@ export const SINGLE_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          An SSP-side function that evaluates and ranks bids during an ad
+          auction based on price, relevance, and publisher-defined criteria.
+          Outputs a ranked list of bids, selecting the top bid as the winner for
+          ad display. Any bid that is less than the contextual bid passed by the
+          SSP tag while calling the runAdAuction is rejected.
+        </p>
+        <p className="mt-1">
           Chrome calls{' '}
           <a
             className="text-bright-navy-blue"
@@ -316,19 +297,6 @@ export const SINGLE_SELLER_CONFIG = {
           </a>{' '}
           SSP JavaScript function for each participating interest group.
         </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
-          <p>
-            An SSP-side function that evaluates and ranks bids during an ad
-            auction based on price, relevance, and publisher-defined criteria.
-            Outputs a ranked list of bids, selecting the top bid as the winner
-            for ad display.
-          </p>
-          <p>
-            Any bid that is less than the contextual bid passed by the SSP tag
-            while calling the runAdAuction is rejected.
-          </p>
-        </p>
       </>
     ),
   },
@@ -338,6 +306,12 @@ export const SINGLE_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          A function executed by the winning DSP to log auction details,
+          including bid price and ad performance, for reporting and
+          optimization. It ensures transparency for campaign performance and
+          provides data for analytics and billing.
+        </p>
+        <p className="mt-1">
           Chrome calls{' '}
           <a
             className="text-bright-navy-blue"
@@ -349,12 +323,6 @@ export const SINGLE_SELLER_CONFIG = {
           </a>{' '}
           DSP JavaScript function to report the winner to DSP.
         </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>A function executed by
-          the winning DSP to log auction details, including bid price and ad
-          performance, for reporting and optimization. It ensures transparency
-          for campaign performance and provides data for analytics and billing.
-        </p>
       </>
     ),
   },
@@ -364,6 +332,11 @@ export const SINGLE_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          A function executed by the SSP or publisher to log auction results,
+          providing transparency and analytics to all parties. It tracks metrics
+          such as winning bids, auction details, and ad performance.
+        </p>
+        <p className="mt-1">
           Chrome calls{' '}
           <a
             className="text-bright-navy-blue"
@@ -374,12 +347,6 @@ export const SINGLE_SELLER_CONFIG = {
             <code className="text-upsed-tomato">reportResult()</code>
           </a>{' '}
           SSP JavaScript function to report the winner to SSP.
-        </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>A function executed by
-          the SSP or publisher to log auction results, providing transparency
-          and analytics to all parties. It tracks metrics such as winning bids,
-          auction details, and ad performance.
         </p>
       </>
     ),
@@ -407,16 +374,13 @@ export const MULTI_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          The header bidding tag loads on the browser and initiates the header
+          bidding process using libraries like Pre-bid or Amazon TAM. This
+          maximizes competition and potentially increases revenue.
+        </p>
+        <p className="mt-1">
           The SSP adapter sends ad requests to the SSP server indicating that
           the browser supports Protected Audience API.
-        </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
-          <p>
-            The header bidding tag loads on the browser and initiates the header
-            bidding process using libraries like Pre-bid or Amazon TAM.
-          </p>
-          <p> This maximizes competition and potentially increases revenue.</p>
         </p>
       </>
     ),
@@ -429,45 +393,38 @@ export const MULTI_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          These are script tags embedded in the advertiser's webpage that enable
+          communication with publisher ad tag webpage. When a user visits a
+          webpage with an ad tag, the tag signals along with header bidding
+          winner to the publisher's ad server that there's an opportunity to
+          show an ad.
+        </p>
+        <p>The ad tag contains key information about the ad space, such as:</p>
+        <ul>
+          <li>
+            <strong>Ad unit ID:</strong> This identifies the specific ad slot on
+            the page.
+          </li>
+          <li>
+            <strong>Ad size:</strong> Specifies the dimensions of the ad slot
+            (e.g., 300x250 pixels).
+          </li>
+          <li>
+            <strong>Page context:</strong> May include information about the
+            webpage content, user demographics, or other targeting parameters.
+          </li>
+        </ul>
+        <p>
+          These tags are crucial for the ad delivery process, ensuring that the
+          right ads are shown to the right users at the right time.
+        </p>
+        <p className="mt-1">
           The Publisher Ad Server tag sends an ad request to the Publisher Ad
           Server. It initiates on-device auction by calling{' '}
           <a href="https://github.com/WICG/turtledove/blob/main/FLEDGE.md#21-initiating-an-on-device-auction">
             <code className="text-upsed-tomato">runAdAuction()</code>
           </a>{' '}
           function.
-        </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
-          <p>
-            These are script tags embedded in the advertiser's webpage that
-            enable communication with publisher ad tag webpage
-          </p>
-          <p>
-            When a user visits a webpage with an ad tag, the tag signals along
-            with header bidding winner to the publisher's ad server that there's
-            an opportunity to show an ad.
-          </p>
-          <p>
-            The ad tag contains key information about the ad space, such as:
-          </p>
-          <ul>
-            <li>
-              <strong>Ad unit ID:</strong> This identifies the specific ad slot
-              on the page.
-            </li>
-            <li>
-              <strong>Ad size:</strong> Specifies the dimensions of the ad slot
-              (e.g., 300x250 pixels).
-            </li>
-            <li>
-              <strong>Page context:</strong> May include information about the
-              webpage content, user demographics, or other targeting parameters.
-            </li>
-          </ul>
-          <p>
-            These tags are crucial for the ad delivery process, ensuring that
-            the right ads are shown to the right users at the right time.
-          </p>
         </p>
       </>
     ),
@@ -549,11 +506,9 @@ export const MULTI_SELLER_CONFIG = {
           each component auction advances to the top-level auction, which
           determines the final ad to be displayed. In unified flows, the
           top-level auction includes winners from both contextual and Protected
-          Audience auctions.
-        </p>
-        <p>
-          Each component auction adheres to the single-seller unified flow
-          outlined in the <em>Bidding and Auction Services Design</em>.
+          Audience auctions. Each component auction adheres to the single-seller
+          unified flow outlined in the{' '}
+          <em>Bidding and Auction Services Design</em>.
         </p>
         <a
           className="text-bright-navy-blue"
@@ -571,6 +526,24 @@ export const MULTI_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          The <code className="text-upsed-tomato">scoreAd()</code> function
+          evaluates and ranks bids during an ad auction based on price,
+          relevance, and publisher-defined criteria. The function outputs a
+          ranked list of bids, selecting the top bid as the winner for ad
+          display.It is implemented by the SSP or publisher, and called by the
+          SSPs to determine the winning bid. It ranks bids from the component
+          auctions. It is implemented by the SSP or publisher, and called by the
+          SSPs to determine the winning bid.
+        </p>
+        <p>
+          The <code className="text-upsed-tomato">scoreAd()</code> function in
+          multi-seller configuration ranks bids from the component auctions and
+          compares with the contextual bid winner passed during the start of the
+          runAdAunction. Any bid less than the contextual bid winner is rejected
+          and bids higher than contextual bid winner are accepted for
+          comparison.
+        </p>
+        <p className="mt-1">
           Chrome calls{' '}
           <a
             className="text-bright-navy-blue"
@@ -582,28 +555,6 @@ export const MULTI_SELLER_CONFIG = {
           </a>{' '}
           SSP JavaScript function for each participating interest group.
         </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
-          <p>
-            The scoreAd() function evaluates and ranks bids during an ad auction
-            based on price, relevance, and publisher-defined criteria. The
-            function outputs a ranked list of bids, selecting the top bid as the
-            winner for ad display.It is implemented by the SSP or publisher, and
-            called by the SSPs to determine the winning bid. It ranks bids from
-            the component auctions.
-          </p>
-          <p>
-            The scoreAd() function is implemented by the SSP or publisher, and
-            called by the SSPs to determine the winning bid.
-          </p>
-          <p>
-            The scoreAd() function in multi-seller configuration ranks bids from
-            the component auctions and compares with the contextual bid winner
-            passed during the start of the runAdAunction. Any bid less than the
-            contextual bid winner is rejected and bids higher than contextual
-            bid winner are accepted for comparison.
-          </p>
-        </p>
       </>
     ),
   },
@@ -613,6 +564,12 @@ export const MULTI_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          The <code className="text-upsed-tomato">reportWin()</code> function
+          sends report to the winning DSP to log auction details. It implemented
+          by the DSPs, and called by the SSPs or adServer to log the auction
+          details.
+        </p>
+        <p className="mt-1">
           Chrome calls{' '}
           <a
             className="text-bright-navy-blue"
@@ -624,12 +581,6 @@ export const MULTI_SELLER_CONFIG = {
           </a>{' '}
           DSP JavaScript function to report winner to DSP.
         </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
-          The reportWin() function sends report to the winning DSP to log
-          auction details. It implemented by the DSPs, and called by the SSPs or
-          adServer to log the auction details.
-        </p>
       </>
     ),
   },
@@ -639,6 +590,12 @@ export const MULTI_SELLER_CONFIG = {
     info: (
       <>
         <p>
+          The <code className="text-upsed-tomato">reportResult()</code> function
+          sends report to all the SSPs to log the winner and all the other
+          details to log the auction details. It is implemented by the SSPs, and
+          called by the adServer at the end of top-level auction.
+        </p>
+        <p className="mt-1">
           Chrome calls{' '}
           <a
             className="text-bright-navy-blue"
@@ -649,13 +606,6 @@ export const MULTI_SELLER_CONFIG = {
             <code className="text-upsed-tomato">reportResult()</code>
           </a>{' '}
           SSP JavaScript function to report winner to SSP.
-        </p>
-        <p className="mt-2">
-          <strong className="block">General Use:</strong>
-          The reportResult() function sends report to all the SSPs to log the
-          winner and all the other details to log the auction details. It is
-          implemented by the SSPs, and called by the adServer at the end of
-          top-level auction.
         </p>
       </>
     ),

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/tableTabPanels/legend.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/tableTabPanels/legend.tsx
@@ -21,26 +21,51 @@ import React from 'react';
 
 const Legend = () => {
   return (
-    <div className="p-4 flex flex-col gap-3">
-      <div className="flex gap-2 items-center">
-        <div className="bg-yellow-400 w-4 h-4 border border-black" />
-        <p>Yellow boxes signify processes running out of browser context.</p>
-      </div>
-      <div className="flex gap-2 items-center">
-        <div className="bg-white w-4 h-4 border border-black" />
-        <p>White boxes signify processes running inside browser context.</p>
-      </div>
-      <div className="flex gap-2 items-center">
-        <div className="w-4 h-4">
-          <div className="flex justify-center w-4">
-            <div className="rounded-full w-2 h-2 bg-[#4e79a7]"></div>
-          </div>
-          <div className="flex">
-            <div className="rounded-full w-2 h-2 bg-[#e15759]"></div>
-            <div className="rounded-full w-2 h-2 bg-[#f28e2c]"></div>
-          </div>
+    <div className="p-3 text-[12.5px]">
+      <p>
+        This{' '}
+        <a
+          target="__blank"
+          className="text-bright-navy-blue"
+          href="https://en.wikipedia.org/wiki/Explorable_explanation"
+        >
+          explorable explanation
+        </a>{' '}
+        explains the generic flow outlined in the{' '}
+        <a
+          target="__blank"
+          className="text-bright-navy-blue"
+          href="https://developers.google.com/display-video/protected-audience/ssp-guide"
+        >
+          ssp-guide
+        </a>{' '}
+        diagrams using synthetic data for both single and multi-seller auctions.
+        The timeline follows a user’s journey from visiting advertiser websites,
+        where interest groups are added, to publisher websites, where auctions
+        take place. Click the info icon on each box to learn more about the
+        process. Below is a guide to the different symbols used in the diagram.
+      </p>
+      <div className="flex flex-col gap-3 mt-3">
+        <div className="flex gap-2 items-center">
+          <div className="bg-yellow-400 w-4 h-4 border border-black" />
+          <p>Yellow boxes signify processes running out of browser context.</p>
         </div>
-        <p>Small bubbles indicate interest groups.</p>
+        <div className="flex gap-2 items-center">
+          <div className="bg-white w-4 h-4 border border-black" />
+          <p>White boxes signify processes running inside browser context.</p>
+        </div>
+        <div className="flex gap-2 items-center">
+          <div className="w-4 h-4">
+            <div className="flex justify-center w-4">
+              <div className="rounded-full w-2 h-2 bg-[#4e79a7]"></div>
+            </div>
+            <div className="flex">
+              <div className="rounded-full w-2 h-2 bg-[#e15759]"></div>
+              <div className="rounded-full w-2 h-2 bg-[#f28e2c]"></div>
+            </div>
+          </div>
+          <p>Small bubbles represent interest groups.</p>
+        </div>
       </div>
     </div>
   );

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/tableTabPanels/legend.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/tableTabPanels/legend.tsx
@@ -30,6 +30,18 @@ const Legend = () => {
         <div className="bg-white w-4 h-4 border border-black" />
         <p>White boxes signify processes running inside browser context.</p>
       </div>
+      <div className="flex gap-2 items-center">
+        <div className="w-4 h-4">
+          <div className="flex justify-center w-4">
+            <div className="rounded-full w-2 h-2 bg-[#4e79a7]"></div>
+          </div>
+          <div className="flex">
+            <div className="rounded-full w-2 h-2 bg-[#e15759]"></div>
+            <div className="rounded-full w-2 h-2 bg-[#f28e2c]"></div>
+          </div>
+        </div>
+        <p>Small bubbles indicate interest groups.</p>
+      </div>
     </div>
   );
 };

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/tableTabPanels/legend.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/tableTabPanels/legend.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 
 const Legend = () => {
   return (
-    <div className="p-3 text-[12.5px]">
+    <div className="p-3 text-[12.5px] dark:text-bright-gray">
       <p>
         This{' '}
         <a
@@ -31,7 +31,7 @@ const Legend = () => {
         >
           explorable explanation
         </a>{' '}
-        explains the generic flow outlined in the{' '}
+        illustrates the generic flow outlined in the{' '}
         <a
           target="__blank"
           className="text-bright-navy-blue"
@@ -52,7 +52,9 @@ const Legend = () => {
         </div>
         <div className="flex gap-2 items-center">
           <div className="bg-white w-4 h-4 border border-black" />
-          <p>White boxes signify processes running inside browser context.</p>
+          <p>
+            White boxes signify processes running inside the browser context.
+          </p>
         </div>
         <div className="flex gap-2 items-center">
           <div className="w-4 h-4">

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/tableTabPanels/legend.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/tableTabPanels/legend.tsx
@@ -18,27 +18,20 @@
  * External dependencies.
  */
 import React from 'react';
+import { Link } from '@google-psat/design-system';
 
 const Legend = () => {
   return (
     <div className="p-3 text-[12.5px] dark:text-bright-gray">
       <p>
         This{' '}
-        <a
-          target="__blank"
-          className="text-bright-navy-blue"
-          href="https://en.wikipedia.org/wiki/Explorable_explanation"
-        >
+        <Link href="https://en.wikipedia.org/wiki/Explorable_explanation">
           explorable explanation
-        </a>{' '}
+        </Link>{' '}
         illustrates the generic flow outlined in the{' '}
-        <a
-          target="__blank"
-          className="text-bright-navy-blue"
-          href="https://developers.google.com/display-video/protected-audience/ssp-guide"
-        >
+        <Link href="https://developers.google.com/display-video/protected-audience/ssp-guide">
           ssp-guide
-        </a>{' '}
+        </Link>{' '}
         diagrams using synthetic data for both single and multi-seller auctions.
         The timeline follows a user’s journey from visiting advertiser websites,
         where interest groups are added, to publisher websites, where auctions


### PR DESCRIPTION
## Description

This PR removes the "General Use" section from the Info tab and add details to the Legend tab. It also adds details for the interest group symbols used in the flow.

## Relevant Technical Choices

NA

## Testing Instructions

1. Open PA:EE and click on the info icon of each box for advertiser, single and multi-seller auctions.
2. Read the info text used for every box and ensure that they make sense and there is no typo.
3. Open Legend tab and read it's content.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<img width="1244" alt="image" src="https://github.com/user-attachments/assets/eb4f4f75-84a8-493b-a560-be1f0887f271" />


## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~[ ] This code is covered by unit tests to verify that it works as intended.~ NA
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #857
