### PR TITLE
Fix: Panel cards borders

### DIFF
--- a/packages/design-system/src/components/landingPage/cardsPanel.tsx
+++ b/packages/design-system/src/components/landingPage/cardsPanel.tsx
@@ -74,7 +74,7 @@ const CardsPanel = ({
                 return (
                   <div
                     key={item.name}
-                    className="w-[366px] border border-chinese-silver px-3 py-4 flex gap-2 justify-start rounded hover:cursor-pointer hover:bg-light-gray dark:hover:bg-charleston-green hover:shadow hover:scale-[1.03] transition-all duration-150 ease-in-out"
+                    className="w-[366px] border-2 border-gray-300 dark:border-quartz px-3 py-4 flex gap-2 justify-start rounded hover:cursor-pointer hover:bg-light-gray dark:hover:bg-charleston-green hover:shadow hover:scale-[1.03] transition-all duration-150 ease-in-out"
                     onClick={() => navigateTo(item.sidebarKey)}
                   >
                     <Icon
@@ -99,7 +99,7 @@ const CardsPanel = ({
                 return (
                   <div
                     key={item.name}
-                    className="w-[366px] border border-chinese-silver px-3 py-4 rounded hover:cursor-pointer hover:bg-light-gray dark:hover:bg-charleston-green hover:shadow hover:scale-[1.03] transition-all duration-150 ease-in-out"
+                    className="w-[366px] rounded border-2 border-gray-300 dark:border-quartz px-3 py-4 hover:cursor-pointer hover:bg-light-gray dark:hover:bg-charleston-green hover:shadow hover:scale-[1.03] transition-all duration-150 ease-in-out"
                     onClick={() => navigateTo(item.sidebarKey)}
                   >
                     <div className="mb-3 flex items-center flex-col gap-2">

--- a/packages/design-system/src/components/landingPage/contentPanel.tsx
+++ b/packages/design-system/src/components/landingPage/contentPanel.tsx
@@ -62,7 +62,7 @@ const ContentPanel = ({ title, content }: ContentPanelProps) => {
 
           return (
             <div
-              className="w-72 min-h-80 bg-[#FDFDFD] dark:bg-charleston-green hover:bg-[#FAFAFA] rounded-xl border border-bright-gray dark:border-quartz p-5 relative"
+              className="w-72 min-h-80 bg-[#FDFDFD] dark:bg-charleston-green hover:bg-[#FAFAFA] rounded-xl border-2 border-gray-300 dark:border-quartz p-5 relative"
               key={index}
             >
               <div


### PR DESCRIPTION
## Description

- Improve cads UI by adding better contrast in the border, adding color and slightly increasing border width

## Testing Instructions

1. Pull and checkout the branch `fix/cards-borders`
2. Build and run the extension: `npm run build:all && npm run dev:ext`
3. Open Privacy Sandbox tab on DevTools
4. Go any landing page that contains cards: Dashboard, Learning, Tracking Protection, Private Advertising, Site Boundaries
5. Observe that the cards have a colored border and they look consistent in all pages

## Screenshot/Screencast

- Light theme:
<img width="1141" alt="Screenshot 2025-04-17 at 10 51 27 AM" src="https://github.com/user-attachments/assets/dc192a23-60fb-420c-a61a-d7e0762a10ac" />

- Dark theme:
<img width="1034" alt="Screenshot 2025-04-17 at 10 51 04 AM" src="https://github.com/user-attachments/assets/d21f86b7-6142-4941-87f5-3a3387ac42fc" />

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [NA] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).
