### PR TITLE
Fix: Update text and line position calculation in timeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21232,7 +21232,7 @@
 		},
 		"packages/analysis-utils": {
 			"name": "@google-psat/analysis-utils",
-			"version": "1.0.0",
+			"version": "1.0.0-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",
@@ -21258,7 +21258,7 @@
 		},
 		"packages/cli": {
 			"name": "@google-psat/cli",
-			"version": "1.0.0",
+			"version": "1.0.0-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/analysis-utils": "*",
@@ -21292,7 +21292,7 @@
 		},
 		"packages/cli-dashboard": {
 			"name": "@google-psat/cli-dashboard",
-			"version": "1.0.0",
+			"version": "1.0.0-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",
@@ -21319,7 +21319,7 @@
 		},
 		"packages/common": {
 			"name": "@google-psat/common",
-			"version": "1.0.0",
+			"version": "1.0.0-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/i18n": "*",
@@ -21357,7 +21357,7 @@
 		},
 		"packages/design-system": {
 			"name": "@google-psat/design-system",
-			"version": "1.0.0",
+			"version": "1.0.0-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",
@@ -21397,7 +21397,7 @@
 		},
 		"packages/eslint-import-resolver": {
 			"name": "@google-psat/eslint-import-resolver",
-			"version": "1.0.0",
+			"version": "1.0.0-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"eslint-import-resolver-node": "^0.3.7"
@@ -21405,7 +21405,7 @@
 		},
 		"packages/explorable-explanations": {
 			"name": "@google-psat/explorable-explanations",
-			"version": "0.11.0-1",
+			"version": "1.0.0-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"just-throttle": "^4.2.0",
@@ -21488,7 +21488,7 @@
 		},
 		"packages/i18n": {
 			"name": "@google-psat/i18n",
-			"version": "1.0.0",
+			"version": "1.0.0-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"intl-messageformat": "^10.5.11"
@@ -21496,7 +21496,7 @@
 		},
 		"packages/report": {
 			"name": "@google-psat/report",
-			"version": "1.0.0",
+			"version": "1.0.0-1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-psat/common": "*",

--- a/packages/design-system/src/components/timeline/bar.tsx
+++ b/packages/design-system/src/components/timeline/bar.tsx
@@ -90,7 +90,7 @@ const Bar = ({
             }
           )}
         >
-          <span className="pr-2 text-xs dark:text-bright-gray flex">
+          <span className="pr-2 text-xs dark:text-bright-gray flex text-nowrap">
             {String(bidder.name)}
             <span className="text-granite-gray dark:text-bright-gray ml-1">
               {bidder.type === BidderType.NO_BID && ' (no bid)'}

--- a/packages/design-system/src/components/timeline/index.tsx
+++ b/packages/design-system/src/components/timeline/index.tsx
@@ -205,8 +205,11 @@ const Timeline = ({
 
         {/*Timeout block*/}
         <div
-          className="absolute flex w-fit top-0"
-          style={{ height: childHeight }}
+          className="absolute flex top-0"
+          style={{
+            height: childHeight,
+            width: lines.length * TIME_DURATION * zoom,
+          }}
         >
           <div
             style={{
@@ -232,9 +235,10 @@ const Timeline = ({
 
         {/*Auction-End block*/}
         <div
-          className="absolute flex w-fit top-0"
+          className="absolute flex top-0"
           style={{
             height: childHeight,
+            width: lines.length * TIME_DURATION * zoom,
           }}
         >
           <div

--- a/packages/design-system/src/components/timeline/index.tsx
+++ b/packages/design-system/src/components/timeline/index.tsx
@@ -72,22 +72,55 @@ const Timeline = ({
 
   const lines = Array.from({ length: lineCount });
 
-  const isAuctionEndBlockOverlappingTimeout = useRef(false);
+  const [timeoutBlock, setTimeoutBlock] = useState(auctionTimeout * zoomLevel);
+  const [auctionEndBlock, setAuctionEndBlock] = useState(
+    auctionEndDuration * zoomLevel
+  );
 
   useEffect(() => {
     const _zoom = zoomLevel;
     setZoom(_zoom);
-    setTimeoutBlockWidth(scrollWidth - auctionTimeout * _zoom);
 
-    isAuctionEndBlockOverlappingTimeout.current =
-      Math.abs(auctionEndDuration * _zoom - auctionTimeout * _zoom) <= 20;
+    let _timeoutBlockWidth = auctionTimeout * _zoom;
+    let _auctionEndBlockWidth = auctionEndDuration * _zoom;
 
-    setAuctionEndBlockWidth(
-      scrollWidth -
-        auctionEndDuration * _zoom +
-        (isAuctionEndBlockOverlappingTimeout.current ? 20 : 0)
-    );
-  }, [scrollWidth, auctionTimeout, auctionEndDuration, zoomLevel]);
+    for (let i = 0; i < lines.length; i++) {
+      const lineWidth = TIME_DURATION * _zoom * (i + 1);
+
+      if (Math.abs(lineWidth - _timeoutBlockWidth) < 10 * _zoom) {
+        _timeoutBlockWidth += Math.abs(lineWidth - _timeoutBlockWidth);
+      }
+
+      if (Math.abs(lineWidth - _auctionEndBlockWidth) < 10 * _zoom) {
+        _auctionEndBlockWidth += Math.abs(lineWidth - _auctionEndBlockWidth);
+      }
+    }
+
+    const isAuctionEndBlockOverlappingTimeout =
+      Math.abs(_auctionEndBlockWidth - _timeoutBlockWidth) <= 20;
+
+    if (isAuctionEndBlockOverlappingTimeout) {
+      if (_auctionEndBlockWidth > _timeoutBlockWidth) {
+        _auctionEndBlockWidth +=
+          20 - Math.abs(_auctionEndBlockWidth - _timeoutBlockWidth);
+      } else {
+        _timeoutBlockWidth +=
+          20 - Math.abs(_auctionEndBlockWidth - _timeoutBlockWidth);
+      }
+    }
+
+    setTimeoutBlockWidth(scrollWidth - _timeoutBlockWidth);
+    setTimeoutBlock(_timeoutBlockWidth);
+
+    setAuctionEndBlockWidth(scrollWidth - _auctionEndBlockWidth);
+    setAuctionEndBlock(_auctionEndBlockWidth);
+  }, [
+    scrollWidth,
+    zoomLevel,
+    lines.length,
+    auctionTimeout,
+    auctionEndDuration,
+  ]);
 
   useEffect(() => {
     const timeout = setTimeout(() => {
@@ -187,7 +220,10 @@ const Timeline = ({
             <div className="bg-[#E90303] opacity-[9%] w-full h-full"></div>
             <span
               className="absolute top-1/2 -translate-y-1/2 rotate-180 text-xs text-[#828282] dark:text-gray h-full flex items-center justify-center"
-              style={{ writingMode: 'vertical-rl' }}
+              style={{
+                writingMode: 'vertical-rl',
+                left: `${Math.abs(timeoutBlock - auctionTimeout * zoom)}px`,
+              }}
             >
               Timeout: {auctionTimeout}ms
             </span>
@@ -211,13 +247,13 @@ const Timeline = ({
           >
             <div className="bg-[#E90303] opacity-[4%] w-full h-full"></div>
             <span
-              className={classNames(
-                'absolute top-1/2 -translate-y-1/2 rotate-180 text-xs text-[#828282] dark:text-gray h-full flex items-center justify-center',
-                {
-                  'left-5': isAuctionEndBlockOverlappingTimeout.current,
-                }
-              )}
-              style={{ writingMode: 'vertical-rl' }}
+              className="absolute top-1/2 -translate-y-1/2 rotate-180 text-xs text-[#828282] dark:text-gray h-full flex items-center justify-center"
+              style={{
+                writingMode: 'vertical-rl',
+                left: `${Math.abs(
+                  auctionEndBlock - auctionEndDuration * zoom
+                )}px`,
+              }}
             >
               Auction End: {formatDuration(String(auctionEndDuration))}ms
             </span>


### PR DESCRIPTION
## Description
This PR updates the logic to handle overlapping of texts, lines in the timeline.
Also, it updates the width for the timeline container, such that there's no unnecessary space to the right when zoomed.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions
- Open PSAT and navigate to the bids timeline.
- Find a site where the auction, timeout timings are close by.
- Check that the gap between texts is enough not to overlap.
- Now find a scenario where values are similar to block lines.
- The text position should be adjusted so that it doesn't overlap the line.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
