### PR TITLE
Enhancement: Add textual description to PA EE arrows

### DIFF
--- a/packages/explorable-explanations/src/protectedAudience/components/progressLine.ts
+++ b/packages/explorable-explanations/src/protectedAudience/components/progressLine.ts
@@ -194,10 +194,12 @@ const ProgressLine = ({
               utils.scrollToCoordinates({ x: x2, y: currentY });
             }
 
+            const textWidth = p.textWidth(text);
+
             utils.drawText(
               text,
-              x1 - (text.startsWith('$') ? 10 : width / 2),
-              y1 + height / 2
+              x1 - (text.startsWith('$') ? 10 : textWidth / 2 + 2),
+              y1 + height / 2 + 4
             );
             resolve({ x: x2, y: currentY });
             return;
@@ -233,10 +235,12 @@ const ProgressLine = ({
               });
             }
 
+            const textWidth = p.textWidth(text);
+
             utils.drawText(
               text,
-              x1 + (text.startsWith('$') ? 10 : width / 2),
-              y1 - height / 2
+              x1 + (text.startsWith('$') ? 10 : textWidth / 2),
+              y1 - height / 2 - 3
             );
             resolve({ x: x2, y: currentY });
             return;

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpFirstSSPTagFlow.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/multi-seller/setUpFirstSSPTagFlow.ts
@@ -63,6 +63,7 @@ const setUpMultiSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
       direction: 'down',
       x1: () => getCoordinateValues(app.auction.nextTipCoordinates).x,
       y1: () => getCoordinateValues(app.auction.nextTipCoordinates).y + 40,
+      text: 'Ad request',
     },
     callBack: (returnValue) => {
       app.auction.nextTipCoordinates = returnValue;
@@ -95,6 +96,7 @@ const setUpMultiSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
       direction: 'down',
       x1: () => getCoordinateValues(app.auction.nextTipCoordinates).x,
       y1: () => getCoordinateValues(app.auction.nextTipCoordinates).y + 40,
+      text: 'OpenRTB \n bid request',
     },
     callBack: (returnValue) => {
       app.auction.nextTipCoordinates = returnValue;
@@ -127,6 +129,7 @@ const setUpMultiSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
       direction: 'up',
       x1: () => getCoordinateValues(app.auction.nextTipCoordinates).x + 10,
       y1: () => getCoordinateValues(app.auction.nextTipCoordinates).y - 15,
+      text: 'OpenRTB \n bid response',
     },
     callBack: (returnValue) => {
       app.auction.nextTipCoordinates = returnValue;

--- a/packages/explorable-explanations/src/protectedAudience/modules/auctions/single-seller/setupFirstSSPTagFlow.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/auctions/single-seller/setupFirstSSPTagFlow.ts
@@ -62,6 +62,7 @@ const setUpSingleSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
       direction: 'down',
       x1: () => getCoordinateValues(app.auction.nextTipCoordinates).x,
       y1: () => getCoordinateValues(app.auction.nextTipCoordinates).y + 40,
+      text: 'Ad request',
     },
     callBack: (returnValue) => {
       app.auction.nextTipCoordinates = returnValue;
@@ -94,6 +95,7 @@ const setUpSingleSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
       direction: 'down',
       x1: () => getCoordinateValues(app.auction.nextTipCoordinates).x,
       y1: () => getCoordinateValues(app.auction.nextTipCoordinates).y + 40,
+      text: 'OpenRTB \n bid request',
     },
     callBack: (returnValue) => {
       app.auction.nextTipCoordinates = returnValue;
@@ -128,6 +130,7 @@ const setUpSingleSellerFirstSSPTagFlow = (steps: AuctionStep[]) => {
       y1: () => {
         return getCoordinateValues(app.auction.nextTipCoordinates).y - 15;
       },
+      text: 'OpenRTB \n bid response',
     },
     callBack: (returnValue) => {
       app.auction.nextTipCoordinates = returnValue;

--- a/packages/explorable-explanations/src/protectedAudience/modules/joinInterestGroup.ts
+++ b/packages/explorable-explanations/src/protectedAudience/modules/joinInterestGroup.ts
@@ -113,6 +113,7 @@ const joinInterestGroup: JoinInterestGroup = {
           getCoordinateValues(app.joinInterestGroup.nextTipCoordinates).x,
         y1: () =>
           getCoordinateValues(app.joinInterestGroup.nextTipCoordinates).y + 40,
+        text: 'Tagging call',
       },
       callBack: (returnValue) => {
         app.joinInterestGroup.nextTipCoordinates = returnValue;


### PR DESCRIPTION
## Description
This PR adds a textual description to arrows to attribute their role in the PA EE flow.
- Adds `Tagging call` text to the arrow from DSP tags to DSPs in the advertiser flow.
- Adds `Ad Request` text to the arrow from SSP adapter to SSP, `OpenRTB bid request` from SSP to DSPs, and `OpenRTB bid response` from DSPs to SSP in the publisher flow.
- It also changes the positioning of text around up and down arrows by using `textWidth` function.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open PSAT and navigate to PA EE.
- Run the flow, the arrow from DSP tags to DSPs in the advertiser flow should have `Tagging call` text.
- In publisher flow, `Ad Request` text to the arrow from SSP adapter to SSP, `OpenRTB bid request` from SSP to DSPs, and `OpenRTB bid response` from DSPs to SSP
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
