### PR TITLE
Fix: Learning page responsive

### DIFF
--- a/packages/design-system/src/components/frameContent/index.tsx
+++ b/packages/design-system/src/components/frameContent/index.tsx
@@ -43,7 +43,7 @@ const FrameContent = ({
     <div className="grid relative" style={{ width, height }}>
       {/* Bottom border (shadow) */}
       <div
-        className={classNames(commonClassName, 'border-b-[15px] top-[13px]')}
+        className={classNames(commonClassName, 'border-b-[18px] top-[13px]')}
       />
       {/* Content */}
       <div

--- a/packages/design-system/src/components/frameContent/index.tsx
+++ b/packages/design-system/src/components/frameContent/index.tsx
@@ -37,13 +37,13 @@ const FrameContent = ({
   height?: string | number;
   color?: string;
 }) => {
-  const commonClassName = `${borderColors[color]} bg-white dark:bg-raisin-black absolute box-border w-full h-full border-[3px] rounded-xl col-start-1 row-start-1`;
+  const commonClassName = `${borderColors[color]} bg-white dark:bg-raisin-black absolute box-border w-full h-full border-[2px] rounded-xl col-start-1 row-start-1`;
 
   return (
     <div className="grid relative" style={{ width, height }}>
       {/* Bottom border (shadow) */}
       <div
-        className={classNames(commonClassName, 'border-b-[12px] top-[9px]')}
+        className={classNames(commonClassName, 'border-b-[15px] top-[13px]')}
       />
       {/* Content */}
       <div

--- a/packages/design-system/src/components/frameContent/index.tsx
+++ b/packages/design-system/src/components/frameContent/index.tsx
@@ -49,7 +49,7 @@ const FrameContent = ({
       <div
         className={classNames(
           commonClassName,
-          'flex items-center justify-center font-bold p-8'
+          'flex items-center justify-center p-8'
         )}
       >
         {children}

--- a/packages/extension/src/view/devtools/pages/layout.tsx
+++ b/packages/extension/src/view/devtools/pages/layout.tsx
@@ -259,6 +259,10 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
 
   const [allowTransition, setAllowTransition] = useState(true);
 
+  const layoutWidth = selectedItemKey?.includes('learning')
+    ? 'min-w-[300px]'
+    : 'min-w-[50rem]';
+
   return (
     <div className="w-full h-full flex flex-row z-1">
       <Resizable
@@ -285,7 +289,7 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
       <div className="flex-1 h-full overflow-hidden flex flex-col">
         <main ref={mainRef} className="w-full flex-1 relative overflow-auto">
           <div className="w-full h-full">
-            <div className="min-w-[50rem] h-full z-1">
+            <div className={layoutWidth + ' h-full z-1'}>
               {PanelElement && <PanelElement {...props} />}
             </div>
           </div>

--- a/packages/extension/src/view/devtools/pages/layout.tsx
+++ b/packages/extension/src/view/devtools/pages/layout.tsx
@@ -259,8 +259,8 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
 
   const [allowTransition, setAllowTransition] = useState(true);
 
-  const layoutWidth = selectedItemKey?.includes('learning')
-    ? 'min-w-[300px]'
+  const layoutWidth = selectedItemKey?.startsWith('learning')
+    ? 'min-w-[400px]'
     : 'min-w-[50rem]';
 
   return (

--- a/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
+++ b/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
@@ -37,9 +37,9 @@ const LandingPage = ({ sidebarKey, icon, frameColor }: LandingPageProps) => {
   const { description, title } = page;
 
   return (
-    <div className="w-full h-full overflow-hidden flex justify-center items-center p-8">
-      <div className="w-full h-full max-w-[800px] flex justify-center items-center">
-        <FrameContent height={500} color={frameColor}>
+    <div className="w-full h-full flex justify-center items-center">
+      <div className="w-[300px] h-[600px] max-h-[900px] md:w-[700px] md:h-[400px] overflow-hidden flex justify-center items-center p-8">
+        <FrameContent color={frameColor}>
           <div className="text-center flex flex-col items-center gap-2 text-raisin-black dark:text-bright-gray">
             <div className="mb-5">{icon}</div>
             {title && <h3 className="font-semibold text-2xl">{title}</h3>}

--- a/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
+++ b/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
@@ -38,13 +38,15 @@ const LandingPage = ({ sidebarKey, icon, frameColor }: LandingPageProps) => {
 
   return (
     <div className="w-full h-full flex justify-center items-center">
-      <div className="w-[300px] h-[600px] max-h-[900px] md:w-[700px] md:h-[400px] overflow-hidden flex justify-center items-center p-8">
+      <div className="w-[400px] h-[400px] md:w-[700px] md:h-[450px] overflow-hidden flex justify-center items-center p-8">
         <FrameContent color={frameColor}>
           <div className="text-center flex flex-col items-center gap-2 text-raisin-black dark:text-bright-gray">
-            <div className="mb-5">{icon}</div>
-            {title && <h3 className="font-semibold text-2xl">{title}</h3>}
+            <div className="mb-5 hidden md:block">{icon}</div>
+            {title && (
+              <h3 className="font-semibold text-xl md:text-2xl">{title}</h3>
+            )}
             {description && (
-              <p className=" p-b-2 m-b-1 text-base">{description}</p>
+              <p className=" p-b-2 m-b-1 text-sm md:text-base">{description}</p>
             )}
           </div>
         </FrameContent>

--- a/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
+++ b/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
@@ -38,10 +38,10 @@ const LandingPage = ({ sidebarKey, icon, frameColor }: LandingPageProps) => {
 
   return (
     <div className="w-full h-full flex justify-center items-center">
-      <div className="w-[400px] h-[450px] lg:w-[700px] lg:h-[450px] overflow-hidden flex justify-center items-center p-8">
+      <div className="w-[400px] h-[450px] lg:w-[700px] lg:h-[400px] overflow-hidden flex justify-center items-center p-8">
         <FrameContent color={frameColor}>
           <div className="text-center flex flex-col items-center gap-2 text-raisin-black dark:text-bright-gray">
-            <div className="mb-0 lg:mb-5 scale-75 lg:scale-100">{icon}</div>
+            <div className="mb-3 lg:mb-5 scale-75 lg:scale-100">{icon}</div>
             {title && (
               <h3 className="font-semibold text-xl lg:text-2xl">{title}</h3>
             )}

--- a/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
+++ b/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
@@ -41,7 +41,7 @@ const LandingPage = ({ sidebarKey, icon, frameColor }: LandingPageProps) => {
       <div className="w-[400px] h-[400px] md:w-[700px] md:h-[450px] overflow-hidden flex justify-center items-center p-8">
         <FrameContent color={frameColor}>
           <div className="text-center flex flex-col items-center gap-2 text-raisin-black dark:text-bright-gray">
-            <div className="mb-5 hidden md:block">{icon}</div>
+            <div className="mb-0 md:mb-5 scale-75 md:scale-100">{icon}</div>
             {title && (
               <h3 className="font-semibold text-xl md:text-2xl">{title}</h3>
             )}

--- a/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
+++ b/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
@@ -38,7 +38,7 @@ const LandingPage = ({ sidebarKey, icon, frameColor }: LandingPageProps) => {
 
   return (
     <div className="w-full h-full flex justify-center items-center">
-      <div className="w-[400px] h-[450px] lg:w-[800px] lg:h-[400px] overflow-hidden flex justify-center items-center p-8">
+      <div className="w-[400px] min-w-[400px] h-[450px] lg:w-[800px] lg:min-w-[600px] lg:h-[400px] overflow-hidden flex justify-center items-center p-8">
         <FrameContent color={frameColor}>
           <div className="text-center flex flex-col items-center gap-2 text-raisin-black dark:text-bright-gray">
             <div className="mb-3 lg:mb-5 scale-75 lg:scale-100">{icon}</div>

--- a/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
+++ b/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
@@ -38,7 +38,7 @@ const LandingPage = ({ sidebarKey, icon, frameColor }: LandingPageProps) => {
 
   return (
     <div className="w-full h-full flex justify-center items-center">
-      <div className="w-[400px] h-[450px] lg:w-[700px] lg:h-[400px] overflow-hidden flex justify-center items-center p-8">
+      <div className="w-[400px] h-[450px] lg:w-[800px] lg:h-[400px] overflow-hidden flex justify-center items-center p-8">
         <FrameContent color={frameColor}>
           <div className="text-center flex flex-col items-center gap-2 text-raisin-black dark:text-bright-gray">
             <div className="mb-3 lg:mb-5 scale-75 lg:scale-100">{icon}</div>

--- a/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
+++ b/packages/extension/src/view/devtools/pages/learning/landingePage.tsx
@@ -38,15 +38,15 @@ const LandingPage = ({ sidebarKey, icon, frameColor }: LandingPageProps) => {
 
   return (
     <div className="w-full h-full flex justify-center items-center">
-      <div className="w-[400px] h-[400px] md:w-[700px] md:h-[450px] overflow-hidden flex justify-center items-center p-8">
+      <div className="w-[400px] h-[450px] lg:w-[700px] lg:h-[450px] overflow-hidden flex justify-center items-center p-8">
         <FrameContent color={frameColor}>
           <div className="text-center flex flex-col items-center gap-2 text-raisin-black dark:text-bright-gray">
-            <div className="mb-0 md:mb-5 scale-75 md:scale-100">{icon}</div>
+            <div className="mb-0 lg:mb-5 scale-75 lg:scale-100">{icon}</div>
             {title && (
-              <h3 className="font-semibold text-xl md:text-2xl">{title}</h3>
+              <h3 className="font-semibold text-xl lg:text-2xl">{title}</h3>
             )}
             {description && (
-              <p className=" p-b-2 m-b-1 text-sm md:text-base">{description}</p>
+              <p className=" p-b-2 m-b-1 text-sm lg:text-base">{description}</p>
             )}
           </div>
         </FrameContent>


### PR DESCRIPTION
## Description

Make learning pages responsive and remove bold from description in framed content

## Testing Instructions

1. Pull and checkout the branch `fix/learning-page-responsive`
2. Build and run the extension: `npm run build:all && npm run dev:ext`
3. Open Privacy Sandbox tab on DevTools
4. Go to Learning Section
5. Visit the following pages: Dev Site, Help Center and Wiki
6. Observer: the content adapts to different screen sizes

## Checklist

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- NA This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).
