### PR TITLE
Rename "Media Type" column to "Ad Type" in bids table

### DIFF
--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/bids/receivedBidsTable.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/bids/receivedBidsTable.tsx
@@ -110,7 +110,7 @@ const ReceivedBidsTable = ({
         widthWeightagePercentage: 16,
       },
       {
-        header: 'Media Type',
+        header: 'Ad Type',
         accessorKey: 'adType',
         cell: (info) => info,
         widthWeightagePercentage: 16,


### PR DESCRIPTION
## Description

This PR renames the "Media Type" column to "Ad Type" in the bids table to better align with the terminologies used within the application.

## Testing Instructions

1. Load the application and navigate to the bids table.
2. Run the auction using the Casale Media demo.
2. Verify that the column previously labeled "Media Type" is now labeled "Ad Type."
3. Ensure related functionalities work seamlessly without errors.
4. Test thoroughly to ensure no unintended side effects occurred due to the renaming.

## Additional Information:

N/A

## Screenshot/Screencast

N/A

---

## Checklist

- [ ] I have thoroughly tested this code to the best of my abilities.
- [ ] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

Fixes #