### PR TITLE
Open "Learn More" button link in the same tab

### DIFF
--- a/packages/design-system/src/components/link/index.tsx
+++ b/packages/design-system/src/components/link/index.tsx
@@ -18,7 +18,7 @@
  */
 import React, { useCallback } from 'react';
 
-interface LinkProps {
+interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   href: string;
   children: React.ReactElement | string;
 }

--- a/packages/extension/src/view/devtools/components/privacySandbox/contentPanel.tsx
+++ b/packages/extension/src/view/devtools/components/privacySandbox/contentPanel.tsx
@@ -64,7 +64,6 @@ const ContentPanel = () => {
             <div className="flex gap-6 justify-center mt-5">
               <Link
                 href={addUTMParams('https://privacysandbox.com')}
-                target="__blank"
                 className="bg-cultured-grey text-raisin-black py-2 px-9 rounded border border-dark-grey text-base hover:bg-light-gray hover:border-american-silver flex"
               >
                 <span>Learn More</span>

--- a/packages/extension/src/view/devtools/components/privacySandbox/contentPanel.tsx
+++ b/packages/extension/src/view/devtools/components/privacySandbox/contentPanel.tsx
@@ -19,9 +19,9 @@
 import React from 'react';
 import {
   PrivacySandboxColoredIcon,
-  ExternalLinkBlack,
   useSidebar,
   SIDEBAR_ITEMS_KEYS,
+  Link,
 } from '@google-psat/design-system';
 import { addUTMParams } from '@google-psat/common';
 import { Resizable } from 're-resizable';
@@ -62,18 +62,13 @@ const ContentPanel = () => {
               keep online content and services free for all.
             </p>
             <div className="flex gap-6 justify-center mt-5">
-              <a
+              <Link
                 href={addUTMParams('https://privacysandbox.com')}
                 target="__blank"
                 className="bg-cultured-grey text-raisin-black py-2 px-9 rounded border border-dark-grey text-base hover:bg-light-gray hover:border-american-silver flex"
               >
                 <span>Learn More</span>
-                <ExternalLinkBlack
-                  width="16"
-                  height="16"
-                  className="mt-1 ml-1"
-                />
-              </a>
+              </Link>
               <button
                 onClick={() => navigateTo(SIDEBAR_ITEMS_KEYS.DASHBOARD)}
                 className="bg-cultured-grey text-raisin-black py-2 px-9 rounded border border-dark-grey text-base hover:bg-light-gray hover:border-american-silver"


### PR DESCRIPTION
## Description

This PR  opens 'Learn More' button on the privacy sandbox landing page in the same tab.

## Relevant Technical Choices

- Use `Link` component from the `design-system` package instead of `<a>` tag.
- Extend `LinkProps` interface to accept more attributes.

## Testing Instructions

Go to privacy sandbox landing page and click on "Learn More" button. It should open in the same tab.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~[ ] This code is covered by unit tests to verify that it works as intended.~ NA
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
