### PR TITLE
Fix: CLI install script

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -14,7 +14,7 @@ case $SHELL in
   grep "chrome_launcher.sh" ~/.zshrc > /dev/null
   if [ $? -ne 0 ]; then
     {
-      echo "if [ -f ~/bin/chrome_launcher.sh ]; then"
+      echo -e "\nif [ -f ~/bin/chrome_launcher.sh ]; then"
         echo -e "\tsource ~/bin/chrome_launcher.sh"
       echo "fi"
     } >> ~/.zshrc
@@ -25,7 +25,7 @@ case $SHELL in
   grep "chrome_launcher.sh" ~/.bashrc > /dev/null
   if [ $? -ne 0 ]; then
     {
-      echo "if [ -f ~/bin/chrome_launcher.sh ]; then"
+      echo -e "\nif [ -f ~/bin/chrome_launcher.sh ]; then"
         echo -e "\tsource ~/bin/chrome_launcher.sh"
       echo "fi"
     } >> ~/.bashrc


### PR DESCRIPTION
## Description

Add new line before appending script into bash file

## Relevant Technical Choices

I had problems installing the CLI in my machine and kept getting a error: `.zshrc:51: parse error near 'then'` due to the script not addding a new line.

## Testing Instructions

- Pull branch `fix/cli-install`
- Run install locally `sh bin/install.sh`
- CLI commands get install succesfuly

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [NA] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
