### PR TITLE
Enhancement: Dynamic dark mode

### DIFF
--- a/packages/design-system/src/components/jsonView/jsonView.css
+++ b/packages/design-system/src/components/jsonView/jsonView.css
@@ -31,3 +31,13 @@
 .json-view .react-json-view .node-ellipsis {
   font-size: 12px !important;
 }
+
+body.dark .json-view .react-json-view .collapsed-icon svg,
+body.dark .json-view .react-json-view .expanded-icon svg {
+  color: #fff !important;
+}
+
+body.light .json-view .react-json-view .collapsed-icon svg,
+body.light .json-view .react-json-view .expanded-icon svg {
+  color: rgb(69,71,76) !important;
+}

--- a/packages/design-system/src/components/jsonView/jsonView.tsx
+++ b/packages/design-system/src/components/jsonView/jsonView.tsx
@@ -44,7 +44,9 @@ const LoadingText = () => {
  * @returns {React.ReactElement} The JsonView component.
  */
 const JsonView = (props: ReactJsonViewProps): React.ReactElement => {
-  const [isDarkMode, setIsDarkMode] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState(
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
 
   useEffect(() => {
     const onColorSchemeChange = (e: MediaQueryListEvent) => {
@@ -54,12 +56,15 @@ const JsonView = (props: ReactJsonViewProps): React.ReactElement => {
     if (mediaQuery) {
       mediaQuery.addEventListener('change', onColorSchemeChange);
     }
+
     return () => {
       if (mediaQuery) {
         mediaQuery.removeEventListener('change', onColorSchemeChange);
       }
     };
   }, []);
+
+  console.log('isDarkMode', isDarkMode);
 
   return (
     <div className="json-view">

--- a/packages/design-system/src/components/jsonView/jsonView.tsx
+++ b/packages/design-system/src/components/jsonView/jsonView.tsx
@@ -64,8 +64,6 @@ const JsonView = (props: ReactJsonViewProps): React.ReactElement => {
     };
   }, []);
 
-  console.log('isDarkMode', isDarkMode);
-
   return (
     <div className="json-view">
       <Suspense fallback={<LoadingText />}>

--- a/packages/design-system/src/components/jsonView/jsonView.tsx
+++ b/packages/design-system/src/components/jsonView/jsonView.tsx
@@ -47,9 +47,18 @@ const JsonView = (props: ReactJsonViewProps): React.ReactElement => {
   const [isDarkMode, setIsDarkMode] = useState(false);
 
   useEffect(() => {
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      setIsDarkMode(true);
+    const onColorSchemeChange = (e: MediaQueryListEvent) => {
+      setIsDarkMode(e.matches);
+    };
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    if (mediaQuery) {
+      mediaQuery.addEventListener('change', onColorSchemeChange);
     }
+    return () => {
+      if (mediaQuery) {
+        mediaQuery.removeEventListener('change', onColorSchemeChange);
+      }
+    };
   }, []);
 
   return (

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -43,9 +43,8 @@ const setThemeMode = (isDarkMode: boolean) => {
   }
 };
 
-// set initial theme mode
-const isDarkMode = chrome.devtools.panels.themeName === 'dark';
-setThemeMode(isDarkMode);
+// set initial theme mode as soon as the extension is loaded
+setThemeMode(window.matchMedia('(prefers-color-scheme: dark)').matches);
 
 const App: React.FC = () => {
   const [sidebarData, setSidebarData] = useState(TABS);
@@ -70,6 +69,7 @@ const App: React.FC = () => {
     buttonText: I18n.getMessage('refreshPanel'),
   });
 
+  // update theme mode when the system theme changes
   useEffect(() => {
     const onColorSchemeChange = (e: MediaQueryListEvent) => {
       setThemeMode(e.matches);

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -43,9 +43,6 @@ const setThemeMode = (isDarkMode: boolean) => {
   }
 };
 
-// set initial theme mode as soon as the extension is loaded
-setThemeMode(chrome.devtools.panels.themeName === 'dark');
-
 const App: React.FC = () => {
   const [sidebarData, setSidebarData] = useState(TABS);
   const contextInvalidatedRef = useRef(null);
@@ -77,7 +74,10 @@ const App: React.FC = () => {
 
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     if (mediaQuery) {
+      // listen for system theme changes
       mediaQuery.addEventListener('change', onColorSchemeChange);
+      // set initial theme mode as app is mounted
+      setThemeMode(mediaQuery.matches);
     }
 
     return () => {

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -33,6 +33,20 @@ import './app.css';
 import { Layout } from './pages';
 import useContextInvalidated from './hooks/useContextInvalidated';
 
+const setThemeMode = (isDarkMode: boolean) => {
+  if (isDarkMode) {
+    document.body.classList.add('dark');
+    document.body.classList.remove('light');
+  } else {
+    document.body.classList.add('light');
+    document.body.classList.remove('dark');
+  }
+};
+
+// set initial theme mode
+const isDarkMode = chrome.devtools.panels.themeName === 'dark';
+setThemeMode(isDarkMode);
+
 const App: React.FC = () => {
   const [sidebarData, setSidebarData] = useState(TABS);
   const contextInvalidatedRef = useRef(null);
@@ -55,6 +69,23 @@ const App: React.FC = () => {
       : 'Something went wrong.',
     buttonText: I18n.getMessage('refreshPanel'),
   });
+
+  useEffect(() => {
+    const onColorSchemeChange = (e: MediaQueryListEvent) => {
+      setThemeMode(e.matches);
+    };
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    if (mediaQuery) {
+      mediaQuery.addEventListener('change', onColorSchemeChange);
+    }
+
+    return () => {
+      if (mediaQuery) {
+        mediaQuery.removeEventListener('change', onColorSchemeChange);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     (async () => {

--- a/packages/extension/src/view/devtools/app.tsx
+++ b/packages/extension/src/view/devtools/app.tsx
@@ -44,7 +44,7 @@ const setThemeMode = (isDarkMode: boolean) => {
 };
 
 // set initial theme mode as soon as the extension is loaded
-setThemeMode(window.matchMedia('(prefers-color-scheme: dark)').matches);
+setThemeMode(chrome.devtools.panels.themeName === 'dark');
 
 const App: React.FC = () => {
   const [sidebarData, setSidebarData] = useState(TABS);

--- a/packages/extension/src/view/devtools/index.tsx
+++ b/packages/extension/src/view/devtools/index.tsx
@@ -39,10 +39,6 @@ import {
   TopicsClassifierProvider,
 } from './stateProviders';
 
-const isDarkMode = chrome.devtools.panels.themeName === 'dark';
-const classes = isDarkMode ? ['dark'] : ['light'];
-document.body.classList.add(...classes);
-
 const root = document.getElementById('root');
 
 //@ts-ignore Disable DeviceMotionEvent and DeviceOrientationEvent to prevent console errors.

--- a/packages/extension/src/view/devtools/tests/app.tsx
+++ b/packages/extension/src/view/devtools/tests/app.tsx
@@ -196,6 +196,20 @@ describe('App', () => {
       configurable: true,
       value: jest.fn(),
     });
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // Deprecated
+        removeListener: jest.fn(), // Deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
   });
 
   it('Should show cookie table if frame is selected', async () => {


### PR DESCRIPTION
## Description

Apply dynamic dark/light mode when changing broswer's appearance theme

## Testing Instructions

1. Pull and checkout the branch `enhancement/dynamic-dark-mode`
2. Build and run the extension: `npm run build:all && npm run dev:ext`
3. Open Privacy Sandbox tab on DevTools
4. Go to`chrome://settings/appearance` 
5. Select a different appearance theme mode
6. Observe: the PSAT extension swaps theme mode automatically

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).
