### PR TITLE
Fix: Table column initial width

### DIFF
--- a/packages/design-system/src/components/table/components/tableHeader/headerCell.tsx
+++ b/packages/design-system/src/components/table/components/tableHeader/headerCell.tsx
@@ -44,10 +44,6 @@ const HeaderCell = ({ cell, setIsRowFocused }: HeaderCellProps) => {
     setSortKey(cell.accessorKey);
   }, [cell.accessorKey, setSortKey]);
 
-  const initialWidth = cell.initialWidth
-    ? Math.max(cell.initialWidth || 0, cell.minWidth || 0) || 'auto'
-    : 'auto';
-
   return (
     <>
       <th
@@ -63,7 +59,7 @@ const HeaderCell = ({ cell, setIsRowFocused }: HeaderCellProps) => {
         data-testid="header-cell"
         data-min-width={cell.minWidth || minColumnWidth}
         data-max-width={cell.maxWidth}
-        style={{ maxWidth: initialWidth, minWidth: initialWidth }}
+        data-initial-width={cell.initialWidth}
       >
         <div
           className="w-full h-full relative flex items-center justify-between text-cool-grey dark:text-bright-gray max-w"

--- a/packages/extension/src/view/devtools/pages/privacyProtection/ipProtection/mdlTable/index.tsx
+++ b/packages/extension/src/view/devtools/pages/privacyProtection/ipProtection/mdlTable/index.tsx
@@ -89,6 +89,7 @@ const MDLTable = () => {
         header: 'Domain',
         accessorKey: 'domain',
         cell: (info) => info,
+        initialWidth: 100,
       },
       {
         header: 'Owner',
@@ -108,6 +109,7 @@ const MDLTable = () => {
 
           return info;
         },
+        initialWidth: 100,
       },
       {
         header: 'Impacted by Script Blocking',


### PR DESCRIPTION
## Description

Fixes and issue in the tables where the initialWith is not respected

## Relevant Technical Choices

remove the logic from the react component and moved all logic to the resize hook to improve readibility

## Testing Instructions

1. Pull and checkout the branch `fix/table-column-initialwidth`
2. Build and run the extension: `npm run build:all && npm run dev:ext`
3. Open Privacy Sandbox tab on DevTools
4. Delete any Extension Storage (DevTools -> Application)
5. Go to Marked Domain LIst table in IP protection
6. Observe, the inital width of 100px is respected for the columns

## Screenshot/Screencast

- Before
<img width="776" height="936" alt="Screenshot 2025-07-14 at 3 18 36 PM" src="https://github.com/user-attachments/assets/ad53baad-ce4e-4fbe-922a-fa4790a7a199" />

- After
<img width="841" height="956" alt="Screenshot 2025-07-14 at 3 17 54 PM" src="https://github.com/user-attachments/assets/55b42e0f-6853-4e3a-a773-1b51c5f67367" />

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [NA] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
