### PR TITLE
Fix: EE auto-scroll after auction end

### DIFF
--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.ts
@@ -22,7 +22,8 @@ import { Box, Custom, ProgressLine, Text } from '../../../components';
 import setUpRunadAuction from '../setUpRunadAuction';
 import { MULTI_SELLER_CONFIG } from '../../flowConfig';
 import { AuctionStep, Coordinates, AuctionStepProps } from '../../../types';
-import { getCoordinateValues } from '../../../utils/getCoordinateValues';
+import { getCoordinateValues } from '../../../utils';
+import scrollToNextCircle from '../../../utils/scrollToNextCircle';
 
 const BOX_WIDTH = 1200;
 const BOX_HEIGHT = 1100;
@@ -518,6 +519,8 @@ const setupAfterComponentAuctionFlow = (steps) => {
     },
   });
 
+  const WINNING_AD_DELAY = 4000;
+
   steps.push({
     component: Box,
     props: {
@@ -529,9 +532,12 @@ const setupAfterComponentAuctionFlow = (steps) => {
         box.height / 2 +
         1,
     },
-    delay: 1000,
-    callBack: (returnValue) => {
-      app.auction.nextTipCoordinates = returnValue.down;
+    delay: WINNING_AD_DELAY,
+    callBack: (returnValue: Coordinates) => {
+      if (returnValue.down) {
+        app.auction.nextTipCoordinates = returnValue.down;
+        scrollToNextCircle(WINNING_AD_DELAY);
+      }
     },
   });
 };

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/setupShowWinningAd.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/setupShowWinningAd.ts
@@ -21,7 +21,8 @@ import app from '../../app';
 import config from '../../config';
 import { ProgressLine, Box } from '../../components';
 import type { AuctionStep } from '../../types';
-import { getCoordinateValues } from '../../utils/getCoordinateValues';
+import { getCoordinateValues } from '../../utils';
+import scrollToNextCircle from '../../utils/scrollToNextCircle';
 
 const setupShowWinningAd = (steps: AuctionStep[]) => {
   const { box } = config.flow;
@@ -41,6 +42,8 @@ const setupShowWinningAd = (steps: AuctionStep[]) => {
     },
   });
 
+  const WINNING_AD_DELAY = 4000;
+
   steps.push({
     component: Box,
     props: {
@@ -49,10 +52,11 @@ const setupShowWinningAd = (steps: AuctionStep[]) => {
       y: () =>
         getCoordinateValues(app.auction.nextTipCoordinates).y - box.height / 2,
     },
-    delay: 1000,
+    delay: WINNING_AD_DELAY,
     callBack: (returnValue) => {
       if (returnValue.down) {
         app.auction.nextTipCoordinates = returnValue.down;
+        scrollToNextCircle(WINNING_AD_DELAY / 3);
       }
     },
   });

--- a/packages/explorable-explanations/src/protectedAudience/utils/scrollToNextCircle.ts
+++ b/packages/explorable-explanations/src/protectedAudience/utils/scrollToNextCircle.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import app from '../app';
+import { delay, getCoordinateValues, scrollToCoordinates } from '.';
+
+const scrollToNextCircle = async (scrollDelay: number) => {
+  if (app.cancelPromise || !app.autoScroll) {
+    return;
+  }
+  // scroll to the next circle before it starts animating
+  const nextCircleIndex = app.timeline.currentIndex + 1;
+  const position = app.timeline.circlePositions[nextCircleIndex];
+  if (!position) {
+    return;
+  }
+  const { x, y } = position;
+  const { x: x1, y: y1 } = getCoordinateValues({ x, y });
+  await delay(scrollDelay / app.speedMultiplier);
+  scrollToCoordinates({ x: x1, y: y1 });
+};
+
+export default scrollToNextCircle;


### PR DESCRIPTION
## Description

Add delay and improve scrolling after an auction is finished and 

## Testing Instructions

1. Pull and checkout the branch `fix/show-winning-ad-scroll`
2. Build and run the extension: `npm run build:all && npm run dev:ext`
3. Open Privacy Sandbox tab on DevTools
4. Go to Private Adverstising -> Topics -> Explorable Explanations
5. Make sure 'auto-scroll' is enable
6. Observe: The animation starts playing
7. Go to a step with an auction (for example step 3)
8. Observe: an auction animaition start
9. Wait for the animation to reach the end ( reaching the 'show winning ad' step) - see media for example
10. Observe: when the auction is finished, the animation scroll to the next step before it stars
11. Observe: There is a delay (proportional to the current speed multiplayer)

## Additional Information:

Should be tested in different speeds

## Screenshot/Screencast

https://github.com/user-attachments/assets/9e07c716-2045-45d6-b5a3-ff92ca204d91

## Checklist

- [ ] I have thoroughly tested this code to the best of my abilities.
- [ ] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
