### PR TITLE
Feature: Link landing page cards to related pages

### DIFF
--- a/packages/design-system/src/components/landingPage/contentPanel.tsx
+++ b/packages/design-system/src/components/landingPage/contentPanel.tsx
@@ -35,7 +35,7 @@ export interface ContentPanelProps {
     url: string;
     storyUrl?: string;
     onClick: () => void;
-    sidebarItemKey: SIDEBAR_ITEMS_KEYS;
+    sidebarItemKey?: SIDEBAR_ITEMS_KEYS;
   }[];
   titleStyles?: string;
   counterStyles?: string;

--- a/packages/design-system/src/components/landingPage/contentPanel.tsx
+++ b/packages/design-system/src/components/landingPage/contentPanel.tsx
@@ -62,14 +62,16 @@ const ContentPanel = ({
             className="w-72 min-h-80 bg-[#FDFDFD] dark:bg-charleston-green hover:bg-[#FAFAFA] rounded-xl border border-bright-gray dark:border-quartz p-5 relative"
             key={index}
           >
-            <div className="w-16 h-16 flex justify-center items-center rounded-full bg-bright-gray mb-5">
+            <div
+              className="w-16 h-16 flex justify-center items-center rounded-full bg-bright-gray mb-5 cursor-pointer"
+              onClick={() =>
+                item.sidebarItemKey
+                  ? updateSelectedItemKey(item.sidebarItemKey)
+                  : null
+              }
+            >
               <div
-                className={`w-9 h-9 flex justify-center items-center rounded-md cursor-pointer ${counterStyles}`}
-                onClick={() =>
-                  item.sidebarItemKey
-                    ? updateSelectedItemKey(item.sidebarItemKey)
-                    : null
-                }
+                className={`w-9 h-9 flex justify-center items-center rounded-md ${counterStyles}`}
               >
                 <span className="text-xxl text-white dark:black font-extrabold">
                   {index + 1}
@@ -77,7 +79,7 @@ const ContentPanel = ({
               </div>
             </div>
             <h3
-              className={`text-lg font-medium mb-5 cursor-pointer ${titleStyles}`}
+              className={`text-lg inline-block font-medium mb-5 cursor-pointer ${titleStyles}`}
               onClick={() =>
                 item.sidebarItemKey
                   ? updateSelectedItemKey(item.sidebarItemKey)

--- a/packages/design-system/src/components/landingPage/contentPanel.tsx
+++ b/packages/design-system/src/components/landingPage/contentPanel.tsx
@@ -65,7 +65,11 @@ const ContentPanel = ({
             <div className="w-16 h-16 flex justify-center items-center rounded-full bg-bright-gray mb-5">
               <div
                 className={`w-9 h-9 flex justify-center items-center rounded-md cursor-pointer ${counterStyles}`}
-                onClick={() => updateSelectedItemKey(item.sidebarItemKey)}
+                onClick={() =>
+                  item.sidebarItemKey
+                    ? updateSelectedItemKey(item.sidebarItemKey)
+                    : null
+                }
               >
                 <span className="text-xxl text-white dark:black font-extrabold">
                   {index + 1}
@@ -74,7 +78,11 @@ const ContentPanel = ({
             </div>
             <h3
               className={`text-lg font-medium mb-5 cursor-pointer ${titleStyles}`}
-              onClick={() => updateSelectedItemKey(item.sidebarItemKey)}
+              onClick={() =>
+                item.sidebarItemKey
+                  ? updateSelectedItemKey(item.sidebarItemKey)
+                  : null
+              }
             >
               {item.title()}
             </h3>

--- a/packages/design-system/src/components/landingPage/contentPanel.tsx
+++ b/packages/design-system/src/components/landingPage/contentPanel.tsx
@@ -25,6 +25,7 @@ import { addUTMParams } from '@google-psat/common';
  */
 import { DescriptionIcon, WebStoriesIcon } from '../../icons';
 import Link from '../link';
+import { SIDEBAR_ITEMS_KEYS, useSidebar } from '../sidebar';
 
 export interface ContentPanelProps {
   title: string;
@@ -45,6 +46,10 @@ const ContentPanel = ({
   titleStyles = '',
   counterStyles = '',
 }: ContentPanelProps) => {
+  const updateSelectedItemKey = useSidebar(
+    ({ actions }) => actions.updateSelectedItemKey
+  );
+
   return (
     <div className="px-2">
       <h3 className="text-base text-raisin-black dark:text-bright-gray mb-7">
@@ -58,14 +63,18 @@ const ContentPanel = ({
           >
             <div className="w-16 h-16 flex justify-center items-center rounded-full bg-bright-gray mb-5">
               <div
-                className={`w-9 h-9 flex justify-center items-center rounded-md ${counterStyles}`}
+                className={`w-9 h-9 flex justify-center items-center rounded-md cursor-pointer ${counterStyles}`}
+                onClick={() => updateSelectedItemKey(SIDEBAR_ITEMS_KEYS.WIKI)}
               >
                 <span className="text-xxl text-white dark:black font-extrabold">
                   {index + 1}
                 </span>
               </div>
             </div>
-            <h3 className={`text-lg font-medium mb-5 ${titleStyles}`}>
+            <h3
+              className={`text-lg font-medium mb-5 cursor-pointer ${titleStyles}`}
+              onClick={() => updateSelectedItemKey(SIDEBAR_ITEMS_KEYS.WIKI)}
+            >
               {item.title()}
             </h3>
             <p className="text-base text-raisin-black dark:text-bright-gray mb-2">

--- a/packages/design-system/src/components/landingPage/contentPanel.tsx
+++ b/packages/design-system/src/components/landingPage/contentPanel.tsx
@@ -35,6 +35,7 @@ export interface ContentPanelProps {
     url: string;
     storyUrl?: string;
     onClick: () => void;
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS;
   }[];
   titleStyles?: string;
   counterStyles?: string;
@@ -64,7 +65,7 @@ const ContentPanel = ({
             <div className="w-16 h-16 flex justify-center items-center rounded-full bg-bright-gray mb-5">
               <div
                 className={`w-9 h-9 flex justify-center items-center rounded-md cursor-pointer ${counterStyles}`}
-                onClick={() => updateSelectedItemKey(SIDEBAR_ITEMS_KEYS.WIKI)}
+                onClick={() => updateSelectedItemKey(item.sidebarItemKey)}
               >
                 <span className="text-xxl text-white dark:black font-extrabold">
                   {index + 1}
@@ -73,7 +74,7 @@ const ContentPanel = ({
             </div>
             <h3
               className={`text-lg font-medium mb-5 cursor-pointer ${titleStyles}`}
-              onClick={() => updateSelectedItemKey(SIDEBAR_ITEMS_KEYS.WIKI)}
+              onClick={() => updateSelectedItemKey(item.sidebarItemKey)}
             >
               {item.title()}
             </h3>

--- a/packages/design-system/src/components/landingPage/index.tsx
+++ b/packages/design-system/src/components/landingPage/index.tsx
@@ -24,6 +24,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import { getStoryPlayerMarkup } from './getStoryPlayerMarkup';
 import LandingPage, { LandingPageProps } from './LandingPage';
 import ContentPanel from './contentPanel';
+import { SIDEBAR_ITEMS_KEYS } from '../sidebar';
 
 type LandingPageContainerProps = LandingPageProps & {
   contentPanelTitle: string;
@@ -32,6 +33,7 @@ type LandingPageContainerProps = LandingPageProps & {
     description: () => string;
     url: string;
     storyUrl?: string;
+    sidebarItemKey?: SIDEBAR_ITEMS_KEYS;
   }[];
   counterStyles: string;
   titleStyles: string;

--- a/packages/extension/src/view/devtools/pages/antiCovertTracking/antiCovertTracking.tsx
+++ b/packages/extension/src/view/devtools/pages/antiCovertTracking/antiCovertTracking.tsx
@@ -18,7 +18,10 @@
  * External Dependencies
  */
 import React from 'react';
-import { LandingPageContainer } from '@google-psat/design-system';
+import {
+  LandingPageContainer,
+  SIDEBAR_ITEMS_KEYS,
+} from '@google-psat/design-system';
 import { I18n } from '@google-psat/i18n';
 
 const content = [
@@ -27,6 +30,7 @@ const content = [
     description: () => I18n.getMessage('ipProtectionDescription'),
     url: 'https://developers.google.com/privacy-sandbox/protections/ip-protection',
     storyUrl: 'https://privacysandbox-stories.com/web-stories/ip-protection/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.IP_PROTECTION,
   },
   {
     title: () => I18n.getMessage('bounceTrackingMitigations'),
@@ -34,6 +38,7 @@ const content = [
     url: 'https://developers.google.com/privacy-sandbox/protections/bounce-tracking-mitigations',
     storyUrl:
       'https://privacysandbox-stories.com/web-stories/bounce-tracking-mitigations/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.BOUNCE_TRACKING,
   },
   {
     title: () => I18n.getMessage('userAgentReduction'),
@@ -41,6 +46,7 @@ const content = [
     url: 'https://developers.google.com/privacy-sandbox/protections/user-agent',
     storyUrl:
       'https://privacysandbox-stories.com/web-stories/user-agent-reduction/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.FINGERPRINTING,
   },
   {
     title: () => I18n.getMessage('privateStateTokens'),
@@ -48,6 +54,7 @@ const content = [
     url: 'https://developers.google.com/privacy-sandbox/protections/private-state-tokens',
     storyUrl:
       'https://privacysandbox-stories.com/web-stories/private-state-tokens/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.PRIVATE_STATE_TOKENS,
   },
 ];
 

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/privateAdvertising.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/privateAdvertising.tsx
@@ -18,7 +18,10 @@
  * External Dependencies
  */
 import React from 'react';
-import { LandingPageContainer } from '@google-psat/design-system';
+import {
+  LandingPageContainer,
+  SIDEBAR_ITEMS_KEYS,
+} from '@google-psat/design-system';
 import { I18n } from '@google-psat/i18n';
 
 const content = [
@@ -27,6 +30,7 @@ const content = [
     description: () => I18n.getMessage('topicsDescription'),
     url: 'https://developers.google.com/privacy-sandbox/relevance/topics',
     storyUrl: 'https://privacysandbox-stories.com/web-stories/the-topics-api/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.TOPICS,
   },
   {
     title: () => I18n.getMessage('protectedAudience'),
@@ -34,6 +38,7 @@ const content = [
     url: 'https://developers.google.com/privacy-sandbox/relevance/protected-audience',
     storyUrl:
       'https://privacysandbox-stories.com/web-stories/the-protected-audience-api/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.PROTECTED_AUDIENCE,
   },
   {
     title: () => I18n.getMessage('attributionReporting'),
@@ -41,6 +46,7 @@ const content = [
     url: 'https://developers.google.com/privacy-sandbox/relevance/attribution-reporting',
     storyUrl:
       'https://privacysandbox-stories.com/web-stories/the-attribution-reporting-api/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.ATTRIBUTION_REPORTING,
   },
   {
     title: () => I18n.getMessage('privateAggregation'),
@@ -48,6 +54,7 @@ const content = [
     url: 'https://developers.google.com/privacy-sandbox/relevance/private-aggregation',
     storyUrl:
       'https://privacysandbox-stories.com/web-stories/private-aggregation-api/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.PRIVATE_AGGREGATION,
   },
 ];
 

--- a/packages/extension/src/view/devtools/pages/siteBoundaries/siteBoundaries.tsx
+++ b/packages/extension/src/view/devtools/pages/siteBoundaries/siteBoundaries.tsx
@@ -17,7 +17,10 @@
  * External Dependencies
  */
 import React from 'react';
-import { LandingPageContainer } from '@google-psat/design-system';
+import {
+  LandingPageContainer,
+  SIDEBAR_ITEMS_KEYS,
+} from '@google-psat/design-system';
 import { I18n } from '@google-psat/i18n';
 
 const content = [
@@ -26,6 +29,7 @@ const content = [
     description: () => I18n.getMessage('chipsDescription'),
     url: 'https://developers.google.com/privacy-sandbox/3pcd/chips',
     storyUrl: 'https://privacysandbox-stories.com/web-stories/chips/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.CHIPS,
   },
   {
     title: () => I18n.getMessage('storageAccessAPI'),
@@ -33,6 +37,7 @@ const content = [
     url: 'https://developers.google.com/privacy-sandbox/3pcd/storage-access-api',
     storyUrl:
       'https://privacysandbox-stories.com/web-stories/storage-access-api/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.STORAGE_ACCESS,
   },
   {
     title: () => I18n.getMessage('rws'),
@@ -40,6 +45,7 @@ const content = [
     url: 'https://developers.google.com/privacy-sandbox/3pcd/related-website-sets',
     storyUrl:
       'https://privacysandbox-stories.com/web-stories/related-website-sets/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.RELATED_WEBSITE_SETS,
   },
   {
     title: () => I18n.getMessage('fedcm'),
@@ -47,6 +53,7 @@ const content = [
     url: 'https://developers.google.com/privacy-sandbox/3pcd/fedcm',
     storyUrl:
       'https://privacysandbox-stories.com/web-stories/federated-credential-management-api/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.FEDERATED_CREDENTIAL,
   },
 ];
 


### PR DESCRIPTION
## Description

This PR links each card title and icon used in the landing pages to the related pages.

## Relevant Technical Choices

- Use `updateSelectedItemKey` to navigate user to the related pages.
- Use additional `sidebarItemKey` to pass `SIDEBAR_ITEMS_KEYS`.

## Testing Instructions

- Visit "Site Boundaries", "Private Advertising" and "Tracking Protection" pages.
- Click on the icon and title of each card and ensure that they go to the correct pages.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~[ ] This code is covered by unit tests to verify that it works as intended.~ NA
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
