### PR TITLE
Fix: Settings container padding

### DIFF
--- a/packages/extension/src/view/devtools/pages/settings/components/informationContainer.tsx
+++ b/packages/extension/src/view/devtools/pages/settings/components/informationContainer.tsx
@@ -113,6 +113,25 @@ const InformationContainer = () => {
     currentTabs,
   ]);
 
+  const sysInfo = [
+    {
+      label: I18n.getMessage('openTabs'),
+      value: currentTabs,
+    },
+    {
+      label: I18n.getMessage('chromeVersion'),
+      value: browserInformation,
+    },
+    {
+      label: I18n.getMessage('pSATVersion'),
+      value: PSATVersion,
+    },
+    {
+      label: I18n.getMessage('systemArchitecture'),
+      value: OSInformation,
+    },
+  ];
+
   return (
     <div data-testid="debugging-information">
       <div>
@@ -137,38 +156,16 @@ const InformationContainer = () => {
           )}
         >
           <div className="flex flex-row gap-x-2 justify-between items-start">
-            <div className="flex flex-col">
-              <span className="text-sm dark:text-bright-gray">
-                {I18n.getMessage('openTabs')}
-              </span>
-              <span className="text-xs text-darkest-gray dark:text-bright-gray">
-                {currentTabs}
-              </span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-sm dark:text-bright-gray">
-                {I18n.getMessage('chromeVersion')}
-              </span>
-              <span className="text-xs text-darkest-gray dark:text-bright-gray">
-                {browserInformation}
-              </span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-sm dark:text-bright-gray">
-                {I18n.getMessage('pSATVersion')}
-              </span>
-              <span className="text-xs text-darkest-gray dark:text-bright-gray">
-                {PSATVersion}
-              </span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-sm dark:text-bright-gray">
-                {I18n.getMessage('systemArchitecture')}
-              </span>
-              <span className="text-xs text-darkest-gray dark:text-bright-gray">
-                {OSInformation}
-              </span>
-            </div>
+            {sysInfo.map((info) => (
+              <div className="flex flex-col mt-2" key={info.label}>
+                <span className="text-sm dark:text-bright-gray">
+                  {info.label}
+                </span>
+                <span className="text-xs text-darkest-gray dark:text-bright-gray">
+                  {info.value}
+                </span>
+              </div>
+            ))}
             <button
               data-testid="copy-button"
               disabled={copying}

--- a/packages/extension/src/view/devtools/pages/settings/components/informationContainer.tsx
+++ b/packages/extension/src/view/devtools/pages/settings/components/informationContainer.tsx
@@ -170,7 +170,7 @@ const InformationContainer = () => {
               data-testid="copy-button"
               disabled={copying}
               onClick={handleCopy}
-              className="-ml-6 -mt-1"
+              className="-ml-8 -mt-1"
             >
               {copying ? (
                 <Done className="active:text-mischka dark:text-bright-gray active:dark:text-mischka" />

--- a/packages/extension/src/view/devtools/pages/settings/components/informationContainer.tsx
+++ b/packages/extension/src/view/devtools/pages/settings/components/informationContainer.tsx
@@ -173,6 +173,7 @@ const InformationContainer = () => {
               data-testid="copy-button"
               disabled={copying}
               onClick={handleCopy}
+              className="-ml-8"
             >
               {copying ? (
                 <Done className="active:text-mischka dark:text-bright-gray active:dark:text-mischka" />

--- a/packages/extension/src/view/devtools/pages/settings/components/informationContainer.tsx
+++ b/packages/extension/src/view/devtools/pages/settings/components/informationContainer.tsx
@@ -157,7 +157,7 @@ const InformationContainer = () => {
         >
           <div className="flex flex-row gap-x-2 justify-between items-start">
             {sysInfo.map((info) => (
-              <div className="flex flex-col mt-2" key={info.label}>
+              <div className="flex flex-col" key={info.label}>
                 <span className="text-sm dark:text-bright-gray">
                   {info.label}
                 </span>
@@ -170,7 +170,7 @@ const InformationContainer = () => {
               data-testid="copy-button"
               disabled={copying}
               onClick={handleCopy}
-              className="-ml-8"
+              className="-ml-6 -mt-1"
             >
               {copying ? (
                 <Done className="active:text-mischka dark:text-bright-gray active:dark:text-mischka" />

--- a/packages/extension/src/view/devtools/pages/settings/components/informationContainer.tsx
+++ b/packages/extension/src/view/devtools/pages/settings/components/informationContainer.tsx
@@ -54,7 +54,7 @@ const InformationContainer = () => {
     if (copying) {
       timeOutRef.current = setTimeout(() => {
         setCopying(false);
-      }, 200);
+      }, 500);
     } else {
       if (timeOutRef.current) {
         clearTimeout(timeOutRef.current);
@@ -133,22 +133,10 @@ const InformationContainer = () => {
         <div
           className={classNames(
             { hidden: !open },
-            'relative rounded flex flex-col w-full px-4 pr-8 py-2 border border-american-silver dark:border-quartz gap-y-3'
+            'relative rounded flex flex-col w-full px-4 py-4 border border-american-silver dark:border-quartz gap-y-3'
           )}
         >
-          <button
-            data-testid="copy-button"
-            disabled={copying}
-            className="absolute right-1 top-1"
-            onClick={handleCopy}
-          >
-            {copying ? (
-              <Done className="active:text-mischka dark:text-bright-gray active:dark:text-mischka" />
-            ) : (
-              <Copy className="active:text-mischka dark:text-bright-gray active:dark:text-mischka" />
-            )}
-          </button>
-          <div className="flex flex-row gap-x-2 justify-between mt-4">
+          <div className="flex flex-row gap-x-2 justify-between items-start">
             <div className="flex flex-col">
               <span className="text-sm dark:text-bright-gray">
                 {I18n.getMessage('openTabs')}
@@ -181,6 +169,17 @@ const InformationContainer = () => {
                 {OSInformation}
               </span>
             </div>
+            <button
+              data-testid="copy-button"
+              disabled={copying}
+              onClick={handleCopy}
+            >
+              {copying ? (
+                <Done className="active:text-mischka dark:text-bright-gray active:dark:text-mischka" />
+              ) : (
+                <Copy className="active:text-mischka dark:text-bright-gray active:dark:text-mischka" />
+              )}
+            </button>
           </div>
           <div className="flex flex-row">
             <div className="mt-1">


### PR DESCRIPTION
## Description

Add padding in settings container

## Testing Instructions

1. Pull and checkout the branch `improvement/initial-theme-mode`
2. Build and run the extension: `npm run build:all && npm run dev:ext`
3. Open Privacy Sandbox tab on DevTools
4. Open settings page
5. Observe: the settings containers have padding

## Screenshot/Screencast

- Before

<img width="945" alt="Screenshot 2025-04-14 at 2 57 53 PM" src="https://github.com/user-attachments/assets/45829c93-9708-4732-8394-69e152b70d08" />

- After

<img width="984" alt="Screenshot 2025-04-14 at 3 24 48 PM" src="https://github.com/user-attachments/assets/6381f6a7-9fbe-4cad-a461-cfd622fde65a" />


## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).