### PR TITLE
Fix: Prevent auto scrolling when animation is paused in EE

### DIFF
--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.ts
@@ -538,9 +538,6 @@ const setupAfterComponentAuctionFlow = (steps) => {
     callBack: (returnValue: Coordinates) => {
       if (returnValue.down) {
         app.auction.nextTipCoordinates = returnValue.down;
-        if (!app.autoScroll) {
-          return;
-        }
         const currentCircleIndex = app.timeline.currentIndex;
         const nextCircleIndex = app.isInteractiveMode
           ? currentCircleIndex

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/setupShowWinningAd.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/setupShowWinningAd.ts
@@ -54,9 +54,6 @@ const setupShowWinningAd = (steps: AuctionStep[]) => {
     callBack: (returnValue) => {
       if (returnValue.down) {
         app.auction.nextTipCoordinates = returnValue.down;
-        if (!app.autoScroll) {
-          return;
-        }
         const currentCircleIndex = app.timeline.currentIndex;
         const nextCircleIndex = app.isInteractiveMode
           ? currentCircleIndex

--- a/packages/explorable-explanations/src/protectedAudience/utils/scrollToCircle.ts
+++ b/packages/explorable-explanations/src/protectedAudience/utils/scrollToCircle.ts
@@ -25,5 +25,8 @@ export const scrollToCircle = async (index: number, scrollDelay = 0) => {
   const { x, y } = position;
   const { x: x1, y: y1 } = getCoordinateValues({ x, y });
   await delay(scrollDelay);
+  if (app.timeline.isPaused || !app.autoScroll) {
+    return;
+  }
   scrollToCoordinates({ x: x1, y: y1 });
 };


### PR DESCRIPTION
## Description

Fixes scrolling when animation is paused

## Relevant Technical Choices

Never scroll if the autoscroll is disable or animation paused

## Testing Instructions

1. Pull and checkout the branch `fix/paused-scrolling`
2. Build and run the extension: `npm run build:all && npm run dev:ext`
3. Open Privacy Sandbox tab on DevTools
4. Go PA:EE
5. Enable auto scroll
6. Wait for a winning app to show up
7. Pause the animation
8. Observer, the animation doesn't trigger any scrolling

## Screenshot/Screencast

https://github.com/user-attachments/assets/25f12ba2-aae0-4353-bde0-38269f7d8c76

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).
