### PR TITLE
Improvement: JSON view

### DIFF
--- a/packages/design-system/src/components/jsonView/jsonView.tsx
+++ b/packages/design-system/src/components/jsonView/jsonView.tsx
@@ -73,7 +73,9 @@ const JsonView = (props: ReactJsonViewProps): React.ReactElement => {
           enableClipboard={false}
           displayDataTypes={false}
           displayObjectSize={false}
-          shouldCollapse={(object) => object.name !== 'root'}
+          shouldCollapse={(object) =>
+            object.name !== 'root' && Object.keys(object.src).length > 5
+          }
           quotesOnKeys={false}
           {...props}
         />

--- a/packages/design-system/src/components/resizableTray/index.tsx
+++ b/packages/design-system/src/components/resizableTray/index.tsx
@@ -74,7 +74,16 @@ export const usePersistentTray = (
 
 const ResizableTray = (props: ResizableTrayProps) => {
   const { trayId, ...rest } = props;
-  const { height, onResizeStop } = usePersistentTray(trayId, rest.defaultSize);
+  const { height, onResizeStop, setHeight } = usePersistentTray(
+    trayId,
+    rest.defaultSize
+  );
+
+  useEffect(() => {
+    if (rest.defaultSize?.height) {
+      setHeight(String(rest.defaultSize?.height));
+    }
+  }, [rest.defaultSize?.height, setHeight]);
 
   if (!trayId) {
     return <Resizable {...rest} />;

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/attributionReporting/activeSources/index.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/attributionReporting/activeSources/index.tsx
@@ -292,7 +292,7 @@ const ActiveSources = () => {
       <ResizableTray
         defaultSize={{
           width: '100%',
-          height: '80%',
+          height: selectedJSON ? '50%' : '90%',
         }}
         enable={{
           bottom: true,

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/attributionReporting/sourceRegistrations/index.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/attributionReporting/sourceRegistrations/index.tsx
@@ -211,7 +211,7 @@ const SourceRegistrations = () => {
       <ResizableTray
         defaultSize={{
           width: '100%',
-          height: '80%',
+          height: selectedJSON ? '50%' : '90%',
         }}
         enable={{
           bottom: true,

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/attributionReporting/triggerRegistrations/index.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/attributionReporting/triggerRegistrations/index.tsx
@@ -212,7 +212,7 @@ const TriggerRegistrations = () => {
       <ResizableTray
         defaultSize={{
           width: '100%',
-          height: '80%',
+          height: selectedJSON ? '50%' : '90%',
         }}
         enable={{
           bottom: true,

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/adUnits/adTable.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/adUnits/adTable.tsx
@@ -173,7 +173,7 @@ const AdTable = ({
       <ResizableTray
         defaultSize={{
           width: '100%',
-          height: '80%',
+          height: selectedRow ? '50%' : '90%',
         }}
         minHeight="20%"
         maxHeight="90%"

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/interestGroups/table.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/interestGroups/table.tsx
@@ -194,9 +194,9 @@ const IGTable = ({
       <ResizableTray
         defaultSize={{
           width: '100%',
-          height: '80%',
+          height: selectedRow ? '50%' : '90%',
         }}
-        minHeight="15%"
+        minHeight="30%"
         maxHeight="90%"
         enable={{
           bottom: true,

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/prebid/tabs/config/components/consentManagement.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/prebid/tabs/config/components/consentManagement.tsx
@@ -103,7 +103,7 @@ const ConsentManagement = ({ config }: ConsentManagementPanelProps) => {
       <ResizableTray
         defaultSize={{
           width: '100%',
-          height: '80%',
+          height: selectedRow ? '50%' : '90%',
         }}
         minHeight="15%"
         maxHeight="90%"

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/prebid/tabs/config/components/installedModules.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/prebid/tabs/config/components/installedModules.tsx
@@ -111,7 +111,7 @@ const InstalledModules = ({ installedModules }: InstalledModulesPanelProps) => {
       <ResizableTray
         defaultSize={{
           width: '100%',
-          height: '80%',
+          height: selectedRow ? '50%' : '90%',
         }}
         minHeight="15%"
         maxHeight="90%"

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/prebid/tabs/config/components/priceGranularity.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/prebid/tabs/config/components/priceGranularity.tsx
@@ -154,7 +154,7 @@ const PriceGranularity = ({
       <ResizableTray
         defaultSize={{
           width: '100%',
-          height: '80%',
+          height: selectedRow ? '50%' : '90%',
         }}
         minHeight="15%"
         maxHeight="90%"

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/prebid/tabs/config/components/tests/userIds.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/prebid/tabs/config/components/tests/userIds.tsx
@@ -107,9 +107,9 @@ describe('UserIds', () => {
       screen.queryByText('Select a row to preview')
     ).not.toBeInTheDocument();
 
-    await waitFor(() => screen.getByText('name'));
-    expect(screen.getByText('name')).toBeInTheDocument();
-    expect(screen.getByText('storage')).toBeInTheDocument();
+    await waitFor(() => screen.getAllByText('name'));
+    expect(screen.getAllByText('name')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('storage')[0]).toBeInTheDocument();
   });
 
   it('handles empty config', () => {

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/prebid/tabs/config/components/userIds.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/prebid/tabs/config/components/userIds.tsx
@@ -102,7 +102,7 @@ const UserIds = ({ config }: ConsentManagementPanelProps) => {
       <ResizableTray
         defaultSize={{
           width: '100%',
-          height: '80%',
+          height: selectedRow ? '50%' : '90%',
         }}
         minHeight="15%"
         maxHeight="90%"

--- a/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/prebid/tabs/userIds/components/userConfig.tsx
+++ b/packages/extension/src/view/devtools/pages/privateAdvertising/protectedAudience/prebid/tabs/userIds/components/userConfig.tsx
@@ -102,7 +102,7 @@ const UserConfig = ({ config }: UserConfigPanelProps) => {
       <ResizableTray
         defaultSize={{
           width: '100%',
-          height: '80%',
+          height: selectedRow ? '50%' : '90%',
         }}
         minHeight="15%"
         maxHeight="90%"


### PR DESCRIPTION
## Description

Improve JSON view by making better use of available space

Depends on #1095 

## Testing Instructions

1. Pull and checkout the branch `improvement/json-view-ux`
2. Run the extension: `npm run start`
3. Open Privacy Sandbox tab on DevTools
4. Go to any page with a table that displays JSON data (example PA:EE)
5. Wait for table to be populated
6. Click on any row
7. Observe the JSON tray opens up using more space than before selected
8. Observe the JSON data only displays collapsed trees if needed(too many object keys)

## Screenshot/Screencast

https://github.com/user-attachments/assets/5f1209cf-48ef-47a6-981e-cbaae7824bdb

## Checklist

<!-- Check these after PR creation -->

- [ ] I have thoroughly tested this code to the best of my abilities.
- [ ] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
