### PR TITLE
Update diagram boxes to yellow for SSPs with minimal integration changes

### DIFF
--- a/packages/explorable-explanations/src/protectedAudience/config.ts
+++ b/packages/explorable-explanations/src/protectedAudience/config.ts
@@ -62,7 +62,7 @@ export type Config = {
     colors: {
       box: {
         background: string;
-        notBrowser: string;
+        yellowBox: string;
         text: string;
         borderStroke: number[];
         noData: string;
@@ -204,7 +204,7 @@ const config: Config = {
     colors: {
       box: {
         background: '255',
-        notBrowser: '#ffec99',
+        yellowBox: '#ffec99',
         noData: '#e9ecef',
         text: '#000',
         borderStroke: [0, 0, 0],

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.ts
@@ -418,7 +418,7 @@ const setUpTPoint = (steps: AuctionStep[]) => {
 };
 
 const setupAfterComponentAuctionFlow = (steps) => {
-  const { box, arrowSize } = config.flow;
+  const { box, arrowSize, colors } = config.flow;
 
   steps.push({
     component: Box,
@@ -495,6 +495,7 @@ const setupAfterComponentAuctionFlow = (steps) => {
       title: MULTI_SELLER_CONFIG.REPORT_RESULT.title,
       info: MULTI_SELLER_CONFIG.REPORT_RESULT.info,
       description: MULTI_SELLER_CONFIG.REPORT_RESULT.description,
+      color: colors.box.notBrowser,
       x: () =>
         getCoordinateValues(app.auction.nextTipCoordinates).x - box.width / 2,
       y: () =>

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.ts
@@ -185,6 +185,8 @@ const setUpComponentAuctionStarter = (
   };
 
   const renderBoxes = (componentAuction: ComponentAuction, index: number) => {
+    const { colors } = config.flow;
+
     steps.push({
       component: ProgressLine,
       props: {
@@ -222,6 +224,7 @@ const setUpComponentAuctionStarter = (
         x: () =>
           getCoordinateValues(returnCoordinates).x - BORDER_BOX_MARGIN - 12,
         y: () => getCoordinateValues(returnCoordinates).y + 20,
+        color: colors.box.yellowBox,
       },
       delay: 1000,
       callBack: () => {
@@ -258,7 +261,7 @@ const setUpComponentAuction = (
   { title, x, y, ssp, info, sspWebsite },
   { bidValue }
 ) => {
-  const { box, arrowSize } = config.flow;
+  const { box, arrowSize, colors } = config.flow;
 
   steps.push({
     component: Text,
@@ -285,6 +288,7 @@ const setUpComponentAuction = (
         12,
       y: () => getCoordinateValues(app.auction.nextTipCoordinates).y + 20,
       info,
+      color: colors.box.yellowBox,
     },
     delay: 1000,
     callBack: (returnValue: Coordinates) => {

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpComponentAuctions.ts
@@ -495,7 +495,7 @@ const setupAfterComponentAuctionFlow = (steps) => {
       title: MULTI_SELLER_CONFIG.REPORT_RESULT.title,
       info: MULTI_SELLER_CONFIG.REPORT_RESULT.info,
       description: MULTI_SELLER_CONFIG.REPORT_RESULT.description,
-      color: colors.box.notBrowser,
+      color: colors.box.yellowBox,
       x: () =>
         getCoordinateValues(app.auction.nextTipCoordinates).x - box.width / 2,
       y: () =>

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpFirstSSPTagFlow.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpFirstSSPTagFlow.ts
@@ -48,6 +48,7 @@ const setUpMultiSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
         getCoordinateValues(app.auction.nextTipCoordinates).x - box.width / 2,
       y: () => getCoordinateValues(app.auction.nextTipCoordinates).y,
       info: MULTI_SELLER_CONFIG.SSP_ADAPTER_HEADER_BIDDING.info,
+      color: colors.box.notBrowser,
     },
     delay: 1000,
     callBack: (returnValue) => {
@@ -78,8 +79,8 @@ const setUpMultiSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
       y: () =>
         getCoordinateValues(app.auction.nextTipCoordinates).y +
         config.flow.arrowSize,
-      color: colors.box.notBrowser,
       info: MULTI_SELLER_CONFIG.SSPs.info,
+      color: colors.box.notBrowser,
     },
     delay: 1000,
     callBack: (returnValue) => {
@@ -110,7 +111,6 @@ const setUpMultiSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
       y: () =>
         getCoordinateValues(app.auction.nextTipCoordinates).y +
         config.flow.arrowSize,
-      color: colors.box.notBrowser,
       info: MULTI_SELLER_CONFIG.DSPs.info,
     },
     delay: 1000,

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpFirstSSPTagFlow.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpFirstSSPTagFlow.ts
@@ -48,7 +48,7 @@ const setUpMultiSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
         getCoordinateValues(app.auction.nextTipCoordinates).x - box.width / 2,
       y: () => getCoordinateValues(app.auction.nextTipCoordinates).y,
       info: MULTI_SELLER_CONFIG.SSP_ADAPTER_HEADER_BIDDING.info,
-      color: colors.box.notBrowser,
+      color: colors.box.yellowBox,
     },
     delay: 1000,
     callBack: (returnValue) => {
@@ -80,7 +80,7 @@ const setUpMultiSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
         getCoordinateValues(app.auction.nextTipCoordinates).y +
         config.flow.arrowSize,
       info: MULTI_SELLER_CONFIG.SSPs.info,
-      color: colors.box.notBrowser,
+      color: colors.box.yellowBox,
     },
     delay: 1000,
     callBack: (returnValue) => {

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpPublisherAdServerFlow.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpPublisherAdServerFlow.ts
@@ -24,7 +24,7 @@ import type { AuctionStep } from '../../../types.js';
 import { getCoordinateValues } from '../../../utils/getCoordinateValues.ts';
 
 const setUpPublisherAdServerFlow = (steps: AuctionStep[]) => {
-  const { box, colors } = config.flow;
+  const { box } = config.flow;
 
   steps.push({
     component: Box,
@@ -62,7 +62,6 @@ const setUpPublisherAdServerFlow = (steps: AuctionStep[]) => {
     props: {
       title: MULTI_SELLER_CONFIG.PUBLISHER_ADSERVER.title,
       description: MULTI_SELLER_CONFIG.PUBLISHER_ADSERVER.description,
-      color: colors.box.notBrowser,
       x: () => getCoordinateValues(app.auction.nextTipCoordinates).x + 10,
       y: () => getCoordinateValues(app.auction.nextTipCoordinates).y - 23,
       info: MULTI_SELLER_CONFIG.PUBLISHER_ADSERVER.info,

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/setUpRunadAuction.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/setUpRunadAuction.ts
@@ -81,13 +81,13 @@ const setUpRunadAuction = (
       title: SINGLE_SELLER_CONFIG.KEY_VALUE_SSP_SERVER.title,
       description: SINGLE_SELLER_CONFIG.KEY_VALUE_SSP_SERVER.description,
       info: SINGLE_SELLER_CONFIG.KEY_VALUE_SSP_SERVER.info,
-      color: colors.box.notBrowser,
+      color: colors.box.yellowBox,
     },
     {
       title: SINGLE_SELLER_CONFIG.SCORE_AD.title,
       description: SINGLE_SELLER_CONFIG.SCORE_AD.description,
       info: SINGLE_SELLER_CONFIG.SCORE_AD.info,
-      color: colors.box.notBrowser,
+      color: colors.box.yellowBox,
     },
     {
       title: SINGLE_SELLER_CONFIG.REPORT_WIN.title,
@@ -98,7 +98,7 @@ const setUpRunadAuction = (
       title: SINGLE_SELLER_CONFIG.REPORT_RESULT.title,
       description: SINGLE_SELLER_CONFIG.REPORT_RESULT.description,
       info: SINGLE_SELLER_CONFIG.REPORT_RESULT.info,
-      color: colors.box.notBrowser,
+      color: colors.box.yellowBox,
     },
   ];
 

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/setUpRunadAuction.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/setUpRunadAuction.ts
@@ -59,7 +59,6 @@ const setUpRunadAuction = (
     {
       title: SINGLE_SELLER_CONFIG.KEY_VALUE_DSP_SERVER.title,
       description: SINGLE_SELLER_CONFIG.KEY_VALUE_DSP_SERVER.description,
-      color: colors.box.notBrowser,
       info: SINGLE_SELLER_CONFIG.KEY_VALUE_DSP_SERVER.info,
     },
     {
@@ -73,12 +72,10 @@ const setUpRunadAuction = (
     {
       title: 'DSP 1',
       info: SINGLE_SELLER_CONFIG.DSP_X.info,
-      color: colors.box.notBrowser,
     },
     {
       title: 'DSP 2',
       info: SINGLE_SELLER_CONFIG.DSP_X.info,
-      color: colors.box.notBrowser,
     },
     {
       title: SINGLE_SELLER_CONFIG.KEY_VALUE_SSP_SERVER.title,
@@ -90,6 +87,7 @@ const setUpRunadAuction = (
       title: SINGLE_SELLER_CONFIG.SCORE_AD.title,
       description: SINGLE_SELLER_CONFIG.SCORE_AD.description,
       info: SINGLE_SELLER_CONFIG.SCORE_AD.info,
+      color: colors.box.notBrowser,
     },
     {
       title: SINGLE_SELLER_CONFIG.REPORT_WIN.title,
@@ -100,6 +98,7 @@ const setUpRunadAuction = (
       title: SINGLE_SELLER_CONFIG.REPORT_RESULT.title,
       description: SINGLE_SELLER_CONFIG.REPORT_RESULT.description,
       info: SINGLE_SELLER_CONFIG.REPORT_RESULT.info,
+      color: colors.box.notBrowser,
     },
   ];
 

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/single-seller/setupFirstSSPTagFlow.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/single-seller/setupFirstSSPTagFlow.ts
@@ -47,6 +47,7 @@ const setUpSingleSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
         getCoordinateValues(app.auction.nextTipCoordinates).x - box.width / 2,
       y: () => getCoordinateValues(app.auction.nextTipCoordinates).y,
       info: SINGLE_SELLER_CONFIG.SSP_TAG.info,
+      color: colors.box.notBrowser,
     },
     delay: 1000,
     callBack: (returnValue) => {
@@ -77,8 +78,8 @@ const setUpSingleSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
       y: () =>
         getCoordinateValues(app.auction.nextTipCoordinates).y +
         config.flow.arrowSize,
-      color: colors.box.notBrowser,
       info: SINGLE_SELLER_CONFIG.SSP.info,
+      color: colors.box.notBrowser,
     },
     delay: 1000,
     callBack: (returnValue) => {
@@ -109,7 +110,6 @@ const setUpSingleSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
       y: () =>
         getCoordinateValues(app.auction.nextTipCoordinates).y +
         config.flow.arrowSize,
-      color: colors.box.notBrowser,
       info: SINGLE_SELLER_CONFIG.DSPS.info,
     },
     delay: 1000,

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/single-seller/setupFirstSSPTagFlow.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/single-seller/setupFirstSSPTagFlow.ts
@@ -47,7 +47,7 @@ const setUpSingleSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
         getCoordinateValues(app.auction.nextTipCoordinates).x - box.width / 2,
       y: () => getCoordinateValues(app.auction.nextTipCoordinates).y,
       info: SINGLE_SELLER_CONFIG.SSP_TAG.info,
-      color: colors.box.notBrowser,
+      color: colors.box.yellowBox,
     },
     delay: 1000,
     callBack: (returnValue) => {
@@ -79,7 +79,7 @@ const setUpSingleSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
         getCoordinateValues(app.auction.nextTipCoordinates).y +
         config.flow.arrowSize,
       info: SINGLE_SELLER_CONFIG.SSP.info,
-      color: colors.box.notBrowser,
+      color: colors.box.yellowBox,
     },
     delay: 1000,
     callBack: (returnValue) => {

--- a/packages/explorable-explanations/src/protectedAudience/modules/flowConfig.tsx
+++ b/packages/explorable-explanations/src/protectedAudience/modules/flowConfig.tsx
@@ -371,7 +371,7 @@ export const SINGLE_SELLER_CONFIG = {
 export const MULTI_SELLER_CONFIG = {
   SSP_ADAPTER_HEADER_BIDDING: {
     title: 'SSP Adapter',
-    description: 'header-bidding lib',
+    description: '(header-bidding lib)',
     info: (
       <>
         <p>

--- a/packages/explorable-explanations/src/protectedAudience/modules/flowConfig.tsx
+++ b/packages/explorable-explanations/src/protectedAudience/modules/flowConfig.tsx
@@ -66,7 +66,7 @@ export const ADVERTIZER_CONFIG = {
 
 export const SINGLE_SELLER_CONFIG = {
   SSP_TAG: {
-    title: 'SSP Tag',
+    title: 'SSP Ad Tag',
     info: (
       <>
         <div>

--- a/packages/explorable-explanations/src/protectedAudience/modules/joinInterestGroup.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/joinInterestGroup.ts
@@ -130,7 +130,6 @@ const joinInterestGroup: JoinInterestGroup = {
         y: () =>
           getCoordinateValues(app.joinInterestGroup.nextTipCoordinates).y +
           config.flow.arrowSize,
-        color: config.flow.colors.box.notBrowser,
         info: ADVERTIZER_CONFIG.DSPS.info,
       },
       delay: 1000,

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/explorableExplanation/tableTabPanels/legend.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/explorableExplanation/tableTabPanels/legend.tsx
@@ -35,14 +35,15 @@ const Legend = () => {
         process. Below is a guide to the different symbols used in the diagram.
       </p>
       <div className="flex flex-col gap-3 mt-3">
-        <div className="flex gap-2 items-center">
+        <div className="flex gap-2">
           <div className="bg-yellow-400 w-4 h-4 border border-black" />
-          <p>Yellow boxes signify processes running out of browser context.</p>
-        </div>
-        <div className="flex gap-2 items-center">
-          <div className="bg-white w-4 h-4 border border-black" />
-          <p>
-            White boxes signify processes running inside the browser context.
+          <p className="mt-[-3px]">
+            Yellow boxes highlight the minimum required changes for SSPs to
+            participate in Protected Audience API workflows. Please refer to{' '}
+            <Link href="https://developers.google.com/display-video/protected-audience/ssp-guide">
+              ssp-guide
+            </Link>{' '}
+            for more information.
           </p>
         </div>
         <div className="flex gap-2 items-center">


### PR DESCRIPTION
## Description

- This PR updates the flow diagrams to use yellow-colored boxes for steps where SSPs are required to make minimal changes, as outlined in the Protected Audience API SSP integration guide. The color change visually distinguishes low-effort implementation steps to help developers quickly identify them in the integration workflow. 
- It also removes yellow color for the non browser boxes and updates the legend to reflect these changes.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

- Go to EE PA and check if all SSP boxes have yellow color.
- Legend doesn't have any typos.

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
