### PR TITLE
Fix: Media Container Size showing undefined in the table.

### DIFF
--- a/packages/common/src/protectedAudience.types.ts
+++ b/packages/common/src/protectedAudience.types.ts
@@ -86,4 +86,5 @@ export type AdsAndBiddersType = {
 export type ReceivedBids = singleAuctionEvent & {
   adUnitCode?: string;
   mediaContainerSize?: number[][];
+  adType?: string;
 };

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/adUnits/adTable.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/adUnits/adTable.tsx
@@ -87,7 +87,13 @@ const AdTable = ({
             <ScreenIcon className="fill-[#323232] min-w-5 min-h-5" />
             <p className="truncate">
               {(info as number[][])
-                ?.map((size: number[]) => `${size[0]}x${size[1]}`)
+                ?.map((size: number[]) => {
+                  if (!size?.[0]) {
+                    return null;
+                  }
+                  return `${size?.[0]}x${size?.[1]}`;
+                })
+                ?.filter((size) => Boolean(size))
                 ?.join(' | ')}
             </p>
           </div>

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/auctions/adunitPanel/panel.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/auctions/adunitPanel/panel.tsx
@@ -82,7 +82,7 @@ const Panel = ({
         Icon: ScreenIcon,
         buttons: [
           ...(currentAd?.mediaContainerSize || []).map((size) => ({
-            name: `${size[0]}x${size[1]}`,
+            name: `${size?.[0]}x${size?.[1]}`,
           })),
         ],
       },

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/bids/receivedBidsTable.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/bids/receivedBidsTable.tsx
@@ -111,7 +111,7 @@ const ReceivedBidsTable = ({
       },
       {
         header: 'Media Type',
-        accessorKey: 'mediaType',
+        accessorKey: 'adType',
         cell: (info) => info,
         widthWeightagePercentage: 16,
       },

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/bids/receivedBidsTable.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/bids/receivedBidsTable.tsx
@@ -95,7 +95,13 @@ const ReceivedBidsTable = ({
             <div className="flex gap-2 items-center">
               <p className="truncate">
                 {(info as number[][])
-                  ?.map((size: number[]) => `${size[0]}x${size[1]}`)
+                  ?.map((size: number[]) => {
+                    if (!size?.[0]) {
+                      return null;
+                    }
+                    return `${size?.[0]}x${size?.[1]}`;
+                  })
+                  ?.filter((size) => Boolean(size))
                   ?.join(' | ')}
               </p>
             </div>

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/explorableExplanation/auctionEventTransformers.ts
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/explorableExplanation/auctionEventTransformers.ts
@@ -454,7 +454,7 @@ const getBidData = (
           ...event,
           adUnitCode,
           mediaContainerSize: [[320, 320]],
-          mediaType: 'video',
+          adType: 'video',
         };
       })
     );

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/explorableExplanation/interestGroupTransformer.ts
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/explorableExplanation/interestGroupTransformer.ts
@@ -60,12 +60,18 @@ export const transformInterestGroup = (site: string) => {
     const circleDateTime = getCircleDatetime(site);
     const date = new Date(circleDateTime.replace('T', ' ').replace('-', '/'));
 
-    interestGroup.time = (date.getTime() + index * 100) / 1000;
+    interestGroup.time = date.getTime() + index * 100;
+    const igFormattedTime = interestGroup.formattedTime as string;
+
+    interestGroup.formattedTime = new Date(
+      interestGroup.time +
+        Number(igFormattedTime.substring(0, igFormattedTime.length - 2)) / 1000
+    ).toISOString();
 
     interestGroup.details.expirationTime =
       new Date(
         interestGroup.time * 1000 + 10 * 60 * 60 * 1000 + index * 1000
-      ).getTime() / 1000;
+      ).getTime() / 1000000;
 
     return interestGroup;
   });

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/interestGroups/table.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/interestGroups/table.tsx
@@ -30,6 +30,7 @@ import { Resizable } from 're-resizable';
 import {
   noop,
   type InterestGroups as InterestGroupsType,
+  type singleAuctionEvent,
 } from '@google-psat/common';
 import React, { useMemo, useState, useCallback } from 'react';
 import { prettyPrintJson } from 'pretty-print-json';
@@ -57,12 +58,8 @@ const IGTable = ({
       {
         header: 'Event Time',
         accessorKey: 'formattedTime',
-        cell: (info) =>
-          (info as string)
-            .replace('T', ' | ')
-            .replace('Z', '')
-            .split('-')
-            .join('/'),
+        cell: (_, details) =>
+          (details as singleAuctionEvent).formattedTime.toString(),
         sortingComparator: (a, b) => {
           const aTime = Number((a as string).slice(0, a.length - 2));
           const bTime = Number((b as string).slice(0, b.length - 2));

--- a/packages/extension/src/view/devtools/stateProviders/protectedAudience/protectedAudienceProvider.tsx
+++ b/packages/extension/src/view/devtools/stateProviders/protectedAudience/protectedAudienceProvider.tsx
@@ -316,7 +316,7 @@ const Provider = ({ children }: PropsWithChildren) => {
                       new Set(
                         ...(adUnitCodeToBidders[adUnitCode]
                           ?.mediaContainerSize ?? []),
-                        mediaContainerSize
+                        ...(mediaContainerSize ?? [])
                       )
                     ),
                   ],

--- a/packages/extension/src/view/devtools/stateProviders/protectedAudience/utils/computeReceivedBidsAndNoBids.ts
+++ b/packages/extension/src/view/devtools/stateProviders/protectedAudience/utils/computeReceivedBidsAndNoBids.ts
@@ -97,6 +97,7 @@ function computeReceivedBidsAndNoBids(
                 ...event,
                 mediaContainerSize: [sellerSignals?.size],
                 adUnitCode: sellerSignals?.divId,
+                adType: sellerSignals?.adType,
               };
             })
           );
@@ -166,7 +167,7 @@ function computeReceivedBidsAndNoBids(
             ...event,
             mediaContainerSize: [sellerSignals.size],
             adUnitCode: sellerSignals?.divId,
-            mediaType: sellerSignals?.type,
+            adType: sellerSignals?.adType,
           };
         })
       );

--- a/packages/extension/src/view/devtools/stateProviders/protectedAudience/utils/computeReceivedBidsAndNoBids.ts
+++ b/packages/extension/src/view/devtools/stateProviders/protectedAudience/utils/computeReceivedBidsAndNoBids.ts
@@ -95,7 +95,7 @@ function computeReceivedBidsAndNoBids(
 
               return {
                 ...event,
-                mediaContainerSize: sellerSignals?.size,
+                mediaContainerSize: [sellerSignals?.size],
                 adUnitCode: sellerSignals?.divId,
               };
             })
@@ -164,7 +164,7 @@ function computeReceivedBidsAndNoBids(
 
           return {
             ...event,
-            mediaContainerSize: sellerSignals.size,
+            mediaContainerSize: [sellerSignals.size],
             adUnitCode: sellerSignals?.divId,
             mediaType: sellerSignals?.type,
           };


### PR DESCRIPTION
## Description
This PR aims to solve Ad Container Size showing undefined in the receivedBids Table.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Clone this branch.
- Open a fresh instance of chrome with the extension installed.
- Now go to [ privacysandboxdemos-domain-aaa.com.](https://privacysandboxdemos.domain-aaa.com/publisher/)
- Then join all the interest groups.
- Now click on run auction.
- Check all the places should show all the data in the tables.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
~~- [ ] This code is covered by unit tests to verify that it works as intended.~~ NA
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

