### PR TITLE
Move 'Wiki' after 'Demos' page under 'Learning' section

### DIFF
--- a/packages/extension/src/view/devtools/pages/learning/constants.ts
+++ b/packages/extension/src/view/devtools/pages/learning/constants.ts
@@ -55,17 +55,6 @@ export const FEATURED_ITEMS = [
     },
   },
   {
-    name: 'Wiki',
-    icon: PSWikiIcon,
-    sidebarKey: SIDEBAR_ITEMS_KEYS.WIKI,
-    title: 'Looking for in-depth guidance on using PSAT?',
-    description:
-      "The PSAT Wiki Page is your dedicated resource where you'll find detailed explanations of the extension's features, practical guidance on how to leverage its tools effectively, and answers to frequently asked questions about its functionality.  Explore the PSAT Wiki in the current browser tab to the left of PSAT.",
-    colorClasses: {
-      heading: 'text-blue-600',
-    },
-  },
-  {
     name: 'Stories',
     icon: PSStoriesIcon,
     sidebarKey: SIDEBAR_ITEMS_KEYS.STORIES,
@@ -84,6 +73,17 @@ export const FEATURED_ITEMS = [
       'Explore and test Privacy Sandbox APIs firsthand using the PSAT extension. Gain hands-on insights by interacting with real-world scenarios and experimenting directly within your browser.',
     colorClasses: {
       heading: 'text-green-700',
+    },
+  },
+  {
+    name: 'Wiki',
+    icon: PSWikiIcon,
+    sidebarKey: SIDEBAR_ITEMS_KEYS.WIKI,
+    title: 'Looking for in-depth guidance on using PSAT?',
+    description:
+      "The PSAT Wiki Page is your dedicated resource where you'll find detailed explanations of the extension's features, practical guidance on how to leverage its tools effectively, and answers to frequently asked questions about its functionality.  Explore the PSAT Wiki in the current browser tab to the left of PSAT.",
+    colorClasses: {
+      heading: 'text-blue-600',
     },
   },
 ];

--- a/packages/extension/src/view/devtools/tabs.ts
+++ b/packages/extension/src/view/devtools/tabs.ts
@@ -469,29 +469,6 @@ const TABS: SidebarItems = {
         children: {},
         containerClassName: 'h-6',
       },
-      [SIDEBAR_ITEMS_KEYS.WIKI]: {
-        title: () => I18n.getMessage('wiki'),
-        panel: {
-          Element: Wiki,
-          href: 'https://github.com/GoogleChromeLabs/ps-analysis-tool/wiki',
-        },
-        icon: {
-          Element: WikiIcon,
-          props: {
-            className: 'fill-granite-gray',
-          },
-        },
-        selectedIcon: {
-          Element: WikiIcon,
-          props: {
-            className: 'fill-bright-gray',
-          },
-        },
-        dropdownOpen: false,
-        children: {},
-        addSpacer: false,
-        containerClassName: 'h-6',
-      },
       [SIDEBAR_ITEMS_KEYS.STORIES]: {
         title: () => 'Stories',
         panel: {
@@ -527,6 +504,29 @@ const TABS: SidebarItems = {
         },
         dropdownOpen: false,
         children: {},
+        containerClassName: 'h-6',
+      },
+      [SIDEBAR_ITEMS_KEYS.WIKI]: {
+        title: () => I18n.getMessage('wiki'),
+        panel: {
+          Element: Wiki,
+          href: 'https://github.com/GoogleChromeLabs/ps-analysis-tool/wiki',
+        },
+        icon: {
+          Element: WikiIcon,
+          props: {
+            className: 'fill-granite-gray',
+          },
+        },
+        selectedIcon: {
+          Element: WikiIcon,
+          props: {
+            className: 'fill-bright-gray',
+          },
+        },
+        dropdownOpen: false,
+        children: {},
+        addSpacer: false,
         containerClassName: 'h-6',
       },
     },


### PR DESCRIPTION
## Description

This PR moves Wiki after the demo page.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

- Go to learning section and see if Wiki is after Demos in the menu.
- Go to learning landing page and check if the order of the cards are the same as the menu items.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~[ ] This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
