### PR TITLE
Fix: Incorrect access count in topics EE

### DIFF
--- a/packages/extension/src/view/devtools/pages/privateAdvertising/topics/explorableExplanation/panel.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/topics/explorableExplanation/panel.tsx
@@ -235,6 +235,18 @@ const Panel = ({
     };
   }, []);
 
+  useEffect(() => {
+    const isCompleted = epochCompleted?.[activeTabRef.current];
+
+    if (!isCompleted) {
+      setTopicsTableData((prevTopicsTableData) => {
+        const newTopicsTableData = { ...prevTopicsTableData };
+        newTopicsTableData[activeTabRef.current] = [];
+        return newTopicsTableData;
+      });
+    }
+  }, [epochCompleted, setTopicsTableData]);
+
   const handleTopicsCalculation = useCallback(
     (visitIndex: number) => {
       setTopicsTableData((prevTopicsTableData) => {


### PR DESCRIPTION
## Description
This PR fixes incorrect access counts by resetting the topics table data for an epoch if it was not completed in the first render.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open PSAT and navigate to topics EE.
- Let the animation run for a bit, then click on any topic in the table, and this should open the tax tree.
- Now come back to the EE tab, the access count should be correct.
- Now resize the table tray, and the data should remain correct.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
