### PR TITLE
Standardize navigation for dashboard callout buttons

### DIFF
--- a/packages/extension/src/view/devtools/pages/constants.ts
+++ b/packages/extension/src/view/devtools/pages/constants.ts
@@ -228,22 +228,18 @@ export const PRIVACY_SANDBOX_LANDINGE_PAGE_BOXES = [
       {
         name: I18n.getMessage('chips'),
         sidebarKey: SIDEBAR_ITEMS_KEYS.CHIPS,
-        url: LINKS.CHIPS.doc,
       },
       {
         name: 'Storage Access API',
         sidebarKey: SIDEBAR_ITEMS_KEYS.STORAGE_ACCESS,
-        url: LINKS.STORAGE_ACCESS.doc,
       },
       {
         name: I18n.getMessage('rws'),
         sidebarKey: SIDEBAR_ITEMS_KEYS.RELATED_WEBSITE_SETS,
-        url: LINKS.RELATED_WEBSITE_SETS.doc,
       },
       {
         name: 'FedCM',
         sidebarKey: SIDEBAR_ITEMS_KEYS.FEDERATED_CREDENTIAL,
-        url: LINKS.FEDERATED_CREDENTIAL.doc,
       },
     ],
   },
@@ -257,7 +253,6 @@ export const PRIVACY_SANDBOX_LANDINGE_PAGE_BOXES = [
       {
         name: I18n.getMessage('topics'),
         sidebarKey: SIDEBAR_ITEMS_KEYS.TOPICS,
-        url: LINKS.TOPICS.doc,
       },
       {
         name: I18n.getMessage('protectedAudience'),
@@ -270,7 +265,6 @@ export const PRIVACY_SANDBOX_LANDINGE_PAGE_BOXES = [
       {
         name: I18n.getMessage('privateAggregation'),
         sidebarKey: SIDEBAR_ITEMS_KEYS.PRIVATE_AGGREGATION,
-        url: LINKS.PRIVATE_AGGREGATION.doc,
       },
     ],
   },
@@ -284,27 +278,22 @@ export const PRIVACY_SANDBOX_LANDINGE_PAGE_BOXES = [
       {
         name: 'IP Protection',
         sidebarKey: SIDEBAR_ITEMS_KEYS.IP_PROTECTION,
-        url: LINKS.IP_PROTECTION.doc,
       },
       {
         name: 'Script Blocking',
         sidebarKey: SIDEBAR_ITEMS_KEYS.SCRIPT_BLOCKING,
-        url: LINKS.SCRIPT_BLOCKING.doc,
       },
       {
         name: I18n.getMessage('bounceTracking'),
         sidebarKey: SIDEBAR_ITEMS_KEYS.BOUNCE_TRACKING,
-        url: LINKS.BOUNCE_TRACKING.doc,
       },
       {
         name: 'User Agent Reduction',
         sidebarKey: SIDEBAR_ITEMS_KEYS.FINGERPRINTING,
-        url: LINKS.USER_AGENT_REDUCTION.doc,
       },
       {
         name: 'Private State Tokens',
         sidebarKey: SIDEBAR_ITEMS_KEYS.PRIVATE_STATE_TOKENS,
-        url: LINKS.PRIVATE_STATE_TOKENS.doc,
       },
     ],
   },


### PR DESCRIPTION
## Description

This PR fixes inconsistent navigation behavior on the main Privacy Sandbox dashboard.

Previously, some callout buttons (e.g., Topics, Private Aggregation) were configured with external URLs, causing the main Chrome tab to navigate away from the site under analysis. Other buttons (e.g., Protected Audience, Attribution Reporting) correctly kept the main tab unchanged, only updating the PSAT panel view. This PR removes those URLs.

## Relevant Technical Choices

- Removed external URLs from all dashboard callout buttons except for "Learning" box because they are supposed to navigate to the page.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [ ] I have thoroughly tested this code to the best of my abilities.
- [ ] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
