### PR TITLE
Fix: Show CDP settings icon buttons only in smaller screens

### DIFF
--- a/packages/extension/src/view/devtools/pages/layout.tsx
+++ b/packages/extension/src/view/devtools/pages/layout.tsx
@@ -208,14 +208,22 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
     return (
       <div className="flex items-center gap-5">
         <Button
-          text={<Tick className="fill-white dark:fill-white w-4 h-4" />}
+          text={
+            <>
+              <Tick className="w-4 h-4 hidden max-sm:block" />
+              <span className="hidden sm:block">Yes</span>
+            </>
+          }
           size="large"
           onClick={handleSettingsChange}
           variant="success"
         />
         <Button
           text={
-            <Plus className="fill-white dark:fill-white rotate-45 w-4 h-4" />
+            <>
+              <Plus className="rotate-45 w-4 h-4 hidden max-sm:block" />
+              <span className="hidden sm:block">No</span>
+            </>
           }
           size="large"
           onClick={async () => {

--- a/packages/extension/src/view/devtools/pages/layout.tsx
+++ b/packages/extension/src/view/devtools/pages/layout.tsx
@@ -246,8 +246,8 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
         <Button
           text={
             <>
-              <Tick className="fill-white dark:fill-white w-4 h-4 md:hidden" />
-              <span className="hidden md:block">Yes</span>
+              <Tick className="w-4 h-4 sm:hidden" />
+              <span className="hidden sm:block">Yes</span>
             </>
           }
           size="large"
@@ -257,8 +257,8 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
         <Button
           text={
             <>
-              <Plus className="fill-white dark:fill-white rotate-45 w-4 h-4 md:hidden" />
-              <span className="hidden md:block">No</span>
+              <Plus className="rotate-45 w-4 h-4 sm:hidden" />
+              <span className="hidden sm:block">No</span>
             </>
           }
           size="large"

--- a/packages/extension/src/view/devtools/pages/layout.tsx
+++ b/packages/extension/src/view/devtools/pages/layout.tsx
@@ -244,14 +244,22 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
     return (
       <div className="flex items-center gap-5">
         <Button
-          text={<Tick className="fill-white dark:fill-white w-4 h-4" />}
+          text={
+            <>
+              <Tick className="fill-white dark:fill-white w-4 h-4 md:hidden" />
+              <span className="hidden md:block">Yes</span>
+            </>
+          }
           size="large"
           onClick={handleSettingsChange}
           variant={exceedingLimitations ? 'danger' : 'success'}
         />
         <Button
           text={
-            <Plus className="fill-white dark:fill-white rotate-45 w-4 h-4" />
+            <>
+              <Plus className="fill-white dark:fill-white rotate-45 w-4 h-4 md:hidden" />
+              <span className="hidden md:block">No</span>
+            </>
           }
           size="large"
           onClick={async () => {

--- a/packages/extension/src/view/devtools/pages/layout.tsx
+++ b/packages/extension/src/view/devtools/pages/layout.tsx
@@ -246,7 +246,7 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
         <Button
           text={
             <>
-              <Tick className="w-4 h-4 sm:hidden" />
+              <Tick className="w-4 h-4 hidden max-sm:block" />
               <span className="hidden sm:block">Yes</span>
             </>
           }
@@ -257,7 +257,7 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
         <Button
           text={
             <>
-              <Plus className="rotate-45 w-4 h-4 sm:hidden" />
+              <Plus className="rotate-45 w-4 h-4 hidden max-sm:block" />
               <span className="hidden sm:block">No</span>
             </>
           }


### PR DESCRIPTION
## Description

Only display icon buttons in smaller screens

## Testing Instructions

1. Pull and checkout the branch `fix/setting-warning-buttons`
2. Build and run the extension: `npm run build:all && npm run dev:ext`
3. Open Privacy Sandbox tab on DevTools
4. Go to settings
5. Enable CPD
6. Observe the buttons on the toast message have icons only when the buttons are large

## Screenshot/Screencast

-Large screen
<img width="962" alt="Screenshot 2025-04-21 at 11 41 42 AM" src="https://github.com/user-attachments/assets/f9e7fe33-fd99-42da-bd3f-c3ada00f259c" />

-Small screen
<img width="477" alt="Screenshot 2025-04-21 at 11 41 50 AM" src="https://github.com/user-attachments/assets/3a292265-5916-4dcb-b217-8e161f0394df" />

## Checklist

<!-- Check these after PR creation -->

- [X] I have thoroughly tested this code to the best of my abilities.
- [X] I have reviewed the code myself before requesting a review.
- This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
