### PR TITLE
Fix: Bubble minify animation

### DIFF
--- a/packages/explorable-explanations/src/protectedAudience/modules/bubbles.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/bubbles.ts
@@ -472,7 +472,7 @@ const bubbles: Bubbles = {
 
     if (app.bubbleContainerDiv) {
       app.bubbleContainerDiv.classList.toggle('expanded', true);
-      app.bubbleContainerDiv.style.width = '100%';
+      // app.bubbleContainerDiv.style.width = '100%';
     }
 
     if (app.closeButton) {
@@ -516,7 +516,7 @@ const bubbles: Bubbles = {
 
     if (app.bubbleContainerDiv) {
       app.bubbleContainerDiv.classList.toggle('expanded', false);
-      app.bubbleContainerDiv.style.width = 'fit-content';
+      // app.bubbleContainerDiv.style.width = 'fit-content';
     }
 
     if (app.closeButton) {

--- a/packages/explorable-explanations/src/protectedAudience/modules/bubbles.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/bubbles.ts
@@ -472,7 +472,6 @@ const bubbles: Bubbles = {
 
     if (app.bubbleContainerDiv) {
       app.bubbleContainerDiv.classList.toggle('expanded', true);
-      // app.bubbleContainerDiv.style.width = '100%';
     }
 
     if (app.closeButton) {
@@ -516,7 +515,6 @@ const bubbles: Bubbles = {
 
     if (app.bubbleContainerDiv) {
       app.bubbleContainerDiv.classList.toggle('expanded', false);
-      // app.bubbleContainerDiv.style.width = 'fit-content';
     }
 
     if (app.closeButton) {

--- a/packages/extension/src/view/devtools/app.css
+++ b/packages/extension/src/view/devtools/app.css
@@ -211,24 +211,12 @@ text {
   backdrop-filter: blur(10px);
 }
 
-.bubble-container {
-  position: sticky;
-  pointer-events: auto;
-}
-
-.bubble-container.expanded {
-  position: absolute;
-  backdrop-filter: blur(1px);
-  z-index: 4;
-  height: 100vh;
-  width: 100vw;
-}
-
 #close-button {
   position: absolute;
   top: 10px;
   cursor: pointer;
   display: none;
+  pointer-events: auto;
 }
 
 #open-button {
@@ -237,6 +225,7 @@ text {
   left: 50px;
   cursor: pointer;
   display: none;
+  pointer-events: auto;
 }
 
 #count-display {
@@ -260,7 +249,16 @@ text {
 }
 
 #bubble-container-div {
-  top: 0px;
-  left: 0px;
+  position: sticky;
+  top: 5px;
+  left: 5px;
+  z-index: 4;
+  pointer-events: none;
+  height: 100%;
+  width: 100%;
+}
+
+#bubble-container-div.bubble-container.expanded {
+  backdrop-filter: blur(1px);
   z-index: 4;
 }

--- a/packages/extension/src/view/devtools/app.css
+++ b/packages/extension/src/view/devtools/app.css
@@ -151,17 +151,27 @@ body {
   position: relative;
 }
 
-#bubble-container {
+/* bubble wrapper */
+#bubble-container-div {
   position: sticky;
+  top: 5px;
+  left: 5px;
+  z-index: 4;
+  height: 100%;
+  width: 100%;
   pointer-events: none;
-  top: 0px;
-  left: 0px;
 }
 
-.minified-bubble-container {
-  position: sticky;
-  top: 10px;
-  left: 10px;
+#bubble-container-div.expanded {
+  backdrop-filter: blur(1px);
+  z-index: 4;
+}
+
+/* bubble element */
+#minified-bubble-container {
+  position: absolute;
+  top: 5px;
+  left: 5px;
   height: 50px;
   width: 50px;
   border-radius: 50%;
@@ -172,34 +182,10 @@ body {
   align-items: center;
   justify-content: center;
   transition: width 0.5s ease, height 0.5s ease, top 0.5s ease, left 0.5s ease;
+  pointer-events: auto;
 }
 
-.circle-svg:hover:active {
-  cursor: pointer;
-}
-
-.text-class {
-  pointer-events: none;
-}
-
-.svg {
-  cursor: pointer;
-}
-
-.circle-svg {
-  transition: transform 0.2s;
-}
-
-.circle-svg:hover {
-  transform: scale(1.05);
-  cursor: pointer;
-}
-
-text {
-  cursor: pointer;
-}
-
-.minified-bubble-container.expanded {
+#minified-bubble-container.expanded {
   position: absolute;
   display: block;
   top: var(--expandedBubbleY);
@@ -248,17 +234,27 @@ text {
   display: flex;
 }
 
-#bubble-container-div {
-  position: sticky;
-  top: 5px;
-  left: 5px;
-  z-index: 4;
-  pointer-events: none;
-  height: 100%;
-  width: 100%;
+.circle-svg:hover:active {
+  cursor: pointer;
 }
 
-#bubble-container-div.bubble-container.expanded {
-  backdrop-filter: blur(1px);
-  z-index: 4;
+.text-class {
+  pointer-events: none;
+}
+
+.svg {
+  cursor: pointer;
+}
+
+.circle-svg {
+  transition: transform 0.2s;
+}
+
+.circle-svg:hover {
+  transform: scale(1.05);
+  cursor: pointer;
+}
+
+text {
+  cursor: pointer;
 }

--- a/packages/extension/src/view/devtools/app.css
+++ b/packages/extension/src/view/devtools/app.css
@@ -165,6 +165,7 @@ body {
 #bubble-container-div.expanded {
   backdrop-filter: blur(1px);
   z-index: 4;
+  pointer-events: auto;
 }
 
 /* bubble element */

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
@@ -298,8 +298,8 @@ const Panel = ({
         const centerX = visibleWidth / 2 - newSize;
         const centerY = visibleHeight / 4 - newSize / 4;
 
-        setExpandedBubbleX(div.scrollLeft + centerX);
-        setExpandedBubbleY(div.scrollTop + centerY);
+        setExpandedBubbleX(centerX);
+        setExpandedBubbleY(centerY);
       }
     }
   }, [getDivDimensions, isBubbleExpanded]);

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
@@ -234,7 +234,7 @@ const Panel = ({
       if (containerRef.current) {
         const containerWidth = containerRef.current.offsetWidth;
         const containerHeight = containerRef.current.offsetHeight;
-        const newSize = Math.min(containerWidth, containerHeight) / 2;
+        const newSize = Math.min(containerWidth, containerHeight) * 0.8;
 
         setBubbleWidth(newSize);
       }
@@ -295,8 +295,8 @@ const Panel = ({
 
       if (div) {
         const { visibleWidth, visibleHeight, newSize } = getDivDimensions();
-        const centerX = visibleWidth / 2 - newSize / 2;
-        const centerY = visibleHeight / 2 - newSize / 2;
+        const centerX = visibleWidth / 2 - newSize;
+        const centerY = visibleHeight / 4 - newSize / 4;
 
         setExpandedBubbleX(centerX);
         setExpandedBubbleY(centerY);

--- a/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
+++ b/packages/extension/src/view/devtools/components/privateAdvertising/protectedAudience/explorableExplanation/panel.tsx
@@ -295,8 +295,8 @@ const Panel = ({
 
       if (div) {
         const { visibleWidth, visibleHeight, newSize } = getDivDimensions();
-        const centerX = visibleWidth / 2 - newSize;
-        const centerY = visibleHeight / 4 - newSize / 4;
+        const centerX = visibleWidth / 2 - newSize / 2;
+        const centerY = visibleHeight / 2 - newSize / 2;
 
         setExpandedBubbleX(centerX);
         setExpandedBubbleY(centerY);


### PR DESCRIPTION
## Description

Remove jumpy animation when minifying bubbles

## Testing Instructions

1. Pull the branch fix/add-missing-api-pages
2. Build and run project the project: npm run build:all && npm run dev:ext
3. Open privacy sandbox tab on DevTools
4. Go to Private advertising section
5. Open Explorable explanations panel
6. Observe: the animation start
7. Click the bubble in the corner left
8. Observe: the bubble animates correctly, going from the top left corner to the center of the container
9. Click the close button
10. Observe: the bubbles correctly, going from the center of the container back to the top left corner

## Additional Information:

Maker sure to test with different number of bubbles in inside the main bubble and when the diagram get big enough to make scrolling appear in the container

## Screenshot/Screencast

- Before:

https://github.com/user-attachments/assets/6fc2259a-e399-464f-9440-9011f666bae9

- After:

https://github.com/user-attachments/assets/ffb3ef01-75e4-4166-ac36-acfdbf698e1c

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- This code is covered by unit tests to verify that it works as intended. **NA**
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).
