### PR TITLE
Fix: EE box info icon

### DIFF
--- a/packages/explorable-explanations/src/protectedAudience/components/box.ts
+++ b/packages/explorable-explanations/src/protectedAudience/components/box.ts
@@ -99,7 +99,7 @@ const Box = ({
     p.text(title, x + width / 2, y + height / 2);
   }
 
-  if (info && typeof info === 'string') {
+  if (info) {
     const { x: xCoordinate, y: yCoordinate } = getCoordinateValues({ x, y });
     const iconX = xCoordinate + width - infoIconSize - INFO_ICON_SPACING;
     const iconY = yCoordinate + INFO_ICON_SPACING;

--- a/packages/explorable-explanations/src/protectedAudience/components/info.ts
+++ b/packages/explorable-explanations/src/protectedAudience/components/info.ts
@@ -24,7 +24,7 @@ interface InfoProps {
   x: number;
   y: number;
   title: string;
-  info: string;
+  info: string | boolean;
   description?: string;
 }
 


### PR DESCRIPTION
## Description

Fixing logic of the box info icon

## Testing Instructions

1. Pull and checkout the branch `fix/ee-box-info-icon`
2. Build and run the extension: `npm run build:all && npm run dev:ext`
3. Open Privacy Sandbox tab on DevTools
4. Go to Private Advertising
5. Go to Explorable Explanations tab
6. Observe: the Boxes in the diagram show an info icon
7. Click the icon
8. Observe: the bottom panel is updated with the information

## Screenshot/Screencast

<img width="761" alt="Screenshot 2025-03-06 at 10 07 39 AM" src="https://github.com/user-attachments/assets/d2aae13a-5edf-4a2d-b663-97540774c4d1" />

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [NA] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).
