### PR TITLE
Replace anchor tag with `Link` component in Landing page info cards

### DIFF
--- a/packages/design-system/src/components/landingPage/contentPanel.tsx
+++ b/packages/design-system/src/components/landingPage/contentPanel.tsx
@@ -24,6 +24,7 @@ import { addUTMParams } from '@google-psat/common';
  * Internal dependencies.
  */
 import { DescriptionIcon, WebStoriesIcon } from '../../icons';
+import Link from '../link';
 
 export interface ContentPanelProps {
   title: string;
@@ -72,17 +73,13 @@ const ContentPanel = ({
             </p>
             <div className="absolute top-10 right-2.5 flex gap-2">
               <div className="w-4 h-4" title="View Documentation">
-                <a
-                  href={addUTMParams(item.url)}
-                  target="_blank"
-                  rel="noreferrer"
-                >
+                <Link href={addUTMParams(item.url)} rel="noreferer">
                   <DescriptionIcon
                     height="16"
                     width="16"
                     className="dark:fill-bright-gray fill-granite-gray group-hover:text-blue-500"
                   />
-                </a>
+                </Link>
               </div>
               {item.onClick && item?.storyUrl && (
                 <div

--- a/packages/design-system/src/components/landingPage/infoCard/renderLink.tsx
+++ b/packages/design-system/src/components/landingPage/infoCard/renderLink.tsx
@@ -18,6 +18,7 @@
  * External dependencies.
  */
 import React from 'react';
+import Link from '../../link';
 
 interface RenderLinkProps {
   label: string;
@@ -34,15 +35,14 @@ const RenderLink = ({ label, link, linkLabel }: RenderLinkProps) => (
             <p className="text-sm font-medium text-raisin-black dark:text-bright-gray truncate capitalize">
               {label}
             </p>
-            <a
+            <Link
               title={link}
               href={link}
               className="text-xs text-bright-navy-blue dark:text-jordy-blue hover:opacity-80"
-              target="_blank"
               rel="noreferrer"
             >
               {linkLabel}
-            </a>
+            </Link>
           </div>
         </div>
       </li>


### PR DESCRIPTION
## Description

Replace anchor tags with the `Link` component in Landing page info cards and other meta links.

## Relevant Technical Choices

Uses the `Link` component to open the links in the same tab instead of opening in a new tab for links within info cards of Landing pages and other meta links on the those pages.

## Testing Instructions

1. Navigate to any landing page.
2. Click on the documentation link in the info card.
3. Verify that the link opens in the same tab instead of opening in a new tab.

## Additional Information:

N/A

## Screenshot/Screencast

N/A

---

## Checklist

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] ~[N/A] This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).