### PR TITLE
Move Cookies from Tracking Protection to Site Boundaries

### DIFF
--- a/packages/extension/src/view/devtools/e2e-tests/allowList/index.ts
+++ b/packages/extension/src/view/devtools/e2e-tests/allowList/index.ts
@@ -100,5 +100,15 @@ describe('Allow Listing', () => {
       );
       expect(divTextContent).toContain('Allow Listed');
     }
+
+    // Navigate to the Cookies tab (updated for new sidebar structure)
+    await frame.waitForSelector('button[title="Site Boundaries"]', {
+      timeout: 10000,
+    });
+    const siteBoundariesButton = await frame.$(
+      'button[title="Site Boundaries"]'
+    );
+    await siteBoundariesButton?.click();
+    await interaction.clickMatchingElement(frame, 'p', 'Cookies');
   }, 120000);
 });

--- a/packages/extension/src/view/devtools/e2e-tests/cookieSearch/validateSearchCookie.ts
+++ b/packages/extension/src/view/devtools/e2e-tests/cookieSearch/validateSearchCookie.ts
@@ -83,6 +83,16 @@ describe('Validate the Cookies search', () => {
       } else {
         throw new Error('No cookies found to search.');
       }
+
+      // Navigate to the Cookies tab (updated for new sidebar structure)
+      await frame.waitForSelector('button[title="Site Boundaries"]', {
+        timeout: 10000,
+      });
+      const siteBoundariesButton = await frame.$(
+        'button[title="Site Boundaries"]'
+      );
+      await siteBoundariesButton?.click();
+      await interaction.clickMatchingElement(frame, 'p', 'Cookies');
     } else {
       throw new Error('Failed to navigate to the cookie frame.');
     }

--- a/packages/extension/src/view/devtools/e2e-tests/cookieTable/cookieFilter.ts
+++ b/packages/extension/src/view/devtools/e2e-tests/cookieTable/cookieFilter.ts
@@ -63,6 +63,16 @@ describe('Validate the Cookies filter option', () => {
       throw new Error('Failed to navigate to cookie frame.');
     }
 
+    // Navigate to the Cookies tab (updated for new sidebar structure)
+    await frame.waitForSelector('button[title="Site Boundaries"]', {
+      timeout: 10000,
+    });
+    const siteBoundariesButton = await frame.$(
+      'button[title="Site Boundaries"]'
+    );
+    await siteBoundariesButton?.click();
+    await interaction.clickMatchingElement(frame, 'p', 'Cookies');
+
     await interaction.openFilter(frame);
     await interaction.openFilterOption(frame, 'Category');
     await interaction.clickOnFilterOption(frame, 'Analytics');

--- a/packages/extension/src/view/devtools/e2e-tests/cookieTable/cookieSorting.ts
+++ b/packages/extension/src/view/devtools/e2e-tests/cookieTable/cookieSorting.ts
@@ -61,6 +61,16 @@ describe('Validate the Cookies sort option', () => {
       throw new Error('Failed to navigate to cookie frame.');
     }
 
+    // Navigate to the Cookies tab (updated for new sidebar structure)
+    await frame.waitForSelector('button[title="Site Boundaries"]', {
+      timeout: 10000,
+    });
+    const siteBoundariesButton = await frame.$(
+      'button[title="Site Boundaries"]'
+    );
+    await siteBoundariesButton?.click();
+    await interaction.clickMatchingElement(frame, 'p', 'Cookies');
+
     await interaction.delay(1000);
     await interaction.clickOnColumn(frame, 'Name');
     await interaction.delay(1000);

--- a/packages/extension/src/view/devtools/e2e-tests/cookieTable/cookieTableFilterClearAllButton.ts
+++ b/packages/extension/src/view/devtools/e2e-tests/cookieTable/cookieTableFilterClearAllButton.ts
@@ -61,6 +61,16 @@ describe('Validate the Cookies filter option', () => {
       throw new Error('Failed to navigate to cookie frame.');
     }
 
+    // Navigate to the Cookies tab (updated for new sidebar structure)
+    await frame.waitForSelector('button[title="Site Boundaries"]', {
+      timeout: 10000,
+    });
+    const siteBoundariesButton = await frame.$(
+      'button[title="Site Boundaries"]'
+    );
+    await siteBoundariesButton?.click();
+    await interaction.clickMatchingElement(frame, 'p', 'Cookies');
+
     await interaction.openFilter(frame);
     await interaction.openFilterOption(frame, 'Category');
     await interaction.clickOnFilterOption(frame, 'Analytics');

--- a/packages/extension/src/view/devtools/e2e-tests/settings/index.ts
+++ b/packages/extension/src/view/devtools/e2e-tests/settings/index.ts
@@ -74,14 +74,14 @@ describe('Settings Page', () => {
       await frame.click('button[data-test-id="button"]');
       await interaction.delay(3000);
 
-      await frame.waitForSelector('button[title="Tracking Protection"]', {
+      await frame.waitForSelector('button[title="Site Boundaries"]', {
         timeout: 5000,
       });
-      const trackingProtectionOpener = await frame.$(
-        'button[title="Tracking Protection"]'
+      const siteBoundariesOpener = await frame.$(
+        'button[title="Site Boundaries"]'
       );
 
-      await trackingProtectionOpener?.click();
+      await siteBoundariesOpener?.click();
 
       const elementTextToClick = 'Cookies';
       await interaction.clickMatchingElement(frame, 'p', elementTextToClick);

--- a/packages/extension/src/view/devtools/pages/layout.tsx
+++ b/packages/extension/src/view/devtools/pages/layout.tsx
@@ -134,16 +134,19 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
       const data = { ...prev };
       const psData = data[SIDEBAR_ITEMS_KEYS.PRIVACY_SANDBOX];
 
-      psData.children[SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING].children[
-        SIDEBAR_ITEMS_KEYS.COOKIES
-      ].panel = {
-        Element: Cookies as (props: any) => React.JSX.Element,
-        props: { setFilteredCookies },
-      };
-      psData.children[SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING].children[
-        SIDEBAR_ITEMS_KEYS.COOKIES
-      ].children = Object.keys(tabFrames || {}).reduce<SidebarItems>(
-        (acc, url) => {
+      const cookiesMainItem =
+        psData.children[SIDEBAR_ITEMS_KEYS.SITE_BOUNDARIES].children[
+          SIDEBAR_ITEMS_KEYS.COOKIES
+        ];
+
+      if (cookiesMainItem) {
+        cookiesMainItem.panel = {
+          Element: Cookies as (props: any) => React.JSX.Element,
+          props: { setFilteredCookies },
+        };
+        cookiesMainItem.children = Object.keys(
+          tabFrames || {}
+        ).reduce<SidebarItems>((acc, url) => {
           const popupTitle = I18n.getMessage('cookiesUsedByFrame', [url]);
 
           acc[url] = {
@@ -164,30 +167,29 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
           };
 
           return acc;
-        },
-        {}
-      );
+        }, {});
 
-      const showInspectButton =
-        canStartInspecting && Boolean(Object.keys(tabFrames || {}).length);
+        const showInspectButton =
+          canStartInspecting && Boolean(Object.keys(tabFrames || {}).length);
 
-      if (showInspectButton) {
-        psData.children[SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING].children[
-          SIDEBAR_ITEMS_KEYS.COOKIES
-        ].extraInterfaceToTitle = {
-          Element: InspectButton,
-          props: {
-            isInspecting,
-            selectedAdUnit,
-            setIsInspecting,
-            isTabFocused:
-              isSidebarFocused && isKeySelected(SIDEBAR_ITEMS_KEYS.COOKIES),
-          },
-        };
-      } else {
-        psData.children[SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING].children[
-          SIDEBAR_ITEMS_KEYS.COOKIES
-        ].extraInterfaceToTitle = {};
+        if (showInspectButton) {
+          psData.children[SIDEBAR_ITEMS_KEYS.SITE_BOUNDARIES].children[
+            SIDEBAR_ITEMS_KEYS.COOKIES
+          ].extraInterfaceToTitle = {
+            Element: InspectButton,
+            props: {
+              isInspecting,
+              selectedAdUnit,
+              setIsInspecting,
+              isTabFocused:
+                isSidebarFocused && isKeySelected(SIDEBAR_ITEMS_KEYS.COOKIES),
+            },
+          };
+        } else {
+          psData.children[SIDEBAR_ITEMS_KEYS.SITE_BOUNDARIES].children[
+            SIDEBAR_ITEMS_KEYS.COOKIES
+          ].extraInterfaceToTitle = {};
+        }
       }
 
       return data;
@@ -336,7 +338,7 @@ const Layout = ({ setSidebarData }: LayoutProps) => {
   const cookieDropdownOpen = useMemo(() => {
     return (
       sidebarItems[SIDEBAR_ITEMS_KEYS.PRIVACY_SANDBOX]?.children[
-        SIDEBAR_ITEMS_KEYS.ANTI_COVERT_TRACKING
+        SIDEBAR_ITEMS_KEYS.SITE_BOUNDARIES
       ]?.children?.[SIDEBAR_ITEMS_KEYS.COOKIES]?.dropdownOpen ?? false
     );
   }, [sidebarItems]);

--- a/packages/extension/src/view/devtools/pages/privacyProtection/privacyProtection.tsx
+++ b/packages/extension/src/view/devtools/pages/privacyProtection/privacyProtection.tsx
@@ -26,15 +26,6 @@ import { I18n } from '@google-psat/i18n';
 
 const content = [
   {
-    title: () => 'Cookies',
-    description: () =>
-      'Insights into the distribution and behavior of cookies on web pages while users navigate across sites during browsing sessions.',
-    url: 'https://developers.google.com/privacy-sandbox/cookies',
-    storyUrl:
-      'https://privacysandbox-stories.com/web-stories/chrome-shifts-to-user-choice-for-third-party-cookies/',
-    sidebarItemKey: SIDEBAR_ITEMS_KEYS.COOKIES,
-  },
-  {
     title: () => I18n.getMessage('ipProtection'),
     description: () => I18n.getMessage('ipProtectionDescription'),
     url: 'https://developers.google.com/privacy-sandbox/protections/ip-protection',

--- a/packages/extension/src/view/devtools/pages/siteBoundaries/siteBoundaries.tsx
+++ b/packages/extension/src/view/devtools/pages/siteBoundaries/siteBoundaries.tsx
@@ -25,6 +25,15 @@ import { I18n } from '@google-psat/i18n';
 
 const content = [
   {
+    title: () => 'Cookies',
+    description: () =>
+      'Insights into the distribution and behavior of cookies on web pages while users navigate across sites during browsing sessions.',
+    url: 'https://developers.google.com/privacy-sandbox/cookies',
+    storyUrl:
+      'https://privacysandbox-stories.com/web-stories/chrome-shifts-to-user-choice-for-third-party-cookies/',
+    sidebarItemKey: SIDEBAR_ITEMS_KEYS.COOKIES,
+  },
+  {
     title: () => I18n.getMessage('chips'),
     description: () => I18n.getMessage('chipsDescription'),
     url: 'https://developers.google.com/privacy-sandbox/3pcd/chips',

--- a/packages/extension/src/view/devtools/tabs.ts
+++ b/packages/extension/src/view/devtools/tabs.ts
@@ -119,23 +119,6 @@ const TABS: SidebarItems = {
           },
         },
         children: {
-          [SIDEBAR_ITEMS_KEYS.COOKIES]: {
-            title: () => I18n.getMessage('cookies'),
-            icon: {
-              Element: CookieIcon,
-              props: {
-                className: '[&_path]:fill-granite-gray',
-              },
-            },
-            selectedIcon: {
-              Element: CookieIcon,
-              props: {
-                className: '[&_path]:fill-bright-gray',
-              },
-            },
-            children: {},
-            dropdownOpen: false,
-          },
           [SIDEBAR_ITEMS_KEYS.IP_PROTECTION]: {
             title: () => I18n.getMessage('ipProtection'),
             panel: {
@@ -233,6 +216,23 @@ const TABS: SidebarItems = {
           },
         },
         children: {
+          [SIDEBAR_ITEMS_KEYS.COOKIES]: {
+            title: () => I18n.getMessage('cookies'),
+            icon: {
+              Element: CookieIcon,
+              props: {
+                className: '[&_path]:fill-granite-gray',
+              },
+            },
+            selectedIcon: {
+              Element: CookieIcon,
+              props: {
+                className: '[&_path]:fill-bright-gray',
+              },
+            },
+            children: {},
+            dropdownOpen: false,
+          },
           [SIDEBAR_ITEMS_KEYS.CHIPS]: {
             title: () => I18n.getMessage('chips'),
             panel: {
@@ -507,7 +507,7 @@ const TABS: SidebarItems = {
         containerClassName: 'h-6',
       },
       [SIDEBAR_ITEMS_KEYS.WIKI]: {
-        title: () => I18n.getMessage('wiki'),
+        title: () => 'PSAT Wiki',
         panel: {
           Element: Wiki,
           href: 'https://github.com/GoogleChromeLabs/ps-analysis-tool/wiki',


### PR DESCRIPTION
This PR pursues the following goal: move the Cookies component curretnly under Tracking Protection to the Site Boundaries section, and change the label "Wiki" to PSAT Wiki.

## Relevant Technical Choices

1. The Cookies "card" definition object has been added as the first item in the content array of siteBoundaries.tsx.
2. The "Cookies" card definition object has been removed from the content array of privacyProtection.tsx.
3. The SIDEBAR_ITEMS_KEYS.COOKIES sidebar item definition was moved from being a child of ANTI_COVERT_TRACKING ("Tracking Protection") to be the first child of SITE_BOUNDARIES.
4. The paths used in the useEffect hook to dynamically update the "Cookies" sidebar item (for iframes and the inspect button) were changed from ...ANTI_COVERT_TRACKING.children.COOKIES... to ...SITE_BOUNDARIES.children.COOKIES....


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast
<img width="1596" alt="image" src="https://github.com/user-attachments/assets/f26059e9-31ab-4203-9472-ddeff9185dbd" />

<img width="1585" alt="image" src="https://github.com/user-attachments/assets/a79c4bfa-0e98-4ba9-99e0-4c0b87cca8ea" />


---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
