### PR TITLE
Reorder menu items and misc UI changes

### DIFF
--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -65,7 +65,7 @@ jobs:
           PUPPETEER_SKIP_DOWNLOAD: true
 
       - name: Setup Jest cache
-        uses: actions/cache@v3.4.0
+        uses: actions/cache@v4
         with:
           path: .jest-cache
           key: ${{ runner.os }}-${{ env.NVMRC }}-jest

--- a/packages/design-system/src/components/landingPage/contentPanel.tsx
+++ b/packages/design-system/src/components/landingPage/contentPanel.tsx
@@ -77,7 +77,7 @@ const ContentPanel = ({
               </div>
             </div>
             <h3
-              className={`text-lg inline-block mb-5 cursor-pointer`}
+              className={`text-lg inline-block mb-5 cursor-pointer text-raisin-black dark:text-bright-gray`}
               onClick={() =>
                 item.sidebarItemKey
                   ? updateSelectedItemKey(item.sidebarItemKey)

--- a/packages/design-system/src/components/landingPage/contentPanel.tsx
+++ b/packages/design-system/src/components/landingPage/contentPanel.tsx
@@ -37,14 +37,12 @@ export interface ContentPanelProps {
     onClick: () => void;
     sidebarItemKey?: SIDEBAR_ITEMS_KEYS;
   }[];
-  titleStyles?: string;
   counterStyles?: string;
 }
 
 const ContentPanel = ({
   title,
   content,
-  titleStyles = '',
   counterStyles = '',
 }: ContentPanelProps) => {
   const updateSelectedItemKey = useSidebar(
@@ -79,7 +77,7 @@ const ContentPanel = ({
               </div>
             </div>
             <h3
-              className={`text-lg inline-block font-medium mb-5 cursor-pointer ${titleStyles}`}
+              className={`text-lg inline-block mb-5 cursor-pointer`}
               onClick={() =>
                 item.sidebarItemKey
                   ? updateSelectedItemKey(item.sidebarItemKey)

--- a/packages/design-system/src/components/landingPage/index.tsx
+++ b/packages/design-system/src/components/landingPage/index.tsx
@@ -42,8 +42,7 @@ type LandingPageContainerProps = LandingPageProps & {
 const LandingPageContainer = (props: LandingPageContainerProps) => {
   const [independentStory, setIndependentStory] = useState<string>('');
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const { children, contentPanelTitle, content, counterStyles, titleStyles } =
-    props;
+  const { children, contentPanelTitle, content, counterStyles } = props;
 
   useEffect(() => {
     if (!independentStory || !iframeRef.current) {
@@ -98,7 +97,6 @@ const LandingPageContainer = (props: LandingPageContainerProps) => {
               };
             })}
             counterStyles={counterStyles}
-            titleStyles={titleStyles}
           />
         }
       >

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -81,8 +81,9 @@ const App: React.FC = () => {
         setSidebarData((prev) => {
           const newSidebarData = { ...prev };
           newSidebarData[SIDEBAR_ITEMS_KEYS.PRIVACY_SANDBOX].children[
-            SIDEBAR_ITEMS_KEYS.COOKIES
-          ].dropdownOpen = data?.cookieDropdownOpen;
+            SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING
+          ].children[SIDEBAR_ITEMS_KEYS.COOKIES].dropdownOpen =
+            data?.cookieDropdownOpen;
           return newSidebarData;
         });
       }

--- a/packages/extension/src/view/devtools/e2e-tests/settings/index.ts
+++ b/packages/extension/src/view/devtools/e2e-tests/settings/index.ts
@@ -168,6 +168,15 @@ describe('Settings Page', () => {
       await frame.click('button[data-test-id="button"]');
       await interaction.delay(3000);
 
+      await frame.waitForSelector('button[title="Tracking Protection"]', {
+        timeout: 5000,
+      });
+      const trackingProtectionOpener = await frame.$(
+        'button[title="Tracking Protection"]'
+      );
+
+      await trackingProtectionOpener?.click();
+
       const elementTextToClick = 'Cookies';
       await interaction.clickMatchingElement(frame, 'p', elementTextToClick);
 

--- a/packages/extension/src/view/devtools/pages/dashboard/constants.ts
+++ b/packages/extension/src/view/devtools/pages/dashboard/constants.ts
@@ -79,7 +79,7 @@ export const FEATURE_LIST = [
         sidebarKey: SIDEBAR_ITEMS_KEYS.BOUNCE_TRACKING,
       },
       {
-        name: I18n.getMessage('fingerprinting'),
+        name: 'User Agent Reduction',
         sidebarKey: SIDEBAR_ITEMS_KEYS.FINGERPRINTING,
       },
       {

--- a/packages/extension/src/view/devtools/pages/dashboard/constants.ts
+++ b/packages/extension/src/view/devtools/pages/dashboard/constants.ts
@@ -60,15 +60,31 @@ export const PINNED_ITEMS = [
 
 export const FEATURE_LIST = [
   {
-    name: I18n.getMessage('cookies'),
-    icon: CookieIcon,
-    sidebarKey: SIDEBAR_ITEMS_KEYS.COOKIES,
+    name: I18n.getMessage('trackingProtection'),
+    icon: PrivacyProtectionIcon,
+    sidebarKey: SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING,
     description:
-      'Insights into the distribution and behavior of cookies on web pages while users navigate across sites during browsing sessions.',
+      'Features and capabilities designed to limit specific covert tracking techniques such as fingerprinting and network-level tracking.',
     buttons: [
       {
-        name: 'Insights',
+        name: 'Cookies',
         sidebarKey: SIDEBAR_ITEMS_KEYS.COOKIES,
+      },
+      {
+        name: 'IP Protection',
+        sidebarKey: SIDEBAR_ITEMS_KEYS.IP_PROTECTION,
+      },
+      {
+        name: I18n.getMessage('bounceTracking'),
+        sidebarKey: SIDEBAR_ITEMS_KEYS.BOUNCE_TRACKING,
+      },
+      {
+        name: I18n.getMessage('fingerprinting'),
+        sidebarKey: SIDEBAR_ITEMS_KEYS.FINGERPRINTING,
+      },
+      {
+        name: 'Private State Tokens',
+        sidebarKey: SIDEBAR_ITEMS_KEYS.PRIVATE_STATE_TOKENS,
       },
     ],
   },
@@ -118,31 +134,6 @@ export const FEATURE_LIST = [
       {
         name: I18n.getMessage('privateAggregation'),
         sidebarKey: SIDEBAR_ITEMS_KEYS.PRIVATE_AGGREGATION,
-      },
-    ],
-  },
-  {
-    name: I18n.getMessage('trackingProtection'),
-    icon: PrivacyProtectionIcon,
-    sidebarKey: SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING,
-    description:
-      'Features and capabilities designed to limit specific covert tracking techniques such as fingerprinting and network-level tracking.',
-    buttons: [
-      {
-        name: 'IP Protection',
-        sidebarKey: SIDEBAR_ITEMS_KEYS.IP_PROTECTION,
-      },
-      {
-        name: I18n.getMessage('bounceTracking'),
-        sidebarKey: SIDEBAR_ITEMS_KEYS.BOUNCE_TRACKING,
-      },
-      {
-        name: I18n.getMessage('fingerprinting'),
-        sidebarKey: SIDEBAR_ITEMS_KEYS.FINGERPRINTING,
-      },
-      {
-        name: 'Private State Tokens',
-        sidebarKey: SIDEBAR_ITEMS_KEYS.PRIVATE_STATE_TOKENS,
       },
     ],
   },

--- a/packages/extension/src/view/devtools/pages/dashboard/contentPanel.tsx
+++ b/packages/extension/src/view/devtools/pages/dashboard/contentPanel.tsx
@@ -44,7 +44,7 @@ const ContentPanel = () => {
       event.stopPropagation();
 
       const firstFrame =
-        Object.keys(tabFrames || {})?.[0] || SIDEBAR_ITEMS_KEYS.COOKIES;
+        Object.keys(tabFrames || {})?.[0] || SIDEBAR_ITEMS_KEYS.PRIVACY_SANDBOX;
 
       navigateTo(sidebarKey === 'FIRST_COOKIE_TABLE' ? firstFrame : sidebarKey);
     },

--- a/packages/extension/src/view/devtools/pages/layout.tsx
+++ b/packages/extension/src/view/devtools/pages/layout.tsx
@@ -120,40 +120,47 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
       const data = { ...prev };
       const psData = data[SIDEBAR_ITEMS_KEYS.PRIVACY_SANDBOX];
 
-      psData.children[SIDEBAR_ITEMS_KEYS.COOKIES].panel = {
+      psData.children[SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING].children[
+        SIDEBAR_ITEMS_KEYS.COOKIES
+      ].panel = {
         Element: Cookies,
         props: { setFilteredCookies },
       };
-      psData.children[SIDEBAR_ITEMS_KEYS.COOKIES].children = Object.keys(
-        tabFrames || {}
-      ).reduce<SidebarItems>((acc, url) => {
-        const popupTitle = I18n.getMessage('cookiesUsedByFrame', [url]);
+      psData.children[SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING].children[
+        SIDEBAR_ITEMS_KEYS.COOKIES
+      ].children = Object.keys(tabFrames || {}).reduce<SidebarItems>(
+        (acc, url) => {
+          const popupTitle = I18n.getMessage('cookiesUsedByFrame', [url]);
 
-        acc[url] = {
-          title: url,
-          popupTitle,
-          panel: {
-            Element: Cookies,
-            props: { setFilteredCookies },
-          },
-          icon: {
-            Element: CookieIcon,
-          },
-          selectedIcon: {
-            Element: CookieIconWhite,
-          },
-          children: {},
-          isBlurred: !frameHasCookies?.[url],
-        };
+          acc[url] = {
+            title: url,
+            popupTitle,
+            panel: {
+              Element: Cookies,
+              props: { setFilteredCookies },
+            },
+            icon: {
+              Element: CookieIcon,
+            },
+            selectedIcon: {
+              Element: CookieIconWhite,
+            },
+            children: {},
+            isBlurred: !frameHasCookies?.[url],
+          };
 
-        return acc;
-      }, {});
+          return acc;
+        },
+        {}
+      );
 
       const showInspectButton =
         canStartInspecting && Boolean(Object.keys(tabFrames || {}).length);
 
       if (showInspectButton) {
-        psData.children[SIDEBAR_ITEMS_KEYS.COOKIES].extraInterfaceToTitle = {
+        psData.children[SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING].children[
+          SIDEBAR_ITEMS_KEYS.COOKIES
+        ].extraInterfaceToTitle = {
           Element: InspectButton,
           props: {
             isInspecting,
@@ -164,7 +171,9 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
           },
         };
       } else {
-        psData.children[SIDEBAR_ITEMS_KEYS.COOKIES].extraInterfaceToTitle = {};
+        psData.children[SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING].children[
+          SIDEBAR_ITEMS_KEYS.COOKIES
+        ].extraInterfaceToTitle = {};
       }
 
       return data;
@@ -191,9 +200,9 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
 
   const cookieDropdownOpen = useMemo(() => {
     return (
-      sidebarItems[SIDEBAR_ITEMS_KEYS.PRIVACY_SANDBOX]?.children?.[
-        SIDEBAR_ITEMS_KEYS.COOKIES
-      ]?.dropdownOpen ?? false
+      sidebarItems[SIDEBAR_ITEMS_KEYS.PRIVACY_SANDBOX]?.children[
+        SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING
+      ]?.children?.[SIDEBAR_ITEMS_KEYS.COOKIES]?.dropdownOpen ?? false
     );
   }, [sidebarItems]);
 
@@ -228,14 +237,14 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
 
     lastUrl.current = tabUrl;
 
-    updateSelectedItemKey(selectedFrame || SIDEBAR_ITEMS_KEYS.COOKIES);
+    updateSelectedItemKey(selectedFrame || SIDEBAR_ITEMS_KEYS.DASHBOARD);
   }, [cookiesAnalyzed, selectedFrame, tabUrl, updateSelectedItemKey]);
 
   const [filteredCookies, setFilteredCookies] = useState<CookieTableData[]>([]);
 
   const handleUpdate = useCallback(
     (key: string | null) => {
-      updateSelectedItemKey(key || SIDEBAR_ITEMS_KEYS.COOKIES);
+      updateSelectedItemKey(key || SIDEBAR_ITEMS_KEYS.DASHBOARD);
     },
     [updateSelectedItemKey]
   );

--- a/packages/extension/src/view/devtools/pages/privacyProtection/privacyProtection.tsx
+++ b/packages/extension/src/view/devtools/pages/privacyProtection/privacyProtection.tsx
@@ -26,6 +26,15 @@ import { I18n } from '@google-psat/i18n';
 
 const content = [
   {
+    title: () => 'Cookies',
+    description: () =>
+      'Insights into the distribution and behavior of cookies on web pages while users navigate across sites during browsing sessions.',
+    url: 'https://developers.google.com/privacy-sandbox/cookies',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/chrome-shifts-to-user-choice-for-third-party-cookies/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.COOKIES,
+  },
+  {
     title: () => I18n.getMessage('ipProtection'),
     description: () => I18n.getMessage('ipProtectionDescription'),
     url: 'https://developers.google.com/privacy-sandbox/protections/ip-protection',

--- a/packages/extension/src/view/devtools/pages/privacyProtection/privacyProtection.tsx
+++ b/packages/extension/src/view/devtools/pages/privacyProtection/privacyProtection.tsx
@@ -74,8 +74,8 @@ const PrivacyProtection = () => {
       extraClasses="min-h-[78vh] w-full"
       contentPanelTitle={I18n.getMessage('antiCovertTrackingDescription')}
       content={content}
-      counterStyles="bg-yellow-500"
-      titleStyles="text-yellow-500"
+      counterStyles="bg-blue-600"
+      titleStyles="text-blue-600"
     />
   );
 };

--- a/packages/extension/src/view/devtools/pages/privacyProtection/privacyProtection.tsx
+++ b/packages/extension/src/view/devtools/pages/privacyProtection/privacyProtection.tsx
@@ -70,7 +70,7 @@ const content = [
 const PrivacyProtection = () => {
   return (
     <LandingPageContainer
-      title="Privacy Protection"
+      title="Tracking Protection"
       extraClasses="min-h-[78vh] w-full"
       contentPanelTitle={I18n.getMessage('antiCovertTrackingDescription')}
       content={content}

--- a/packages/extension/src/view/devtools/pages/privacyProtection/tests/index.tsx
+++ b/packages/extension/src/view/devtools/pages/privacyProtection/tests/index.tsx
@@ -89,7 +89,7 @@ describe('PrivacyProtection Landing Pages', () => {
     act(() => {
       render(<PrivacyProtection />);
     });
-    expect(await screen.findByText('Privacy Protection')).toBeInTheDocument();
+    expect(await screen.findByText('Tracking Protection')).toBeInTheDocument();
   });
 
   it('should render IPProtection', async () => {

--- a/packages/extension/src/view/devtools/pages/siteBoundaries/siteBoundaries.tsx
+++ b/packages/extension/src/view/devtools/pages/siteBoundaries/siteBoundaries.tsx
@@ -65,8 +65,8 @@ const SiteBoundaries = () => {
         title={I18n.getMessage('siteBoundaries')}
         contentPanelTitle={I18n.getMessage('siteBoundariesDescription')}
         content={content}
-        counterStyles="bg-green-700"
-        titleStyles="text-green-700"
+        counterStyles="bg-blue-600"
+        titleStyles="text-blue-600"
         extraClasses="min-h-[78vh] w-full"
       />
     </>

--- a/packages/extension/src/view/devtools/tabs.ts
+++ b/packages/extension/src/view/devtools/tabs.ts
@@ -119,6 +119,23 @@ const TABS: SidebarItems = {
           },
         },
         children: {
+          [SIDEBAR_ITEMS_KEYS.COOKIES]: {
+            title: () => I18n.getMessage('cookies'),
+            icon: {
+              Element: CookieIcon,
+              props: {
+                className: '[&_path]:fill-granite-gray',
+              },
+            },
+            selectedIcon: {
+              Element: CookieIcon,
+              props: {
+                className: '[&_path]:fill-bright-gray',
+              },
+            },
+            children: {},
+            dropdownOpen: false,
+          },
           [SIDEBAR_ITEMS_KEYS.IP_PROTECTION]: {
             title: () => I18n.getMessage('ipProtection'),
             panel: {
@@ -197,23 +214,6 @@ const TABS: SidebarItems = {
             children: {},
           },
         },
-      },
-      [SIDEBAR_ITEMS_KEYS.COOKIES]: {
-        title: () => I18n.getMessage('cookies'),
-        icon: {
-          Element: CookieIcon,
-          props: {
-            className: '[&_path]:fill-granite-gray',
-          },
-        },
-        selectedIcon: {
-          Element: CookieIcon,
-          props: {
-            className: '[&_path]:fill-bright-gray',
-          },
-        },
-        children: {},
-        dropdownOpen: false,
       },
       [SIDEBAR_ITEMS_KEYS.SITE_BOUNDARIES]: {
         title: () => I18n.getMessage('siteBoundaries'),

--- a/packages/extension/src/view/devtools/tabs.ts
+++ b/packages/extension/src/view/devtools/tabs.ts
@@ -101,6 +101,103 @@ const TABS: SidebarItems = {
     },
     dropdownOpen: true,
     children: {
+      [SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING]: {
+        title: () => 'Tracking Protection',
+        panel: {
+          Element: PrivacyProtection,
+        },
+        icon: {
+          Element: PrivacyProtectionIcon,
+          props: {
+            className: '[&_path]:fill-granite-gray',
+          },
+        },
+        selectedIcon: {
+          Element: PrivacyProtectionIcon,
+          props: {
+            className: '[&_path]:fill-bright-gray',
+          },
+        },
+        children: {
+          [SIDEBAR_ITEMS_KEYS.IP_PROTECTION]: {
+            title: () => I18n.getMessage('ipProtection'),
+            panel: {
+              Element: IPProtection,
+            },
+            icon: {
+              Element: ProtectionIcon,
+              props: {
+                className: 'fill-granite-gray relative right-[3px]',
+              },
+            },
+            selectedIcon: {
+              Element: ProtectionIcon,
+              props: {
+                className: 'fill-bright-gray relative right-[3px]',
+              },
+            },
+            children: {},
+          },
+          [SIDEBAR_ITEMS_KEYS.BOUNCE_TRACKING]: {
+            title: () => I18n.getMessage('bounceTracking'),
+            panel: {
+              Element: BounceTracking,
+            },
+            icon: {
+              Element: BounceTrackingIcon,
+              props: {
+                className: 'relative top-[2px]',
+              },
+            },
+            selectedIcon: {
+              Element: BounceTrackingIconWhite,
+              props: {
+                className: 'relative top-[2px]',
+              },
+            },
+            children: {},
+          },
+          [SIDEBAR_ITEMS_KEYS.FINGERPRINTING]: {
+            title: () => 'User Agent Reduction',
+            panel: {
+              Element: UserAgentReduction,
+            },
+            icon: {
+              Element: UserAgentReductionIcon,
+              props: {
+                className: 'relative top-[2px]',
+              },
+            },
+            selectedIcon: {
+              Element: UserAgentReductionIconWhite,
+              props: {
+                className: 'relative top-[2px]',
+              },
+            },
+            children: {},
+          },
+
+          [SIDEBAR_ITEMS_KEYS.PRIVATE_STATE_TOKENS]: {
+            title: () => I18n.getMessage('privateStateTokens'),
+            panel: {
+              Element: PrivateStateTokens,
+            },
+            icon: {
+              Element: TokenIcon,
+              props: {
+                className: 'fill-granite-gray relative right-[3px]',
+              },
+            },
+            selectedIcon: {
+              Element: TokenIcon,
+              props: {
+                className: 'fill-bright-gray relative right-[3px]',
+              },
+            },
+            children: {},
+          },
+        },
+      },
       [SIDEBAR_ITEMS_KEYS.COOKIES]: {
         title: () => I18n.getMessage('cookies'),
         icon: {
@@ -300,103 +397,6 @@ const TABS: SidebarItems = {
               Element: PrivateAggregationicon,
               props: {
                 className: 'fill-bright-gray',
-              },
-            },
-            children: {},
-          },
-        },
-      },
-      [SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING]: {
-        title: () => 'Privacy Protection',
-        panel: {
-          Element: PrivacyProtection,
-        },
-        icon: {
-          Element: PrivacyProtectionIcon,
-          props: {
-            className: '[&_path]:fill-granite-gray',
-          },
-        },
-        selectedIcon: {
-          Element: PrivacyProtectionIcon,
-          props: {
-            className: '[&_path]:fill-bright-gray',
-          },
-        },
-        children: {
-          [SIDEBAR_ITEMS_KEYS.IP_PROTECTION]: {
-            title: () => I18n.getMessage('ipProtection'),
-            panel: {
-              Element: IPProtection,
-            },
-            icon: {
-              Element: ProtectionIcon,
-              props: {
-                className: 'fill-granite-gray relative right-[3px]',
-              },
-            },
-            selectedIcon: {
-              Element: ProtectionIcon,
-              props: {
-                className: 'fill-bright-gray relative right-[3px]',
-              },
-            },
-            children: {},
-          },
-          [SIDEBAR_ITEMS_KEYS.BOUNCE_TRACKING]: {
-            title: () => I18n.getMessage('bounceTracking'),
-            panel: {
-              Element: BounceTracking,
-            },
-            icon: {
-              Element: BounceTrackingIcon,
-              props: {
-                className: 'relative top-[2px]',
-              },
-            },
-            selectedIcon: {
-              Element: BounceTrackingIconWhite,
-              props: {
-                className: 'relative top-[2px]',
-              },
-            },
-            children: {},
-          },
-          [SIDEBAR_ITEMS_KEYS.FINGERPRINTING]: {
-            title: () => 'User Agent Reduction',
-            panel: {
-              Element: UserAgentReduction,
-            },
-            icon: {
-              Element: UserAgentReductionIcon,
-              props: {
-                className: 'relative top-[2px]',
-              },
-            },
-            selectedIcon: {
-              Element: UserAgentReductionIconWhite,
-              props: {
-                className: 'relative top-[2px]',
-              },
-            },
-            children: {},
-          },
-
-          [SIDEBAR_ITEMS_KEYS.PRIVATE_STATE_TOKENS]: {
-            title: () => I18n.getMessage('privateStateTokens'),
-            panel: {
-              Element: PrivateStateTokens,
-            },
-            icon: {
-              Element: TokenIcon,
-              props: {
-                className: 'fill-granite-gray relative right-[3px]',
-              },
-            },
-            selectedIcon: {
-              Element: TokenIcon,
-              props: {
-                className: 'fill-bright-gray relative right-[3px]',
               },
             },
             children: {},

--- a/packages/extension/src/view/devtools/test-utils/interaction.ts
+++ b/packages/extension/src/view/devtools/test-utils/interaction.ts
@@ -77,6 +77,15 @@ export class Interaction {
     await this.delay(2000);
 
     if (frame) {
+      await frame.waitForSelector('button[title="Tracking Protection"]', {
+        timeout: 5000,
+      });
+      const trackingProtectionOpener = await frame.$(
+        'button[title="Tracking Protection"]'
+      );
+
+      await trackingProtectionOpener?.click();
+
       const elementTextToClick = 'Cookies';
       await this.clickMatchingElement(frame, 'p', elementTextToClick);
 


### PR DESCRIPTION
## Description

This PR does the following changes

- [x] Make the number icons blue in all LPs. That would be consistent with the “all blue frames”
- [x] Make the Heading text black and remove bold.
- [x] Rename the Privacy Protection section back to Tracking Protection 
- [x] Move Tracking Protection up, making it the first component under Privacy Sandbox
- [x] Move the Cookies section to become the first component under Tracking Protection
- [x] Remove Cookies card from Dashboard
- [x] Add the Cookies card to the Tracking Protection landing page; Add cookies tab in the Tracking Protection card of the dashboard.
- [x] Reorder the Dashboard LP to have Tracking Protection, Site Boundaries, Private Advertising , Learning


## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

- Test if all of the above items have been addressed without creating regression.
- Since the order of the menu items have changed and cookies page has been moved inside "Tracking Protection", see if it creates any regression issue specially preserving page visits.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~[ ] This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
