### PR TITLE
Fix: Learning card demo link

### DIFF
--- a/packages/extension/src/view/devtools/pages/dashboard/constants.ts
+++ b/packages/extension/src/view/devtools/pages/dashboard/constants.ts
@@ -142,7 +142,7 @@ export const FEATURE_LIST = [
     icon: PSLearningIcon,
     sidebarKey: SIDEBAR_ITEMS_KEYS.LEARNING,
     description:
-      'Explore and learn everything about the Privacy Sandbox via the Help Center, developer documentation, and Stories, and learn about PSAT via the wiki and demos.',
+      'Explore and learn everything about the Privacy Sandbox through the Help Center, developer documentation, and case studies. You can also learn about PSAT via the wiki and demos.',
     buttons: [
       {
         name: 'Wiki',

--- a/packages/extension/src/view/devtools/pages/dashboard/constants.ts
+++ b/packages/extension/src/view/devtools/pages/dashboard/constants.ts
@@ -142,7 +142,7 @@ export const FEATURE_LIST = [
     icon: PSLearningIcon,
     sidebarKey: SIDEBAR_ITEMS_KEYS.LEARNING,
     description:
-      'Explore and learn everything about the Privacy Sandbox via the Help Center, developer documentation, and Stories, and learn about PSAT via the wiki.',
+      'Explore and learn everything about the Privacy Sandbox via the Help Center, developer documentation, and Stories, and learn about PSAT via the wiki and demos.',
     buttons: [
       {
         name: 'Wiki',

--- a/packages/extension/src/view/devtools/pages/dashboard/constants.ts
+++ b/packages/extension/src/view/devtools/pages/dashboard/constants.ts
@@ -160,6 +160,10 @@ export const FEATURE_LIST = [
         name: 'Dev Site',
         sidebarKey: SIDEBAR_ITEMS_KEYS.DEV_SITE,
       },
+      {
+        name: 'Demos',
+        sidebarKey: SIDEBAR_ITEMS_KEYS.DEMOS,
+      },
     ],
   },
 ];


### PR DESCRIPTION
## Description

Add demo button in learning card

## Testing Instructions

1. Pull and checkout the branch `fix/learning-card`
2. Build and run the extension: `npm run build:all && npm run dev:ext`
3. Open Privacy Sandbox tab on DevTools
4. Go to Dashboard
5. Observer the learning card has a link to the demos

## Screenshot/Screencast

<img width="419" alt="Screenshot 2025-04-22 at 11 47 04 AM" src="https://github.com/user-attachments/assets/32ea244d-0251-41ca-b9f2-e844faf72eb2" />

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).
