### PR TITLE
Feature: Add topics legend tab

### DIFF
--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/animation.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/animation.tsx
@@ -124,7 +124,7 @@ const Animation = ({
     speedMultiplierCallback?.(speedMultiplier);
   }, [speedMultiplier, speedMultiplierCallback]);
 
-  return <div ref={node} className="overflow-auto" />;
+  return <div ref={node} className="overflow-auto bg-white" />;
 };
 
 export default Animation;

--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/index.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/index.tsx
@@ -29,6 +29,7 @@ import {
  */
 import TopicsTable, { type TopicsTableType } from './topicsTable';
 import Panel from './panel';
+import Legend from './legend';
 
 const ExplorableExplanation = () => {
   const [topicsTableData, setTopicsTableData] = useState<
@@ -56,9 +57,9 @@ const ExplorableExplanation = () => {
     [setPAActiveTab, setPAStorage]
   );
 
-  const tabItems = useMemo<TabItems>(
-    () =>
-      ['Epoch 1', 'Epoch 2', 'Epoch 3', 'Epoch 4'].map((item) => ({
+  const tabItems = useMemo<TabItems>(() => {
+    const items: TabItems = ['Epoch 1', 'Epoch 2', 'Epoch 3', 'Epoch 4'].map(
+      (item) => ({
         title: item,
         content: {
           Element: TopicsTable,
@@ -69,9 +70,18 @@ const ExplorableExplanation = () => {
             topicsNavigator,
           },
         },
-      })),
-    [highlightAdTech, topicsNavigator, topicsTableData]
-  );
+      })
+    );
+
+    items.push({
+      title: 'Legend',
+      content: {
+        Element: Legend,
+      },
+    });
+
+    return items;
+  }, [highlightAdTech, topicsNavigator, topicsTableData]);
 
   return (
     <TabsProvider items={tabItems} name="topics-ee">

--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/legend.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/legend.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies.
+ */
+import React from 'react';
+
+const Legend = () => {
+  return (
+    <div className="p-3 text-[12.5px]">
+      <p>
+        This explorable explanation shows user journeys on the web. Each site
+        has topics describing its content, adtech companies extract these topics
+        to serve targeted ads.
+      </p>
+      <p className="pb-2">
+        Each epoch represents a week of user activity. The epoch table lists
+        topics and the adtechs that accessed them. Click on small colored
+        bubbles (when paused) to see associated adtechs being highlighted in the
+        epoch table.
+      </p>
+      <div className="flex gap-2 items-center">
+        <div className="w-4 h-4">
+          <div className="flex justify-center w-4">
+            <div className="rounded-full w-2 h-2 bg-[#4e79a7]"></div>
+          </div>
+          <div className="flex">
+            <div className="rounded-full w-2 h-2 bg-[#e15759]"></div>
+            <div className="rounded-full w-2 h-2 bg-[#f28e2c]"></div>
+          </div>
+        </div>
+        <p>Small colored bubbles represent adtech companies.</p>
+      </div>
+    </div>
+  );
+};
+
+export default Legend;

--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/legend.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/legend.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 
 const Legend = () => {
   return (
-    <div className="p-3 text-[12.5px]">
+    <div className="p-3 text-[12.5px] text-raisin-black dark:text-bright-gray">
       <p>
         This explorable explanation shows user journeys on the web. Each site
         has topics describing its content, adtech companies extract these topics

--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/panel.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/panel.tsx
@@ -72,10 +72,17 @@ const Panel = ({
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const storageRef = useRef(PAstorage);
   const activeTabRef = useRef(activeTab);
+  const wasPreviousTabLegend = useRef(false);
 
   useEffect(() => {
     if (activeTab === 4) {
       return;
+    }
+
+    if (activeTabRef.current === activeTab) {
+      wasPreviousTabLegend.current = true;
+    } else {
+      wasPreviousTabLegend.current = false;
     }
 
     activeTabRef.current = activeTab;
@@ -106,7 +113,7 @@ const Panel = ({
   }, [PAstorage]);
 
   useEffect(() => {
-    if (activeTab === 4) {
+    if (activeTab === 4 || wasPreviousTabLegend.current) {
       return;
     }
 
@@ -171,7 +178,7 @@ const Panel = ({
   }, [setActiveTab, setTopicsTableData]);
 
   useEffect(() => {
-    if (activeTab === 4) {
+    if (activeTab === 4 || wasPreviousTabLegend.current) {
       return;
     }
 

--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/panel.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/panel.tsx
@@ -76,6 +76,7 @@ const Panel = ({
 
   useEffect(() => {
     if (activeTab === 4) {
+      setPlay(false);
       return;
     }
 

--- a/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/panel.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/topics/explorableExplanation/panel.tsx
@@ -86,6 +86,7 @@ const Panel = ({
       ? JSON.parse(storageRef.current[1])?.siteAdTechs
       : assignAdtechsToSites(websites, adtechs);
   }, []);
+
   const epochs = useMemo(() => {
     return (
       (JSON.parse(storageRef.current[1] || '{}')?.epochs as ReturnType<
@@ -105,6 +106,10 @@ const Panel = ({
   }, [PAstorage]);
 
   useEffect(() => {
+    if (activeTab === 4) {
+      return;
+    }
+
     setVisitIndexStart(
       JSON.parse(storageRef.current[1] || '{}')?.currentVisitIndexes?.[
         activeTabRef.current
@@ -166,6 +171,10 @@ const Panel = ({
   }, [setActiveTab, setTopicsTableData]);
 
   useEffect(() => {
+    if (activeTab === 4) {
+      return;
+    }
+
     if (!epochCompleted[activeTabRef.current]) {
       setTopicsTableData((prevTopicsTableData) => {
         const newTopicsTableData = { ...prevTopicsTableData };


### PR DESCRIPTION
## Description
This PR adds a legend tab to topics EE.
- The legend tab contains general information about topics EE.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open PSAT and navigate to topics EE.
- Open the Legend tab, the tab should contain basic information about topics.
- Switch between tabs should not affect the EE, no distorted figures should be present.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

https://github.com/user-attachments/assets/92401e3f-59ae-4fcc-aaee-05f073e445e5


<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #856 
