### PR TITLE
Fix: Ad unit tab notification bubble disappearance

### DIFF
--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/index.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/index.ts
@@ -32,7 +32,7 @@ import setupBranches from './setupBranches';
 import setupShowWinningAd from './setupShowWinningAd';
 import { showWinningAdDirectly } from './showWinningAdDirectly';
 import { getCoordinateValues } from '../../utils/getCoordinateValues';
-import { MULTI_SELLER_CONFIG } from '../flowConfig';
+import { MULTI_SELLER_CONFIG, SINGLE_SELLER_CONFIG } from '../flowConfig';
 export type Auction = {
   setupAuctions: () => void;
   setUp: (index: number) => void;
@@ -150,6 +150,7 @@ const auction: Auction = {
                 MULTI_SELLER_CONFIG.SCORE_AD.title,
                 MULTI_SELLER_CONFIG.REPORT_WIN.title,
                 MULTI_SELLER_CONFIG.REPORT_RESULT.title,
+                SINGLE_SELLER_CONFIG.SHOW_WINNING_AD.title,
               ].includes(props.title)
             ) {
               ssp = 'https://www.' + config.timeline.circles[index].website;

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/explorableExplanation/index.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/explorableExplanation/index.tsx
@@ -301,10 +301,15 @@ const ExplorableExplanation = () => {
 
       if (receivedBids || noBids) {
         const isDataEqual = isEqual(
-          { receivedBids, noBids },
           {
-            receivedBids: prevData?.receivedBids,
-            noBids: prevData?.noBids,
+            receivedBids: Object.values(receivedBids),
+            noBids: Object.values(noBids),
+          },
+          {
+            receivedBids: Object.keys(prevData?.receivedBids || {}).length
+              ? Object.values(prevData?.receivedBids || {})
+              : [[], [], []],
+            noBids: Object.values(prevData?.noBids || {}),
           }
         );
 

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/explorableExplanation/index.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/explorableExplanation/index.tsx
@@ -297,6 +297,10 @@ const ExplorableExplanation = () => {
         if (!isDataEqual) {
           setAuctionUpdateIndicator((prev) => (prev === -1 ? 0 : prev) ^ 1);
         }
+
+        if (!Object.keys(auctionData).length) {
+          setAuctionUpdateIndicator(() => -1);
+        }
       }
 
       if (receivedBids || noBids) {
@@ -315,6 +319,10 @@ const ExplorableExplanation = () => {
 
         if (!isDataEqual) {
           setBidsUpdateIndicator((prev) => (prev === -1 ? 0 : prev) ^ 1);
+        }
+
+        if (!Object.keys(receivedBids).length && !Object.keys(noBids).length) {
+          setBidsUpdateIndicator(() => -1);
         }
       }
 

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/panel.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/panel.tsx
@@ -80,8 +80,6 @@ const Panel = () => {
     if (filteredIGData.length !== filteredIGRefData?.length) {
       if (filteredIGData.length > 0) {
         highlightTab(2);
-      } else {
-        highlightTab(2, false);
       }
 
       store = {
@@ -93,8 +91,6 @@ const Panel = () => {
     if (!isEqual(data.current?.adsAndBidders, adsAndBidders)) {
       if (Object.keys(adsAndBidders).length > 0) {
         highlightTab(3);
-      } else {
-        highlightTab(3, false);
       }
 
       store = {
@@ -107,9 +103,6 @@ const Panel = () => {
       if (receivedBids.length > 0) {
         highlightTab(3);
         highlightTab(5);
-      } else {
-        highlightTab(3, false);
-        highlightTab(5, false);
       }
 
       store = {
@@ -122,9 +115,6 @@ const Panel = () => {
       if (Object.keys(noBids).length > 0) {
         highlightTab(3);
         highlightTab(5);
-      } else {
-        highlightTab(3, false);
-        highlightTab(5, false);
       }
 
       store = {
@@ -142,8 +132,6 @@ const Panel = () => {
         Object.keys(adsAndBidders).length > 0
       ) {
         highlightTab(4);
-      } else {
-        highlightTab(4, false);
       }
 
       store = {
@@ -161,6 +149,31 @@ const Panel = () => {
     noBids,
     receivedBids,
   ]);
+
+  useEffect(() => {
+    const listener = ({
+      frameId,
+      frameType,
+      tabId,
+    }: chrome.webNavigation.WebNavigationFramedCallbackDetails) => {
+      if (
+        (frameType !== 'outermost_frame' && frameId !== 0) ||
+        tabId !== chrome.devtools.inspectedWindow.tabId
+      ) {
+        return;
+      }
+
+      highlightTab(3, false);
+      highlightTab(4, false);
+      highlightTab(5, false);
+    };
+
+    chrome.webNavigation.onCommitted.addListener(listener);
+
+    return () => {
+      chrome.webNavigation.onCommitted.removeListener(listener);
+    };
+  }, [highlightTab]);
 
   return (
     <div


### PR DESCRIPTION
## Description
The notification bubble on the Ad Unit tab disappears the first time the IG demo is run under Protected Audience. This PR resolves the issue by relocating the unhighlighting logic to the onCommitted listener. This ensures the tab’s highlight is correctly reset when data disappears during a page reload.

<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open PSAT and navigate to https://privacysandboxdemos.domain-aaa.com/
- Select multi-auction demo.
- Add some IGs from both advertisers and run an auction.
- The adunits tab notification bubble does not disappear.
- Now compare to the release branch, where the bubble disappears on first auction run.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
